### PR TITLE
feat: add linkStyle directive support

### DIFF
--- a/src/__tests__/parser.test.ts
+++ b/src/__tests__/parser.test.ts
@@ -408,6 +408,42 @@ describe('parseMermaid – style statements', () => {
 })
 
 // ============================================================================
+// linkStyle directives
+// ============================================================================
+
+describe('parseMermaid – linkStyle directives', () => {
+  it('applies linkStyle to a specific edge index', () => {
+    const g = parseMermaid(`graph TD
+      A --> B
+      B --> C
+      linkStyle 0 stroke:#f00,stroke-width:3px`)
+    expect(g.edges[0]!.inlineStyle).toEqual({ stroke: '#f00', 'stroke-width': '3px' })
+    expect(g.edges[1]!.inlineStyle).toBeUndefined()
+  })
+
+  it('applies linkStyle to multiple indices', () => {
+    const g = parseMermaid(`graph TD
+      A --> B
+      B --> C
+      C --> D
+      linkStyle 0,2 stroke:#0f0`)
+    expect(g.edges[0]!.inlineStyle).toEqual({ stroke: '#0f0' })
+    expect(g.edges[1]!.inlineStyle).toBeUndefined()
+    expect(g.edges[2]!.inlineStyle).toEqual({ stroke: '#0f0' })
+  })
+
+  it('applies default linkStyle to all edges and merges with specific overrides', () => {
+    const g = parseMermaid(`graph TD
+      A --> B
+      B --> C
+      linkStyle default stroke:#333,stroke-width:2px
+      linkStyle 1 stroke:#f00`)
+    expect(g.edges[0]!.inlineStyle).toEqual({ stroke: '#333', 'stroke-width': '2px' })
+    expect(g.edges[1]!.inlineStyle).toEqual({ stroke: '#f00', 'stroke-width': '2px' })
+  })
+})
+
+// ============================================================================
 // Subgraph direction override (Batch 2.7)
 // ============================================================================
 

--- a/src/__tests__/renderer.test.ts
+++ b/src/__tests__/renderer.test.ts
@@ -431,6 +431,30 @@ describe('renderSvg – inline styles', () => {
   })
 })
 
+describe('renderSvg – edge inline styles', () => {
+  it('applies inline stroke override to edges', () => {
+    const edge = makeEdge({ inlineStyle: { stroke: '#123456' } })
+    const graph = makeGraph({ edges: [edge] })
+    const svg = renderSvg(graph, lightColors)
+    expect(svg).toContain('stroke="#123456"')
+  })
+
+  it('applies inline stroke-width override to edges', () => {
+    const edge = makeEdge({ inlineStyle: { 'stroke-width': '5' } })
+    const graph = makeGraph({ edges: [edge] })
+    const svg = renderSvg(graph, lightColors)
+    expect(svg).toContain('stroke-width="5"')
+  })
+
+  it('escapes injection in edge inline stroke', () => {
+    const edge = makeEdge({ inlineStyle: { stroke: 'red" onmouseover="alert(1)' } })
+    const graph = makeGraph({ edges: [edge] })
+    const svg = renderSvg(graph, lightColors)
+    expect(svg).not.toContain('onmouseover="alert')
+    expect(svg).toContain('red&quot; onmouseover=&quot;alert(1)')
+  })
+})
+
 // ============================================================================
 // XML escaping
 // ============================================================================

--- a/src/layout.ts
+++ b/src/layout.ts
@@ -216,6 +216,7 @@ function preComputeSubgraphLayout(
       hasArrowEnd: originalEdge.hasArrowEnd,
       points,
       labelPosition,
+      inlineStyle: originalEdge.inlineStyle,
     }
   })
 
@@ -680,6 +681,7 @@ function extractPositionedGraph(
       hasArrowEnd: originalEdge.hasArrowEnd,
       points,
       labelPosition,
+      inlineStyle: originalEdge.inlineStyle,
     }
   })
 

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -145,7 +145,11 @@ function renderEdge(edge: PositionedEdge): string {
 
   const pathData = pointsToPolylinePath(edge.points)
   const dashArray = edge.style === 'dotted' ? ' stroke-dasharray="4 4"' : ''
-  const strokeWidth = edge.style === 'thick' ? STROKE_WIDTHS.connector * 2 : STROKE_WIDTHS.connector
+
+  // Resolve stroke and stroke-width — inline styles (from linkStyle) override defaults
+  const stroke = escapeXml(edge.inlineStyle?.stroke ?? 'var(--_line)')
+  const defaultStrokeWidth = edge.style === 'thick' ? STROKE_WIDTHS.connector * 2 : STROKE_WIDTHS.connector
+  const strokeWidth = escapeXml(edge.inlineStyle?.['stroke-width'] ?? String(defaultStrokeWidth))
 
   // Build marker attributes based on arrow direction flags
   let markers = ''
@@ -153,7 +157,7 @@ function renderEdge(edge: PositionedEdge): string {
   if (edge.hasArrowStart) markers += ' marker-start="url(#arrowhead-start)"'
 
   return (
-    `<polyline points="${pathData}" fill="none" stroke="var(--_line)" ` +
+    `<polyline points="${pathData}" fill="none" stroke="${stroke}" ` +
     `stroke-width="${strokeWidth}"${dashArray}${markers} />`
   )
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,6 +12,10 @@ export interface MermaidGraph {
   classAssignments: Map<string, string>
   /** Maps node IDs to inline styles (from `style X fill:#f00,stroke:#333`) */
   nodeStyles: Map<string, Record<string, string>>
+  /** Maps edge indices to inline styles (from `linkStyle N stroke:#f00`) */
+  linkStyles: Map<number, Record<string, string>>
+  /** Default link style applied to all edges (from `linkStyle default ...`) */
+  defaultLinkStyle?: Record<string, string>
 }
 
 export type Direction = 'TD' | 'TB' | 'LR' | 'BT' | 'RL'
@@ -50,6 +54,8 @@ export interface MermaidEdge {
   hasArrowStart: boolean
   /** Whether to render an arrowhead at the end (target end) of the edge */
   hasArrowEnd: boolean
+  /** Inline styles from linkStyle directive (stroke, stroke-width, etc.) */
+  inlineStyle?: Record<string, string>
 }
 
 export type EdgeStyle = 'solid' | 'dotted' | 'thick'
@@ -98,6 +104,8 @@ export interface PositionedEdge {
   points: Point[]
   /** Layout-computed label center position (avoids label-label collisions) */
   labelPosition?: Point
+  /** Inline styles from linkStyle directive (stroke, stroke-width, etc.) */
+  inlineStyle?: Record<string, string>
 }
 
 export interface Point {


### PR DESCRIPTION
Adds support for the `linkStyle` directive to customize edge appearance in Mermaid flowcharts, matching the standard Mermaid syntax.

## Features

- **Index-based styling**: `linkStyle 0 stroke:#f00,stroke-width:3px`
- **Multiple indices**: `linkStyle 0,2,3 stroke:#0f0`
- **Default styling**: `linkStyle default stroke:#333` (applies to all edges)
- **Style merging**: Default styles merge with index-specific overrides (index takes precedence)

## Example

```
graph TD
  A --> B
  B --> C
  C --> D
  linkStyle default stroke:#333,stroke-width:2px
  linkStyle 0 stroke:#f00
  linkStyle 2 stroke:#0f0,stroke-width:4px
```

```mermaid
graph TD
  A --> B
  B --> C
  C --> D
  linkStyle default stroke:#333,stroke-width:2px
  linkStyle 0 stroke:#f00
  linkStyle 2 stroke:#0f0,stroke-width:4px
```

