### PR TITLE
feat: add multiline node labels with <br> and auto word-wrap

### DIFF
--- a/src/__tests__/renderer.test.ts
+++ b/src/__tests__/renderer.test.ts
@@ -535,3 +535,51 @@ describe('renderSvg – CSS variable theming', () => {
     expect(svg).toContain('fill="var(--_arrow)"')
   })
 })
+
+// ============================================================================
+// Multiline label rendering
+// ============================================================================
+
+describe('renderSvg – multiline labels', () => {
+  it('renders single-line label without tspan', () => {
+    const node = makeNode({ label: 'Hello' })
+    const graph = makeGraph({ nodes: [node] })
+    const svg = renderSvg(graph, lightColors)
+    expect(svg).toContain('>Hello</text>')
+    expect(svg).not.toContain('<tspan')
+  })
+
+  it('renders multiline node label with tspan elements', () => {
+    const node = makeNode({ label: 'Line 1\nLine 2' })
+    const graph = makeGraph({ nodes: [node] })
+    const svg = renderSvg(graph, lightColors)
+    expect(svg).toContain('<tspan')
+    expect(svg).toContain('>Line 1</tspan>')
+    expect(svg).toContain('>Line 2</tspan>')
+  })
+
+  it('renders three-line node label with three tspan elements', () => {
+    const node = makeNode({ label: 'A\nB\nC' })
+    const graph = makeGraph({ nodes: [node] })
+    const svg = renderSvg(graph, lightColors)
+    const tspanCount = (svg.match(/<tspan/g) ?? []).length
+    expect(tspanCount).toBe(3)
+  })
+
+  it('renders multiline edge label with tspan elements', () => {
+    const edge = makeEdge({ label: 'Yes\nNo' })
+    const graph = makeGraph({ edges: [edge] })
+    const svg = renderSvg(graph, lightColors)
+    expect(svg).toContain('<tspan')
+    expect(svg).toContain('>Yes</tspan>')
+    expect(svg).toContain('>No</tspan>')
+  })
+
+  it('escapes XML in multiline tspan content', () => {
+    const node = makeNode({ label: '<b>Bold</b>\n"Quoted"' })
+    const graph = makeGraph({ nodes: [node] })
+    const svg = renderSvg(graph, lightColors)
+    expect(svg).toContain('&lt;b&gt;Bold&lt;/b&gt;')
+    expect(svg).toContain('&quot;Quoted&quot;')
+  })
+})

--- a/src/__tests__/styles.test.ts
+++ b/src/__tests__/styles.test.ts
@@ -3,7 +3,7 @@
  * Theme resolution tests are in theme.test.ts (CSS custom property system).
  */
 import { describe, it, expect } from 'bun:test'
-import { estimateTextWidth, FONT_SIZES, FONT_WEIGHTS, NODE_PADDING, STROKE_WIDTHS, ARROW_HEAD } from '../styles.ts'
+import { estimateTextWidth, FONT_SIZES, FONT_WEIGHTS, NODE_PADDING, STROKE_WIDTHS, ARROW_HEAD, wrapText, LINE_HEIGHT_RATIO, MAX_LABEL_WIDTH } from '../styles.ts'
 import { THEMES, DEFAULTS, fromShikiTheme, buildStyleBlock, svgOpenTag } from '../theme.ts'
 import type { DiagramColors } from '../theme.ts'
 
@@ -177,5 +177,55 @@ describe('constants', () => {
   it('ARROW_HEAD has expected values', () => {
     expect(ARROW_HEAD.width).toBe(8)
     expect(ARROW_HEAD.height).toBe(4.8)
+  })
+
+  it('LINE_HEIGHT_RATIO is 1.4', () => {
+    expect(LINE_HEIGHT_RATIO).toBe(1.4)
+  })
+
+  it('MAX_LABEL_WIDTH is 200', () => {
+    expect(MAX_LABEL_WIDTH).toBe(200)
+  })
+})
+
+// ============================================================================
+// Text wrapping
+// ============================================================================
+
+describe('wrapText', () => {
+  it('returns single-element array for short text', () => {
+    const lines = wrapText('Hello', 13, 500)
+    expect(lines).toEqual(['Hello'])
+  })
+
+  it('splits on existing newlines', () => {
+    const lines = wrapText('Line 1\nLine 2', 13, 500)
+    expect(lines).toEqual(['Line 1', 'Line 2'])
+  })
+
+  it('preserves multiple newlines as separate lines', () => {
+    const lines = wrapText('A\nB\nC', 13, 500)
+    expect(lines).toEqual(['A', 'B', 'C'])
+  })
+
+  it('auto-wraps long lines at word boundaries', () => {
+    // Create a long text that exceeds maxWidth of 200px
+    const longText = 'This is a very long label that should be wrapped at word boundaries'
+    const lines = wrapText(longText, 13, 500, 100)
+    expect(lines.length).toBeGreaterThan(1)
+    // All words should still be present
+    expect(lines.join(' ')).toBe(longText)
+  })
+
+  it('does not wrap text that fits within maxWidth', () => {
+    const lines = wrapText('Short', 13, 500, 200)
+    expect(lines).toEqual(['Short'])
+  })
+
+  it('handles combined newlines and word wrapping', () => {
+    const text = 'Short line\nThis is a very long line that should definitely be word wrapped'
+    const lines = wrapText(text, 13, 500, 100)
+    expect(lines.length).toBeGreaterThan(2)
+    expect(lines[0]).toBe('Short line')
   })
 })

--- a/src/ascii/draw.ts
+++ b/src/ascii/draw.ts
@@ -68,12 +68,21 @@ export function drawBox(node: AsciiNode, graph: AsciiGraph): Canvas {
     box[to.x]![to.y] = '+'
   }
 
-  // Center the display label inside the box
+  // Center the display label inside the box (supports multiline via \n)
   const label = node.displayLabel
-  const textY = from.y + Math.floor(h / 2)
-  const textX = from.x + Math.floor(w / 2) - Math.ceil(label.length / 2) + 1
-  for (let i = 0; i < label.length; i++) {
-    box[textX + i]![textY] = label[i]!
+  const lines = label.split('\n')
+  const totalLines = lines.length
+  const startY = from.y + Math.floor(h / 2) - Math.floor(totalLines / 2)
+
+  for (let lineIdx = 0; lineIdx < totalLines; lineIdx++) {
+    const line = lines[lineIdx]!
+    const textY = startY + lineIdx
+    const textX = from.x + Math.floor(w / 2) - Math.ceil(line.length / 2) + 1
+    for (let i = 0; i < line.length; i++) {
+      if (textX + i > from.x && textX + i < to.x && textY > from.y && textY < to.y) {
+        box[textX + i]![textY] = line[i]!
+      }
+    }
   }
 
   return box

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -1,7 +1,7 @@
 import type { PositionedGraph, PositionedNode, PositionedEdge, PositionedGroup, Point } from './types.ts'
 import type { DiagramColors } from './theme.ts'
 import { svgOpenTag, buildStyleBlock } from './theme.ts'
-import { FONT_SIZES, FONT_WEIGHTS, STROKE_WIDTHS, ARROW_HEAD, estimateTextWidth, TEXT_BASELINE_SHIFT } from './styles.ts'
+import { FONT_SIZES, FONT_WEIGHTS, STROKE_WIDTHS, ARROW_HEAD, estimateTextWidth, TEXT_BASELINE_SHIFT, LINE_HEIGHT_RATIO, wrapText } from './styles.ts'
 
 // ============================================================================
 // SVG renderer — converts a PositionedGraph into an SVG string.
@@ -168,20 +168,40 @@ function renderEdgeLabel(edge: PositionedEdge, font: string): string {
   // Fall back to geometric midpoint of the edge polyline.
   const mid = edge.labelPosition ?? edgeMidpoint(edge.points)
   const label = edge.label!
-  const textWidth = estimateTextWidth(label, FONT_SIZES.edgeLabel, FONT_WEIGHTS.edgeLabel)
+  const lines = wrapText(label, FONT_SIZES.edgeLabel, FONT_WEIGHTS.edgeLabel)
+  const widestLine = lines.reduce((max, line) =>
+    Math.max(max, estimateTextWidth(line, FONT_SIZES.edgeLabel, FONT_WEIGHTS.edgeLabel)), 0)
   const padding = 8
 
   // Background pill behind text for readability
-  const bgWidth = textWidth + padding * 2
-  const bgHeight = FONT_SIZES.edgeLabel + padding * 2
+  const lineHeight = FONT_SIZES.edgeLabel * LINE_HEIGHT_RATIO
+  const bgWidth = widestLine + padding * 2
+  const bgHeight = lines.length * lineHeight + padding * 2
+
+  let textContent: string
+  if (lines.length <= 1) {
+    textContent =
+      `<text x="${mid.x}" y="${mid.y}" text-anchor="middle" dy="${TEXT_BASELINE_SHIFT}" ` +
+      `font-size="${FONT_SIZES.edgeLabel}" font-weight="${FONT_WEIGHTS.edgeLabel}" ` +
+      `fill="var(--_text-muted)">${escapeXml(label)}</text>`
+  } else {
+    const totalTextHeight = lines.length * lineHeight
+    const startDy = -(totalTextHeight / 2) + lineHeight / 2
+    const tspans = lines.map((line, i) => {
+      const dy = i === 0 ? startDy : lineHeight
+      return `<tspan x="${mid.x}" dy="${dy}">${escapeXml(line)}</tspan>`
+    }).join('')
+    textContent =
+      `<text x="${mid.x}" y="${mid.y}" text-anchor="middle" ` +
+      `font-size="${FONT_SIZES.edgeLabel}" font-weight="${FONT_WEIGHTS.edgeLabel}" ` +
+      `fill="var(--_text-muted)">${tspans}</text>`
+  }
 
   return (
     `<rect x="${mid.x - bgWidth / 2}" y="${mid.y - bgHeight / 2}" ` +
     `width="${bgWidth}" height="${bgHeight}" rx="4" ry="4" ` +
     `fill="var(--bg)" stroke="var(--_inner-stroke)" stroke-width="0.5" />\n` +
-    `<text x="${mid.x}" y="${mid.y}" text-anchor="middle" dy="${TEXT_BASELINE_SHIFT}" ` +
-    `font-size="${FONT_SIZES.edgeLabel}" font-weight="${FONT_WEIGHTS.edgeLabel}" ` +
-    `fill="var(--_text-muted)">${escapeXml(label)}</text>`
+    textContent
   )
 }
 
@@ -463,10 +483,31 @@ function renderNodeLabel(node: PositionedNode, font: string): string {
   // Resolve text color — inline styles can override the CSS variable default
   const textColor = escapeXml(node.inlineStyle?.color ?? 'var(--_text)')
 
+  const lines = wrapText(node.label, FONT_SIZES.nodeLabel, FONT_WEIGHTS.nodeLabel)
+
+  if (lines.length <= 1) {
+    return (
+      `<text x="${cx}" y="${cy}" text-anchor="middle" dy="${TEXT_BASELINE_SHIFT}" ` +
+      `font-size="${FONT_SIZES.nodeLabel}" font-weight="${FONT_WEIGHTS.nodeLabel}" ` +
+      `fill="${textColor}">${escapeXml(node.label)}</text>`
+    )
+  }
+
+  // Multiline: use <tspan> elements, vertically centered
+  const lineHeight = FONT_SIZES.nodeLabel * LINE_HEIGHT_RATIO
+  const totalTextHeight = lines.length * lineHeight
+  // First tspan y offset: shift up by half the block height, then down by half a line
+  const startDy = -(totalTextHeight / 2) + lineHeight / 2
+
+  const tspans = lines.map((line, i) => {
+    const dy = i === 0 ? startDy : lineHeight
+    return `<tspan x="${cx}" dy="${dy}">${escapeXml(line)}</tspan>`
+  }).join('')
+
   return (
-    `<text x="${cx}" y="${cy}" text-anchor="middle" dy="${TEXT_BASELINE_SHIFT}" ` +
+    `<text x="${cx}" y="${cy}" text-anchor="middle" ` +
     `font-size="${FONT_SIZES.nodeLabel}" font-weight="${FONT_WEIGHTS.nodeLabel}" ` +
-    `fill="${textColor}">${escapeXml(node.label)}</text>`
+    `fill="${textColor}">${tspans}</text>`
   )
 }
 

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -85,6 +85,56 @@ export const STROKE_WIDTHS = {
  */
 export const TEXT_BASELINE_SHIFT = '0.35em' as const
 
+/** Line height multiplier for multiline text (relative to font size) */
+export const LINE_HEIGHT_RATIO = 1.4
+
+/** Maximum label width in px before auto-wrapping at word boundaries */
+export const MAX_LABEL_WIDTH = 200
+
+/**
+ * Wrap text into multiple lines:
+ * 1. Split on existing `\n` characters (from `<br>` normalization)
+ * 2. Word-wrap any line exceeding `maxWidth` at word boundaries
+ *
+ * Returns an array of lines.
+ */
+export function wrapText(text: string, fontSize: number, fontWeight: number, maxWidth: number = MAX_LABEL_WIDTH): string[] {
+  const hardLines = text.split('\n')
+  const result: string[] = []
+
+  for (const line of hardLines) {
+    const lineWidth = estimateTextWidth(line, fontSize, fontWeight)
+    if (lineWidth <= maxWidth) {
+      result.push(line)
+      continue
+    }
+
+    // Word-wrap this line
+    const words = line.split(/\s+/)
+    let currentLine = ''
+
+    for (const word of words) {
+      if (currentLine.length === 0) {
+        currentLine = word
+        continue
+      }
+      const testLine = currentLine + ' ' + word
+      const testWidth = estimateTextWidth(testLine, fontSize, fontWeight)
+      if (testWidth <= maxWidth) {
+        currentLine = testLine
+      } else {
+        result.push(currentLine)
+        currentLine = word
+      }
+    }
+    if (currentLine.length > 0) {
+      result.push(currentLine)
+    }
+  }
+
+  return result
+}
+
 /** Arrow head dimensions */
 export const ARROW_HEAD = {
   width: 8,


### PR DESCRIPTION
Adds support for explicit `<br>` line breaks and automatic word wrapping in node, edge, and subgraph labels. 

Fixes #5. Fixes #26.

- **Parser**: `normalizeLabel()` strips surrounding `"` quotes and replaces `<br>`, `<br/>`, `<br />` (case-insensitive) with `\n`
- **Styles**: `wrapText()` splits on `\n` then word-wraps lines exceeding `MAX_LABEL_WIDTH` (200px) at word boundaries
- **Layout**: `estimateNodeSize()` uses widest wrapped line for width and line count for height; edge label sizing updated similarly
- **SVG renderer**: `renderNodeLabel()` and `renderEdgeLabel()` emit `<tspan>` elements for multiline text with vertical centering
- **ASCII renderer**: `drawBox()` splits labels on `\n` and renders each line centered vertically