### PR TITLE
security: escape inline style values to prevent SVG attribute injection

### DIFF
--- a/src/__tests__/renderer.test.ts
+++ b/src/__tests__/renderer.test.ts
@@ -462,6 +462,46 @@ describe('renderSvg – XML escaping', () => {
     const svg = renderSvg(graph, lightColors)
     expect(svg).toContain('A &lt; B')
   })
+
+  it('escapes attribute injection in inline style fill', () => {
+    const node = makeNode({ inlineStyle: { fill: 'red" onmouseover="alert(1)' } })
+    const graph = makeGraph({ nodes: [node] })
+    const svg = renderSvg(graph, lightColors)
+    expect(svg).not.toContain('onmouseover="alert')
+    expect(svg).toContain('red&quot; onmouseover=&quot;alert(1)')
+  })
+
+  it('escapes element injection in inline style fill', () => {
+    const node = makeNode({ inlineStyle: { fill: 'red"/><svg onload="alert(1)"><rect fill="x' } })
+    const graph = makeGraph({ nodes: [node] })
+    const svg = renderSvg(graph, lightColors)
+    expect(svg).not.toContain('<svg onload')
+    expect(svg).toContain('&lt;svg onload=')
+  })
+
+  it('escapes injection in inline style stroke', () => {
+    const node = makeNode({ inlineStyle: { stroke: 'blue" onclick="alert(1)' } })
+    const graph = makeGraph({ nodes: [node] })
+    const svg = renderSvg(graph, lightColors)
+    expect(svg).not.toContain('onclick="alert')
+    expect(svg).toContain('blue&quot; onclick=&quot;alert(1)')
+  })
+
+  it('escapes injection in inline style stroke-width', () => {
+    const node = makeNode({ inlineStyle: { 'stroke-width': '2" onmouseover="alert(1)' } })
+    const graph = makeGraph({ nodes: [node] })
+    const svg = renderSvg(graph, lightColors)
+    expect(svg).not.toContain('onmouseover="alert')
+    expect(svg).toContain('2&quot; onmouseover=&quot;alert(1)')
+  })
+
+  it('escapes injection in inline style color', () => {
+    const node = makeNode({ inlineStyle: { color: 'green" onfocus="alert(1)' } })
+    const graph = makeGraph({ nodes: [node] })
+    const svg = renderSvg(graph, lightColors)
+    expect(svg).not.toContain('onfocus="alert')
+    expect(svg).toContain('green&quot; onfocus=&quot;alert(1)')
+  })
 })
 
 // ============================================================================

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -227,9 +227,9 @@ function renderNodeShape(node: PositionedNode): string {
   // Resolve fill and stroke — inline styles (from mermaid `style` directives)
   // override the CSS variable defaults. When no inline style is present, the
   // CSS variable handles theming automatically via color-mix() derivation.
-  const fill = inlineStyle?.fill ?? 'var(--_node-fill)'
-  const stroke = inlineStyle?.stroke ?? 'var(--_node-stroke)'
-  const sw = inlineStyle?.['stroke-width'] ?? String(STROKE_WIDTHS.innerBox)
+  const fill = escapeXml(inlineStyle?.fill ?? 'var(--_node-fill)')
+  const stroke = escapeXml(inlineStyle?.stroke ?? 'var(--_node-stroke)')
+  const sw = escapeXml(inlineStyle?.['stroke-width'] ?? String(STROKE_WIDTHS.innerBox))
 
   switch (shape) {
     case 'diamond':
@@ -461,7 +461,7 @@ function renderNodeLabel(node: PositionedNode, font: string): string {
   const cy = node.y + node.height / 2
 
   // Resolve text color — inline styles can override the CSS variable default
-  const textColor = node.inlineStyle?.color ?? 'var(--_text)'
+  const textColor = escapeXml(node.inlineStyle?.color ?? 'var(--_text)')
 
   return (
     `<text x="${cx}" y="${cy}" text-anchor="middle" dy="${TEXT_BASELINE_SHIFT}" ` +


### PR DESCRIPTION
It's possible for a crafted Mermaid diagram to inject SVG attributes into the page, allowing XSS and element injection.

User-controlled values from `style` and `classDef` directives are currently interpolated directly into SVG attributes without escaping. This fix applies `escapeXml()` to all four `inlineStyle` properties (`fill`, `stroke`, `stroke-width`, `color`) before they're written into SVG output.

**Example: injecting JavaScript, executed on page load**

```
graph TD
  A[Harmless] --> B[Safe]
  style A fill:red"/><svg onload="alert('XSS-onload')"><rect fill="x
```

renders:

```
<rect x="39.99999999999999" y="40" width="89.2" height="36" rx="0" ry="0" fill="red"></rect><svg onload="alert('XSS-onload')"><rect fill="x" stroke="var(--_node-stroke)" stroke-width="0.75"></rect>
```

This closes the `<rect>` tag and injects an `<svg onload>` that executes on render. After the fix, `"` and `<` are escaped.

**Example: injecting an external image**

```
graph TD
  A[Innocent node] --> B[Also safe]
  style A fill:red"/><image href="https://placehold.co/200x100/red/white?text=INJECTED%20IMAGE" width="200" height="100
```

```
style A fill:red"/><image href="https://example.com/exfil" width="200" height="100
```