### PR TITLE
fix(ascii): handle CJK/fullwidth label width correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,6 +385,7 @@ Render a Mermaid diagram to ASCII/Unicode text. Synchronous.
 | `paddingX` | `number` | `5` | Horizontal node spacing |
 | `paddingY` | `number` | `5` | Vertical node spacing |
 | `boxBorderPadding` | `number` | `1` | Inner box padding |
+| `preserveDisplayWidth` | `boolean` | `false` | Keep zero-width placeholders for fullwidth alignment |
 
 ### `fromShikiTheme(theme): DiagramColors`
 

--- a/src/ascii/draw.ts
+++ b/src/ascii/draw.ts
@@ -15,6 +15,7 @@ import {
   drawingCoordEquals,
 } from './types.ts'
 import { mkCanvas, copyCanvas, getCanvasSize, mergeCanvases, drawText } from './canvas.ts'
+import { stringWidth } from './text-width.ts'
 import { determineDirection, dirEquals } from './edge-routing.ts'
 import { gridToDrawingCoord, lineToDrawing } from './grid.ts'
 
@@ -70,11 +71,10 @@ export function drawBox(node: AsciiNode, graph: AsciiGraph): Canvas {
 
   // Center the display label inside the box
   const label = node.displayLabel
+  const labelWidth = stringWidth(label)
   const textY = from.y + Math.floor(h / 2)
-  const textX = from.x + Math.floor(w / 2) - Math.ceil(label.length / 2) + 1
-  for (let i = 0; i < label.length; i++) {
-    box[textX + i]![textY] = label[i]!
-  }
+  const textX = from.x + Math.floor(w / 2) - Math.ceil(labelWidth / 2) + 1
+  drawText(box, { x: textX, y: textY }, label)
 
   return box
 }
@@ -102,7 +102,7 @@ export function drawMultiBox(
   let maxTextWidth = 0
   for (const section of sections) {
     for (const line of section) {
-      maxTextWidth = Math.max(maxTextWidth, line.length)
+      maxTextWidth = Math.max(maxTextWidth, stringWidth(line))
     }
   }
   const innerWidth = maxTextWidth + 2 * padding
@@ -153,9 +153,7 @@ export function drawMultiBox(
     // Draw section text lines
     for (const line of lines) {
       const startX = 1 + padding
-      for (let i = 0; i < line.length; i++) {
-        canvas[startX + i]![row] = line[i]!
-      }
+      drawText(canvas, { x: startX, y: row }, line)
       row++
     }
 
@@ -447,7 +445,7 @@ function drawTextOnLine(canvas: Canvas, line: DrawingCoord[], label: string): vo
   const maxY = Math.max(line[0]!.y, line[1]!.y)
   const middleX = minX + Math.floor((maxX - minX) / 2)
   const middleY = minY + Math.floor((maxY - minY) / 2)
-  const startX = middleX - Math.floor(label.length / 2)
+  const startX = middleX - Math.floor(stringWidth(label) / 2)
   drawText(canvas, { x: startX, y: middleY }, label)
 }
 
@@ -496,14 +494,10 @@ export function drawSubgraphLabel(sg: AsciiSubgraph, graph: AsciiGraph): [Canvas
 
   const canvas = mkCanvas(width, height)
   const labelY = 1 // second row inside the subgraph box
-  let labelX = Math.floor(width / 2) - Math.floor(sg.name.length / 2)
+  const labelWidth = stringWidth(sg.name)
+  let labelX = Math.floor(width / 2) - Math.floor(labelWidth / 2)
   if (labelX < 1) labelX = 1
-
-  for (let i = 0; i < sg.name.length; i++) {
-    if (labelX + i < width) {
-      canvas[labelX + i]![labelY] = sg.name[i]!
-    }
-  }
+  drawText(canvas, { x: labelX, y: labelY }, sg.name)
 
   return [canvas, { x: sg.minX, y: sg.minY }]
 }

--- a/src/ascii/edge-routing.ts
+++ b/src/ascii/edge-routing.ts
@@ -12,6 +12,7 @@ import {
   gridCoordDirection,
 } from './types.ts'
 import { getPath, mergePath } from './pathfinder.ts'
+import { stringWidth } from './text-width.ts'
 
 // ============================================================================
 // Direction utilities
@@ -196,7 +197,7 @@ export function determinePath(graph: AsciiGraph, edge: AsciiEdge): void {
 export function determineLabelLine(graph: AsciiGraph, edge: AsciiEdge): void {
   if (edge.text.length === 0) return
 
-  const lenLabel = edge.text.length
+  const lenLabel = stringWidth(edge.text)
   let prevStep = edge.path[0]!
   let largestLine: [GridCoord, GridCoord] = [prevStep, edge.path[1]!]
   let largestLineSize = 0

--- a/src/ascii/grid.ts
+++ b/src/ascii/grid.ts
@@ -14,6 +14,7 @@ import { gridKey } from './types.ts'
 import { mkCanvas, setCanvasSizeToGrid } from './canvas.ts'
 import { determinePath, determineLabelLine } from './edge-routing.ts'
 import { drawBox } from './draw.ts'
+import { stringWidth } from './text-width.ts'
 
 // ============================================================================
 // Grid coordinate → drawing coordinate conversion
@@ -105,7 +106,8 @@ export function setColumnWidth(graph: AsciiGraph, node: AsciiNode): void {
   const padding = graph.config.boxBorderPadding
 
   // 3 columns: [border=1] [content=2*padding+labelLen] [border=1]
-  const colWidths = [1, 2 * padding + node.displayLabel.length, 1]
+  const labelWidth = stringWidth(node.displayLabel)
+  const colWidths = [1, 2 * padding + labelWidth, 1]
   // 3 rows: [border=1] [content=1+2*padding] [border=1]
   const rowHeights = [1, 1 + 2 * padding, 1]
 

--- a/src/ascii/index.ts
+++ b/src/ascii/index.ts
@@ -35,6 +35,8 @@ export interface AsciiRenderOptions {
   paddingY?: number
   /** Padding inside node boxes. Default: 1 */
   boxBorderPadding?: number
+  /** Preserve zero-width placeholders in output to keep column alignment. Default: false */
+  preserveDisplayWidth?: boolean
 }
 
 /**
@@ -87,6 +89,7 @@ export function renderMermaidAscii(
     paddingX: options.paddingX ?? 5,
     paddingY: options.paddingY ?? 5,
     boxBorderPadding: options.boxBorderPadding ?? 1,
+    preserveDisplayWidth: options.preserveDisplayWidth ?? false,
     graphDirection: 'TD', // default, overridden for flowcharts below
   }
 
@@ -126,7 +129,7 @@ export function renderMermaidAscii(
         flipCanvasVertically(graph.canvas)
       }
 
-      return canvasToString(graph.canvas)
+      return canvasToString(graph.canvas, !config.preserveDisplayWidth)
     }
   }
 }

--- a/src/ascii/sequence.ts
+++ b/src/ascii/sequence.ts
@@ -12,7 +12,8 @@
 import { parseSequenceDiagram } from '../sequence/parser.ts'
 import type { SequenceDiagram, Block } from '../sequence/types.ts'
 import type { Canvas, AsciiConfig } from './types.ts'
-import { mkCanvas, canvasToString, increaseSize } from './canvas.ts'
+import { mkCanvas, canvasToString, increaseSize, drawText } from './canvas.ts'
+import { charWidth, stringWidth } from './text-width.ts'
 
 /**
  * Render a Mermaid sequence diagram to ASCII/Unicode text.
@@ -45,7 +46,7 @@ export function renderSequenceAscii(text: string, config: AsciiConfig): string {
   diagram.actors.forEach((a, i) => actorIdx.set(a.id, i))
 
   const boxPad = 1
-  const actorBoxWidths = diagram.actors.map(a => a.label.length + 2 * boxPad + 2)
+  const actorBoxWidths = diagram.actors.map(a => stringWidth(a.label) + 2 * boxPad + 2)
   const halfBox = actorBoxWidths.map(w => Math.ceil(w / 2))
   const actorBoxH = 3 // top border + label row + bottom border
 
@@ -60,7 +61,7 @@ export function renderSequenceAscii(text: string, config: AsciiConfig): string {
     const lo = Math.min(fi, ti)
     const hi = Math.max(fi, ti)
     // Required gap per span = (label + arrow decorations) / number of gaps
-    const needed = msg.label.length + 4
+    const needed = stringWidth(msg.label) + 4
     const numGaps = hi - lo
     const perGap = Math.ceil(needed / numGaps)
     for (let g = lo; g < hi; g++) {
@@ -135,7 +136,7 @@ export function renderSequenceAscii(text: string, config: AsciiConfig): string {
         curY += 1
         const note = diagram.notes[n]!
         const nLines = note.text.split('\\n')
-        const nWidth = Math.max(...nLines.map(l => l.length)) + 4
+        const nWidth = Math.max(...nLines.map(l => stringWidth(l))) + 4
         const nHeight = nLines.length + 2
 
         // Determine x position based on note.position
@@ -185,7 +186,7 @@ export function renderSequenceAscii(text: string, config: AsciiConfig): string {
     const msg = diagram.messages[m]!
     if (msg.from === msg.to) {
       const fi = actorIdx.get(msg.from)!
-      const selfRight = llX[fi]! + 6 + 2 + msg.label.length
+      const selfRight = llX[fi]! + 6 + 2 + stringWidth(msg.label)
       totalW = Math.max(totalW, selfRight + 1)
     }
   }
@@ -197,8 +198,29 @@ export function renderSequenceAscii(text: string, config: AsciiConfig): string {
 
   // ---- DRAW: helper to place a bordered actor box ----
 
+  const ZERO_WIDTH = '\u200b'
+
+  function drawTextClipped(x: number, y: number, text: string, maxX: number): void {
+    let cx = x
+    for (const ch of text) {
+      const w = charWidth(ch)
+      if (w === 0) {
+        if (cx <= maxX) canvas[cx]![y] = ch
+        continue
+      }
+      if (cx + w - 1 > maxX) break
+      canvas[cx]![y] = ch
+      for (let i = 1; i < w; i++) {
+        if (canvas[cx + i]![y] === ' ') {
+          canvas[cx + i]![y] = ZERO_WIDTH
+        }
+      }
+      cx += w
+    }
+  }
+
   function drawActorBox(cx: number, topY: number, label: string): void {
-    const w = label.length + 2 * boxPad + 2
+    const w = stringWidth(label) + 2 * boxPad + 2
     const left = cx - Math.floor(w / 2)
     // Top border
     canvas[left]![topY] = TL
@@ -208,7 +230,7 @@ export function renderSequenceAscii(text: string, config: AsciiConfig): string {
     canvas[left]![topY + 1] = V
     canvas[left + w - 1]![topY + 1] = V
     const ls = left + 1 + boxPad
-    for (let i = 0; i < label.length; i++) canvas[ls + i]![topY + 1] = label[i]!
+    drawText(canvas, { x: ls, y: topY + 1 }, label)
     // Bottom border
     canvas[left]![topY + 2] = BL
     for (let x = 1; x < w - 1; x++) canvas[left + x]![topY + 2] = H
@@ -269,9 +291,7 @@ export function renderSequenceAscii(text: string, config: AsciiConfig): string {
       // Row 1: vertical on right side + label
       canvas[fromX + loopW]![y0 + 1] = V
       const labelX = fromX + loopW + 2
-      for (let i = 0; i < msg.label.length; i++) {
-        if (labelX + i < totalW) canvas[labelX + i]![y0 + 1] = msg.label[i]!
-      }
+      drawText(canvas, { x: labelX, y: y0 + 1 }, msg.label)
 
       // Row 2: arrow-back + horizontal + bottom-right corner
       const arrowChar = isFilled ? (useAscii ? '<' : '◀') : (useAscii ? '<' : '◁')
@@ -286,11 +306,8 @@ export function renderSequenceAscii(text: string, config: AsciiConfig): string {
 
       // Draw label centered between the two lifelines
       const midX = Math.floor((fromX + toX) / 2)
-      const labelStart = midX - Math.floor(msg.label.length / 2)
-      for (let i = 0; i < msg.label.length; i++) {
-        const lx = labelStart + i
-        if (lx >= 0 && lx < totalW) canvas[lx]![labelY] = msg.label[i]!
-      }
+      const labelStart = midX - Math.floor(stringWidth(msg.label) / 2)
+      if (labelStart >= 0) drawText(canvas, { x: labelStart, y: labelY }, msg.label)
 
       // Draw arrow line
       if (leftToRight) {
@@ -335,9 +352,7 @@ export function renderSequenceAscii(text: string, config: AsciiConfig): string {
     canvas[bRight]![topY] = TR
     // Write block header label over the top border
     const hdrLabel = block.label ? `${block.type} [${block.label}]` : block.type
-    for (let i = 0; i < hdrLabel.length && bLeft + 1 + i < bRight; i++) {
-      canvas[bLeft + 1 + i]![topY] = hdrLabel[i]!
-    }
+    drawTextClipped(bLeft + 1, topY, hdrLabel, bRight - 1)
 
     // Bottom border
     canvas[bLeft]![botY] = BL
@@ -362,9 +377,7 @@ export function renderSequenceAscii(text: string, config: AsciiConfig): string {
       const dLabel = block.dividers[d]!.label
       if (dLabel) {
         const dStr = `[${dLabel}]`
-        for (let i = 0; i < dStr.length && bLeft + 1 + i < bRight; i++) {
-          canvas[bLeft + 1 + i]![dY] = dStr[i]!
-        }
+        drawTextClipped(bLeft + 1, dY, dStr, bRight - 1)
       }
     }
   }
@@ -383,9 +396,7 @@ export function renderSequenceAscii(text: string, config: AsciiConfig): string {
       const ly = np.y + 1 + l
       canvas[np.x]![ly] = V
       canvas[np.x + np.width - 1]![ly] = V
-      for (let i = 0; i < np.lines[l]!.length; i++) {
-        canvas[np.x + 2 + i]![ly] = np.lines[l]![i]!
-      }
+      drawText(canvas, { x: np.x + 2, y: ly }, np.lines[l]!)
     }
     // Bottom border
     const by = np.y + np.height - 1
@@ -394,7 +405,7 @@ export function renderSequenceAscii(text: string, config: AsciiConfig): string {
     canvas[np.x + np.width - 1]![by] = BR
   }
 
-  return canvasToString(canvas)
+  return canvasToString(canvas, !config.preserveDisplayWidth)
 
   // ---- Helper: dashed horizontal character ----
   function isDashedH(): string {

--- a/src/ascii/text-width.ts
+++ b/src/ascii/text-width.ts
@@ -1,0 +1,56 @@
+// ============================================================================
+// ASCII renderer — text width utilities (monospace columns)
+//
+// Measures display width for mixed ASCII + CJK + emoji in fixed-width output.
+// Inspired by wcwidth / string-width (MIT), trimmed for our use-case.
+// ============================================================================
+
+/** Return the display width of a string in monospace columns. */
+export function stringWidth(text: string): number {
+  let width = 0
+  for (const ch of text) {
+    width += charWidth(ch)
+  }
+  return width
+}
+
+/** Return the display width of a single Unicode character. */
+export function charWidth(ch: string): number {
+  const codePoint = ch.codePointAt(0)
+  if (codePoint === undefined) return 0
+
+  // Control characters
+  if (codePoint <= 0x1F || (codePoint >= 0x7F && codePoint <= 0x9F)) return 0
+
+  // Combining marks (zero width)
+  if (isCombining(ch)) return 0
+
+  return isFullwidthCodePoint(codePoint) ? 2 : 1
+}
+
+function isCombining(ch: string): boolean {
+  return /\p{Mark}/u.test(ch)
+}
+
+// Based on https://github.com/sindresorhus/is-fullwidth-code-point (MIT)
+function isFullwidthCodePoint(codePoint: number): boolean {
+  if (codePoint >= 0x1100 && (
+    codePoint <= 0x115F ||
+    codePoint === 0x2329 ||
+    codePoint === 0x232A ||
+    (codePoint >= 0x2E80 && codePoint <= 0xA4CF && codePoint !== 0x303F) ||
+    (codePoint >= 0xAC00 && codePoint <= 0xD7A3) ||
+    (codePoint >= 0xF900 && codePoint <= 0xFAFF) ||
+    (codePoint >= 0xFE10 && codePoint <= 0xFE19) ||
+    (codePoint >= 0xFE30 && codePoint <= 0xFE6F) ||
+    (codePoint >= 0xFF00 && codePoint <= 0xFF60) ||
+    (codePoint >= 0xFFE0 && codePoint <= 0xFFE6) ||
+    (codePoint >= 0x1F300 && codePoint <= 0x1F64F) ||
+    (codePoint >= 0x1F900 && codePoint <= 0x1F9FF) ||
+    (codePoint >= 0x20000 && codePoint <= 0x3FFFD)
+  )) {
+    return true
+  }
+
+  return false
+}

--- a/src/ascii/types.ts
+++ b/src/ascii/types.ts
@@ -107,6 +107,8 @@ export interface AsciiConfig {
   paddingY: number
   /** Padding inside node boxes. Default: 1 */
   boxBorderPadding: number
+  /** Preserve zero-width placeholders in output to keep column alignment. Default: false */
+  preserveDisplayWidth: boolean
   /** Graph direction: "LR" or "TD". */
   graphDirection: 'LR' | 'TD'
 }


### PR DESCRIPTION
fix: #13 #14 

- Add fullwidth-aware text width measurement for CJK/emoji to improve ASCII/Unicode layout alignment.
- Box sizing, label centering, and edge/relationship labels now use display width instead of string length.
- Default output strips zero‑width placeholders; add preserveDisplayWidth option to keep them when needed.
- ER horizontal relationship labels avoid box borders (keep padding in gap, otherwise move up).

Tests
`bun test src/__tests__/ascii.test.ts`

