### PR TITLE
Add browser bundle for CDN script tag usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,20 @@ const ascii = renderMermaidAscii(`graph LR; A --> B --> C`)
 └───┘     └───┘     └───┘
 ```
 
+### Browser (Script Tag)
+
+For non-bundled environments, include via CDN:
+
+```html
+<script src="https://unpkg.com/beautiful-mermaid/dist/beautiful-mermaid.browser.global.js"></script>
+<script>
+  const { renderMermaid, THEMES } = beautifulMermaid;
+  renderMermaid('graph TD; A-->B').then(svg => { ... });
+</script>
+```
+
+Also available via [jsDelivr](https://cdn.jsdelivr.net/npm/beautiful-mermaid/dist/beautiful-mermaid.browser.global.js). The bundle exposes `renderMermaid`, `renderMermaidAscii`, `THEMES`, `DEFAULTS`, and `fromShikiTheme` on the global `beautifulMermaid` object.
+
 ---
 
 ## Theming

--- a/package.json
+++ b/package.json
@@ -12,8 +12,14 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
+    },
+    "./browser": {
+      "types": "./dist/beautiful-mermaid.browser.d.ts",
+      "default": "./dist/beautiful-mermaid.browser.global.js"
     }
   },
+  "unpkg": "./dist/beautiful-mermaid.browser.global.js",
+  "jsdelivr": "./dist/beautiful-mermaid.browser.global.js",
   "files": [
     "dist",
     "README.md",

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -1,18 +1,38 @@
 // ============================================================================
 // Browser entry point for beautiful-mermaid
 //
-// Exposes renderMermaid and renderMermaidAscii on window.__mermaid so they
-// can be called from inline <script> tags in samples.html.
+// This file serves two purposes:
 //
-// Bundled via `Bun.build({ target: 'browser' })` in index.ts.
+// 1. CDN bundle (via tsup IIFE build):
+//    Exposes `window.beautifulMermaid` with all public APIs for <script> tags.
+//    Usage:
+//      <script src="https://unpkg.com/beautiful-mermaid/dist/beautiful-mermaid.browser.global.js"></script>
+//      <script>
+//        const { renderMermaid, THEMES } = beautifulMermaid;
+//        renderMermaid('graph TD\n  A --> B').then(svg => { ... });
+//      </script>
+//
+// 2. Internal samples page (via Bun.build in index.ts):
+//    Also sets `window.__mermaid` for the dynamically generated samples HTML.
 // ============================================================================
 
 import { renderMermaid } from './index.ts'
 import { renderMermaidAscii } from './ascii/index.ts'
-import { THEMES } from './theme.ts'
+import { THEMES, DEFAULTS, fromShikiTheme } from './theme.ts'
 
-;(window as unknown as Record<string, unknown>).__mermaid = {
-  renderMermaid,
-  renderMermaidAscii,
-  THEMES,
+// Re-export for tsup IIFE bundle (creates window.beautifulMermaid)
+export { renderMermaid, renderMermaidAscii, THEMES, DEFAULTS, fromShikiTheme }
+export type { RenderOptions } from './types.ts'
+export type { AsciiRenderOptions } from './ascii/index.ts'
+export type { DiagramColors, ThemeName } from './theme.ts'
+
+// Also set window.__mermaid for internal samples page (Bun.build uses ESM format)
+if (typeof window !== 'undefined') {
+  ;(window as unknown as Record<string, unknown>).__mermaid = {
+    renderMermaid,
+    renderMermaidAscii,
+    THEMES,
+    DEFAULTS,
+    fromShikiTheme,
+  }
 }

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,12 +1,27 @@
 import { defineConfig } from 'tsup'
 
-export default defineConfig({
-  entry: ['src/index.ts'],
-  format: ['esm', 'cjs'],
-  dts: true,
-  clean: true,
-  sourcemap: true,
-  minify: false,
-  splitting: false,
-  treeshake: true,
-})
+export default defineConfig([
+  // Main library builds (ESM + CJS)
+  {
+    entry: ['src/index.ts'],
+    format: ['esm', 'cjs'],
+    dts: true,
+    clean: true,
+    sourcemap: true,
+    minify: false,
+    splitting: false,
+    treeshake: true,
+  },
+  // Browser bundle (IIFE for <script> tag usage)
+  {
+    entry: { 'beautiful-mermaid.browser': 'src/browser.ts' },
+    format: ['iife'],
+    globalName: 'beautifulMermaid',
+    platform: 'browser',
+    sourcemap: true,
+    minify: true,
+    splitting: false,
+    treeshake: true,
+    noExternal: [/.*/], // Bundle all dependencies
+  },
+])


### PR DESCRIPTION
Hey folks, lovely work. My team uses standard Mermaid charts without bundling in our environment, but we'd like to switch to using these. Figured I'd upstream the change we made to support our use case.

---

- Add IIFE build target in tsup.config.ts that bundles all dependencies
- Update browser.ts to export all public APIs (renderMermaid, renderMermaidAscii, THEMES, etc.)
- Add unpkg and jsdelivr fields to package.json for automatic CDN support
- Document script tag usage in README

Usage: `<script src="https://unpkg.com/beautiful-mermaid/dist/beautiful-mermaid.browser.global.js"></script>`

Exposes `window.beautifulMermaid` with all public APIs.
