### PR TITLE
Add static color resolution for PDF-compatible SVG output

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "beautiful-mermaid",

--- a/src/__tests__/integration.test.ts
+++ b/src/__tests__/integration.test.ts
@@ -213,8 +213,9 @@ describe('renderMermaid – Batch 2 edge features', () => {
 
   it('renders bidirectional arrows', async () => {
     const svg = await renderMermaid('graph TD\n  A <--> B')
-    expect(svg).toContain('marker-end="url(#arrowhead)"')
-    expect(svg).toContain('marker-start="url(#arrowhead-start)"')
+    // Marker IDs may be namespaced (e.g. m1234-arrowhead) for multi-SVG safety
+    expect(svg).toMatch(/marker-end="url\(#[^"]*arrowhead\)"/)
+    expect(svg).toMatch(/marker-start="url\(#[^"]*arrowhead-start\)"/)
   })
 
   it('renders parallel links with &', async () => {

--- a/src/__tests__/static-colors.test.ts
+++ b/src/__tests__/static-colors.test.ts
@@ -1,0 +1,715 @@
+/**
+ * Tests for static color resolution (output: 'static').
+ *
+ * Verifies that when output is 'static', rendered SVG contains no
+ * CSS custom properties (var(--)), color-mix(), or @import directives -
+ * producing output compatible with PDF renderers.
+ */
+import { describe, it, expect } from 'bun:test'
+import { renderMermaid } from '../index.ts'
+import type { ResolvedColors } from '../theme.ts'
+import { colorMix, resolveColors, parseHex, toHex, createColorFn, validateHexColor, HEX_RE, COLOR_GRAPH, generateMarkerId, svgOpenTagStatic } from '../theme.ts'
+
+// ============================================================================
+// Unit tests: color utilities
+// ============================================================================
+
+describe('parseHex / toHex', () => {
+  it('parses 6-digit hex', () => {
+    expect(parseHex('#FF8000')).toEqual({ r: 255, g: 128, b: 0 })
+  })
+
+  it('parses 3-digit shorthand hex', () => {
+    expect(parseHex('#F80')).toEqual({ r: 255, g: 136, b: 0 })
+  })
+
+  it('parses 8-digit hex (preserves alpha)', () => {
+    expect(parseHex('#FF800080')).toEqual({ r: 255, g: 128, b: 0, a: 128 })
+  })
+
+  it('round-trips through toHex', () => {
+    expect(toHex(parseHex('#27272a'))).toBe('#27272a')
+  })
+
+  it('toHex clamps out-of-range values', () => {
+    expect(toHex({ r: 300, g: -10, b: 128 })).toBe('#ff0080')
+  })
+
+  it('toHex emits alpha when present and not 255', () => {
+    expect(toHex({ r: 255, g: 128, b: 0, a: 128 })).toBe('#ff800080')
+  })
+
+  it('toHex omits alpha when fully opaque (255)', () => {
+    expect(toHex({ r: 255, g: 128, b: 0, a: 255 })).toBe('#ff8000')
+  })
+
+  it('toHex omits alpha when not present', () => {
+    expect(toHex({ r: 255, g: 128, b: 0 })).toBe('#ff8000')
+  })
+
+  it('round-trips 8-digit hex through parseHex/toHex', () => {
+    expect(toHex(parseHex('#ff800080'))).toBe('#ff800080')
+  })
+
+  it('throws on invalid hex length (4 digits)', () => {
+    expect(() => parseHex('#ABCD')).toThrow(/Invalid hex color/)
+  })
+
+  it('throws on invalid hex length (5 digits)', () => {
+    expect(() => parseHex('#ABCDE')).toThrow(/Invalid hex color/)
+  })
+
+  it('throws on invalid hex length (7 digits)', () => {
+    expect(() => parseHex('#AABBCCD')).toThrow(/Invalid hex color/)
+  })
+
+  it('throws on empty input', () => {
+    expect(() => parseHex('')).toThrow(/Invalid hex color/)
+  })
+
+  it('throws on hash-only input', () => {
+    expect(() => parseHex('#')).toThrow(/Invalid hex color/)
+  })
+})
+
+describe('colorMix', () => {
+  it('returns bg at 0%', () => {
+    expect(colorMix('#000000', '#ffffff', 0)).toBe('#ffffff')
+  })
+
+  it('returns fg at 100%', () => {
+    expect(colorMix('#000000', '#ffffff', 100)).toBe('#000000')
+  })
+
+  it('returns midpoint at 50%', () => {
+    const result = colorMix('#000000', '#ffffff', 50)
+    // 50% mix of black into white = #808080 (or close)
+    const parsed = parseHex(result)
+    expect(parsed.r).toBeGreaterThanOrEqual(127)
+    expect(parsed.r).toBeLessThanOrEqual(128)
+  })
+
+  it('mixes colored values correctly', () => {
+    // 50% of #FF0000 into #0000FF = #800080
+    const result = colorMix('#FF0000', '#0000FF', 50)
+    const parsed = parseHex(result)
+    expect(parsed.r).toBeGreaterThanOrEqual(127)
+    expect(parsed.r).toBeLessThanOrEqual(128)
+    expect(parsed.g).toBe(0)
+    expect(parsed.b).toBeGreaterThanOrEqual(127)
+    expect(parsed.b).toBeLessThanOrEqual(128)
+  })
+
+  it('interpolates alpha when inputs have alpha', () => {
+    // 50% mix: fg alpha 0 into bg alpha 255 → alpha ~128
+    const result = colorMix('#FF000000', '#00FF00FF', 50)
+    const parsed = parseHex(result)
+    expect(parsed.a).toBeGreaterThanOrEqual(127)
+    expect(parsed.a).toBeLessThanOrEqual(128)
+  })
+
+  it('defaults missing alpha to 255 during mix', () => {
+    // fg has alpha 0, bg has no alpha (defaults to 255)
+    const result = colorMix('#FF000000', '#00FF00', 50)
+    const parsed = parseHex(result)
+    expect(parsed.a).toBeGreaterThanOrEqual(127)
+    expect(parsed.a).toBeLessThanOrEqual(128)
+  })
+
+  it('omits alpha when neither input has alpha', () => {
+    const result = colorMix('#FF0000', '#00FF00', 50)
+    const parsed = parseHex(result)
+    expect(parsed.a).toBeUndefined()
+  })
+})
+
+// ============================================================================
+// Hex color validation
+// ============================================================================
+
+describe('validateHexColor', () => {
+  it('accepts 3-digit hex', () => {
+    expect(() => validateHexColor('#F80', 'test')).not.toThrow()
+  })
+
+  it('accepts 6-digit hex', () => {
+    expect(() => validateHexColor('#FF8000', 'test')).not.toThrow()
+  })
+
+  it('accepts 8-digit hex (alpha)', () => {
+    expect(() => validateHexColor('#FF800080', 'test')).not.toThrow()
+  })
+
+  it('rejects rgb() values', () => {
+    expect(() => validateHexColor('rgb(255, 128, 0)', 'test')).toThrow(/Invalid color/)
+  })
+
+  it('rejects hsl() values', () => {
+    expect(() => validateHexColor('hsl(30, 100%, 50%)', 'test')).toThrow(/Invalid color/)
+  })
+
+  it('rejects named colors', () => {
+    expect(() => validateHexColor('red', 'test')).toThrow(/Invalid color/)
+  })
+
+  it('rejects var() references', () => {
+    expect(() => validateHexColor('var(--bg)', 'test')).toThrow(/Invalid color/)
+  })
+
+  it('rejects empty string', () => {
+    expect(() => validateHexColor('', 'test')).toThrow(/Invalid color/)
+  })
+})
+
+// ============================================================================
+// HEX_RE - single source of truth
+// ============================================================================
+
+describe('HEX_RE alignment', () => {
+  const validHex = ['#F80', '#FF8000', '#FF800080']
+  const invalidHex = ['rgb(0,0,0)', 'hsl(0,0%,0%)', 'red', 'var(--bg)', '', '#ABCD', '#ABCDE']
+
+  for (const v of validHex) {
+    it(`HEX_RE accepts ${v}`, () => {
+      expect(HEX_RE.test(v)).toBe(true)
+    })
+    it(`validateHexColor accepts ${v}`, () => {
+      expect(() => validateHexColor(v, 'test')).not.toThrow()
+    })
+  }
+
+  for (const v of invalidHex) {
+    it(`HEX_RE rejects '${v}'`, () => {
+      expect(HEX_RE.test(v)).toBe(false)
+    })
+    it(`validateHexColor rejects '${v}'`, () => {
+      expect(() => validateHexColor(v, 'test')).toThrow()
+    })
+  }
+})
+
+// ============================================================================
+// COLOR_GRAPH - shared derivation
+// ============================================================================
+
+describe('COLOR_GRAPH', () => {
+  it('has entries for all ResolvedColors keys (except bg)', () => {
+    const graphKeys = COLOR_GRAPH.map(r => r.cssVar)
+    expect(graphKeys).toContain('_text')
+    expect(graphKeys).toContain('_text-sec')
+    expect(graphKeys).toContain('_text-muted')
+    expect(graphKeys).toContain('_text-faint')
+    expect(graphKeys).toContain('_line')
+    expect(graphKeys).toContain('_arrow')
+    expect(graphKeys).toContain('_node-fill')
+    expect(graphKeys).toContain('_node-stroke')
+    expect(graphKeys).toContain('_group-fill')
+    expect(graphKeys).toContain('_group-hdr')
+    expect(graphKeys).toContain('_inner-stroke')
+    expect(graphKeys).toContain('_key-badge')
+  })
+
+  it('has 12 entries (one per derived variable)', () => {
+    expect(COLOR_GRAPH.length).toBe(12)
+  })
+
+  it('reverse sync: every ResolvedColors key (except bg) is in COLOR_GRAPH', () => {
+    const graphCssVars = new Set(COLOR_GRAPH.map(r => r.cssVar))
+    // Get ResolvedColors keys from a resolved instance
+    const resolved = resolveColors({ bg: '#FFFFFF', fg: '#000000' })
+    const resolvedKeys = Object.keys(resolved).filter(k => k !== 'bg')
+    for (const key of resolvedKeys) {
+      expect(graphCssVars.has(key)).toBe(true)
+    }
+  })
+})
+
+// ============================================================================
+// resolveColors
+// ============================================================================
+
+describe('resolveColors', () => {
+  it('resolves all 13 color keys', () => {
+    const resolved = resolveColors({ bg: '#FFFFFF', fg: '#27272A' })
+    const keys = Object.keys(resolved)
+    expect(keys).toContain('bg')
+    expect(keys).toContain('_text')
+    expect(keys).toContain('_text-sec')
+    expect(keys).toContain('_text-muted')
+    expect(keys).toContain('_text-faint')
+    expect(keys).toContain('_line')
+    expect(keys).toContain('_arrow')
+    expect(keys).toContain('_node-fill')
+    expect(keys).toContain('_node-stroke')
+    expect(keys).toContain('_group-fill')
+    expect(keys).toContain('_group-hdr')
+    expect(keys).toContain('_inner-stroke')
+    expect(keys).toContain('_key-badge')
+  })
+
+  it('uses literal fg for _text', () => {
+    const resolved = resolveColors({ bg: '#FFFFFF', fg: '#27272A' })
+    expect(resolved._text).toBe('#27272A')
+  })
+
+  it('uses bg for _group-fill', () => {
+    const resolved = resolveColors({ bg: '#1a1b26', fg: '#a9b1d6' })
+    expect(resolved['_group-fill']).toBe('#1a1b26')
+  })
+
+  it('uses provided enrichment colors when set', () => {
+    const resolved = resolveColors({
+      bg: '#FFFFFF', fg: '#000000',
+      line: '#aabbcc', accent: '#112233', muted: '#445566',
+      surface: '#eeff00', border: '#998877',
+    })
+    expect(resolved._line).toBe('#aabbcc')
+    expect(resolved._arrow).toBe('#112233')
+    expect(resolved['_text-sec']).toBe('#445566')
+    expect(resolved['_text-muted']).toBe('#445566')
+    expect(resolved['_node-fill']).toBe('#eeff00')
+    expect(resolved['_node-stroke']).toBe('#998877')
+  })
+
+  it('falls back to color-mix when enrichment colors are not set', () => {
+    const resolved = resolveColors({ bg: '#FFFFFF', fg: '#000000' })
+    // _line should be mix(#000, #FFF, 30%) ≈ #b3b3b3
+    const line = parseHex(resolved._line)
+    expect(line.r).toBeGreaterThan(150)
+    expect(line.r).toBeLessThan(200)
+  })
+
+  it('all values are valid hex strings', () => {
+    const resolved = resolveColors({ bg: '#18181B', fg: '#FAFAFA' })
+    for (const [key, value] of Object.entries(resolved)) {
+      expect(value).toMatch(/^#[0-9a-f]{6}$/i)
+    }
+  })
+
+  it('throws on non-hex bg color', () => {
+    expect(() => resolveColors({ bg: 'white', fg: '#000000' })).toThrow(/Invalid color/)
+  })
+
+  it('throws on non-hex fg color', () => {
+    expect(() => resolveColors({ bg: '#FFFFFF', fg: 'rgb(0,0,0)' })).toThrow(/Invalid color/)
+  })
+
+  it('throws on non-hex enrichment color', () => {
+    expect(() => resolveColors({ bg: '#FFFFFF', fg: '#000000', line: 'red' })).toThrow(/Invalid color/)
+  })
+})
+
+// ============================================================================
+// Regression snapshots: exact color values for known inputs
+// ============================================================================
+
+describe('resolveColors – regression snapshots', () => {
+  it('default white/zinc palette produces expected values', () => {
+    const r = resolveColors({ bg: '#FFFFFF', fg: '#27272A' })
+    expect(r.bg).toBe('#FFFFFF')
+    expect(r._text).toBe('#27272A')
+    expect(r['_group-fill']).toBe('#FFFFFF')
+    // _text-faint at 25%: mix(#27272A, #FFFFFF, 25%)
+    expect(r['_text-faint']).toBe('#c9c9ca')
+    // _node-fill at 3%: mix(#27272A, #FFFFFF, 3%)
+    expect(r['_node-fill']).toBe('#f9f9f9')
+    // _line at 30%: mix(#27272A, #FFFFFF, 30%)
+    expect(r._line).toBe('#bebebf')
+    // _arrow at 50%: mix(#27272A, #FFFFFF, 50%)
+    expect(r._arrow).toBe('#939395')
+  })
+
+  it('black/white palette produces expected values', () => {
+    const r = resolveColors({ bg: '#FFFFFF', fg: '#000000' })
+    expect(r._text).toBe('#000000')
+    // 50% mix of black into white = #808080
+    expect(r._arrow).toBe('#808080')
+    // 30% mix of black into white = #b3b3b3
+    expect(r._line).toBe('#b3b3b3')
+    // 3% mix of black into white = #f7f7f7
+    expect(r['_node-fill']).toBe('#f7f7f7')
+  })
+
+  it('tokyo night palette produces expected values', () => {
+    const r = resolveColors({ bg: '#1a1b26', fg: '#a9b1d6' })
+    expect(r.bg).toBe('#1a1b26')
+    expect(r._text).toBe('#a9b1d6')
+    expect(r['_group-fill']).toBe('#1a1b26')
+    // Derived values for tokyo night mono
+    expect(r['_text-faint']).toMatch(/^#[0-9a-f]{6}$/i)
+    expect(r._line).toMatch(/^#[0-9a-f]{6}$/i)
+  })
+})
+
+// ============================================================================
+// createColorFn
+// ============================================================================
+
+describe('createColorFn', () => {
+  it('returns var() strings when resolved is null', () => {
+    const c = createColorFn(null)
+    expect(c('_text')).toBe('var(--_text)')
+    expect(c('_line')).toBe('var(--_line)')
+    expect(c.bg()).toBe('var(--bg)')
+  })
+
+  it('returns hex strings when resolved is provided', () => {
+    const resolved = resolveColors({ bg: '#FFFFFF', fg: '#000000' })
+    const c = createColorFn(resolved)
+    expect(c('_text')).toBe('#000000')
+    expect(c.bg()).toBe('#FFFFFF')
+    expect(c('_line')).toMatch(/^#[0-9a-f]{6}$/i)
+  })
+})
+
+// ============================================================================
+// generateMarkerId
+// ============================================================================
+
+describe('generateMarkerId', () => {
+  it('returns a string starting with m', () => {
+    const id = generateMarkerId()
+    expect(id).toMatch(/^m[0-9a-f]{4}$/)
+  })
+
+  it('generates different IDs on successive calls', () => {
+    const ids = new Set(Array.from({ length: 20 }, () => generateMarkerId()))
+    // Should have high uniqueness (allow small chance of collision)
+    expect(ids.size).toBeGreaterThan(15)
+  })
+
+  it('generates custom length IDs', () => {
+    const id = generateMarkerId(6)
+    // m + 6 hex chars = 7 chars total
+    expect(id).toHaveLength(7)
+    expect(id).toMatch(/^m[0-9a-f]{6}$/)
+  })
+
+  it('throws on length 0', () => {
+    expect(() => generateMarkerId(0)).toThrow(/length must be >= 1/)
+  })
+
+  it('throws on negative length', () => {
+    expect(() => generateMarkerId(-3)).toThrow(/length must be >= 1/)
+  })
+
+  it('generates full entropy for large lengths', () => {
+    const id = generateMarkerId(20)
+    expect(id).toHaveLength(21) // m + 20 hex chars
+    expect(id).toMatch(/^m[0-9a-f]{20}$/)
+  })
+})
+
+// ============================================================================
+// svgOpenTagStatic - unit tests
+// ============================================================================
+
+describe('svgOpenTagStatic', () => {
+  it('background comes before font-family in style attribute', () => {
+    const tag = svgOpenTagStatic(100, 100, '#FFFFFF', false, 'Inter', true)
+    const styleMatch = tag.match(/style="([^"]*)"/)
+    expect(styleMatch).toBeTruthy()
+    const style = styleMatch![1]!
+    const bgIdx = style.indexOf('background:')
+    const fontIdx = style.indexOf('font-family:')
+    expect(bgIdx).toBeGreaterThanOrEqual(0)
+    expect(fontIdx).toBeGreaterThan(bgIdx)
+  })
+
+  it('includes font-family when transparent and noStyleBlock', () => {
+    const tag = svgOpenTagStatic(100, 100, '#FFFFFF', true, 'Inter', true)
+    expect(tag).toContain('background:none')
+    expect(tag).toContain("font-family:'Inter',system-ui,sans-serif")
+  })
+
+  it('escapes single quotes in font names', () => {
+    const tag = svgOpenTagStatic(100, 100, '#FFF', false, "Foo'Bar", true)
+    expect(tag).toContain("font-family:'Foo&#39;Bar'")
+    // Must not break the style attribute quoting
+    const quoteCount = (tag.match(/style="/g) ?? []).length
+    expect(quoteCount).toBe(1) // exactly one opening style="
+  })
+
+  it('omits font-family when noStyleBlock is false', () => {
+    const tag = svgOpenTagStatic(100, 100, '#FFFFFF', false, 'Inter', false)
+    expect(tag).not.toContain('font-family')
+  })
+
+  it('omits font-family when font is not provided', () => {
+    const tag = svgOpenTagStatic(100, 100, '#FFFFFF', false, undefined, true)
+    expect(tag).not.toContain('font-family')
+  })
+})
+
+// ============================================================================
+// Integration: static SVG output (no var, no color-mix, no @import)
+// ============================================================================
+
+/** Assert that SVG contains no CSS-dependent constructs */
+function assertStaticSvg(svg: string): void {
+  // No CSS custom properties
+  expect(svg).not.toMatch(/var\(--/)
+  // No color-mix() functions
+  expect(svg).not.toMatch(/color-mix\(/)
+  // No @import directives
+  expect(svg).not.toMatch(/@import/)
+}
+
+describe('renderMermaid – output: static', () => {
+  describe('flowchart', () => {
+    it('produces static SVG with no CSS variables', async () => {
+      const svg = await renderMermaid('graph TD\n  A --> B', { output: 'static' })
+      assertStaticSvg(svg)
+      expect(svg).toContain('<svg')
+      expect(svg).toContain('>A</text>')
+      expect(svg).toContain('>B</text>')
+    })
+
+    it('uses hex colors in fill/stroke attributes', async () => {
+      const svg = await renderMermaid('graph TD\n  A --> B', {
+        bg: '#1a1b26', fg: '#a9b1d6', output: 'static',
+      })
+      assertStaticSvg(svg)
+      // Should contain hex color values in the output
+      expect(svg).toMatch(/#[0-9a-f]{6}/i)
+    })
+
+    it('renders subgraphs with static colors', async () => {
+      const svg = await renderMermaid(`graph TD
+        subgraph Backend
+          A[API] --> B[DB]
+        end
+        C[Client] --> A`, { output: 'static' })
+      assertStaticSvg(svg)
+      expect(svg).toContain('>Backend</text>')
+    })
+
+    it('renders edge labels with static colors', async () => {
+      const svg = await renderMermaid('graph TD\n  A -->|Yes| B', { output: 'static' })
+      assertStaticSvg(svg)
+      expect(svg).toContain('>Yes</text>')
+    })
+
+    it('renders state diagrams with static colors', async () => {
+      const svg = await renderMermaid(`stateDiagram-v2
+        [*] --> Idle
+        Idle --> Active : start
+        Active --> [*]`, { output: 'static' })
+      assertStaticSvg(svg)
+      expect(svg).toContain('>Idle</text>')
+      expect(svg).toContain('>Active</text>')
+    })
+
+    it('uses background:none for transparent in static mode', async () => {
+      const svg = await renderMermaid('graph TD\n  A --> B', {
+        output: 'static', transparent: true,
+      })
+      assertStaticSvg(svg)
+      expect(svg).toContain('background:none')
+    })
+
+    it('preserves inline style overrides in static mode', async () => {
+      const svg = await renderMermaid(`graph TD
+        A[Red Node] --> B
+        style A fill:#ff0000,stroke:#cc0000`, { output: 'static' })
+      assertStaticSvg(svg)
+      expect(svg).toContain('fill="#ff0000"')
+      expect(svg).toContain('stroke="#cc0000"')
+    })
+  })
+
+  describe('sequence diagram', () => {
+    it('produces static SVG', async () => {
+      const svg = await renderMermaid(`sequenceDiagram
+        Alice->>Bob: Hello
+        Bob-->>Alice: Hi`, { output: 'static' })
+      assertStaticSvg(svg)
+      expect(svg).toContain('>Alice</text>')
+      expect(svg).toContain('>Bob</text>')
+      expect(svg).toContain('>Hello</text>')
+    })
+  })
+
+  describe('class diagram', () => {
+    it('produces static SVG', async () => {
+      const svg = await renderMermaid(`classDiagram
+        class Animal {
+          +String name
+          +eat()
+        }
+        class Dog {
+          +bark()
+        }
+        Animal <|-- Dog`, { output: 'static' })
+      assertStaticSvg(svg)
+      expect(svg).toContain('>Animal</text>')
+      expect(svg).toContain('>Dog</text>')
+    })
+  })
+
+  describe('ER diagram', () => {
+    it('produces static SVG', async () => {
+      const svg = await renderMermaid(`erDiagram
+        CUSTOMER ||--o{ ORDER : places
+        ORDER ||--|{ LINE-ITEM : contains`, { output: 'static' })
+      assertStaticSvg(svg)
+      expect(svg).toContain('>CUSTOMER</text>')
+      expect(svg).toContain('>ORDER</text>')
+    })
+  })
+})
+
+// ============================================================================
+// Pre-resolved palettes (resolvedColors option)
+// ============================================================================
+
+describe('renderMermaid – resolvedColors option', () => {
+  it('accepts pre-resolved palette (skips resolveColors)', async () => {
+    const palette = resolveColors({ bg: '#1a1b26', fg: '#a9b1d6' })
+    const svg = await renderMermaid('graph TD\n  A --> B', { resolvedColors: palette })
+    assertStaticSvg(svg)
+    expect(svg).toContain('>A</text>')
+  })
+
+  it('produces same output as output: static with same colors', async () => {
+    const colors = { bg: '#1a1b26', fg: '#a9b1d6' }
+    const palette = resolveColors(colors)
+    const svg1 = await renderMermaid('graph TD\n  A --> B', { ...colors, output: 'static', markerId: false })
+    const svg2 = await renderMermaid('graph TD\n  A --> B', { resolvedColors: palette, markerId: false })
+    expect(svg1).toBe(svg2)
+  })
+})
+
+// ============================================================================
+// noStyleBlock option
+// ============================================================================
+
+describe('renderMermaid – noStyleBlock option', () => {
+  it('omits style block when noStyleBlock is true', async () => {
+    const svg = await renderMermaid('graph TD\n  A --> B', {
+      output: 'static', noStyleBlock: true,
+    })
+    assertStaticSvg(svg)
+    expect(svg).not.toContain('<style>')
+    expect(svg).not.toContain('</style>')
+  })
+
+  it('includes style block by default in static mode', async () => {
+    const svg = await renderMermaid('graph TD\n  A --> B', { output: 'static' })
+    assertStaticSvg(svg)
+    expect(svg).toContain('<style>')
+  })
+
+  it('SVG root has font-family when noStyleBlock is true', async () => {
+    const svg = await renderMermaid('graph TD\n  A --> B', {
+      output: 'static', noStyleBlock: true, font: 'Inter',
+    })
+    assertStaticSvg(svg)
+    expect(svg).toMatch(/style="[^"]*font-family:'Inter',system-ui,sans-serif/)
+  })
+
+  it('SVG root omits font-family when noStyleBlock is false', async () => {
+    const svg = await renderMermaid('graph TD\n  A --> B', {
+      output: 'static', noStyleBlock: false, font: 'Inter',
+    })
+    expect(svg).not.toMatch(/style="[^"]*font-family:'Inter'/)
+  })
+
+  it('class diagram .mono text has inline font-family when noStyleBlock is true', async () => {
+    const svg = await renderMermaid(`classDiagram
+      class Foo {
+        +String bar
+      }`, { output: 'static', noStyleBlock: true })
+    assertStaticSvg(svg)
+    expect(svg).toContain('font-family="\'JetBrains Mono\'')
+  })
+
+  it('SVG root has font-family when both noStyleBlock and transparent are true', async () => {
+    const svg = await renderMermaid('graph TD\n  A --> B', {
+      output: 'static', noStyleBlock: true, transparent: true, font: 'Inter',
+    })
+    assertStaticSvg(svg)
+    expect(svg).not.toContain('<style>')
+    expect(svg).toContain('background:none')
+    expect(svg).toMatch(/style="[^"]*font-family:'Inter',system-ui,sans-serif/)
+  })
+})
+
+// ============================================================================
+// Marker ID namespacing
+// ============================================================================
+
+describe('renderMermaid – marker ID namespacing', () => {
+  it('uses namespaced marker IDs in dynamic mode by default', async () => {
+    const svg = await renderMermaid('graph TD\n  A --> B')
+    // Should have a namespaced marker ID (m + 4 hex chars + -)
+    expect(svg).toMatch(/id="m[0-9a-f]{4}-arrowhead"/)
+  })
+
+  it('uses bare marker IDs when markerId is false', async () => {
+    const svg = await renderMermaid('graph TD\n  A --> B', { markerId: false })
+    expect(svg).toContain('id="arrowhead"')
+  })
+
+  it('uses custom marker ID prefix', async () => {
+    const svg = await renderMermaid('graph TD\n  A --> B', { markerId: 'diag1' })
+    expect(svg).toContain('id="diag1-arrowhead"')
+    expect(svg).toContain('url(#diag1-arrowhead)')
+  })
+
+  it('uses bare IDs in static mode (no collision risk)', async () => {
+    const svg = await renderMermaid('graph TD\n  A --> B', { output: 'static' })
+    expect(svg).toContain('id="arrowhead"')
+  })
+})
+
+// ============================================================================
+// normalizeInlineStyles - integration tests via renderMermaid
+// ============================================================================
+
+describe('renderMermaid – inline style normalization', () => {
+  it('passes hex values through unchanged in static mode', async () => {
+    const svg = await renderMermaid(`graph TD
+      A --> B
+      style A fill:#aabbcc`, { output: 'static' })
+    assertStaticSvg(svg)
+    expect(svg).toContain('fill="#aabbcc"')
+  })
+
+  it('passes 8-digit hex values through in static mode', async () => {
+    const svg = await renderMermaid(`graph TD
+      A --> B
+      style A fill:#aabbcc80`, { output: 'static' })
+    assertStaticSvg(svg)
+    expect(svg).toContain('fill="#aabbcc80"')
+  })
+
+  it('drops non-hex style values in static mode (falls back to default)', async () => {
+    // Named colors get split by the parser as key:value, so 'fill:red' would be
+    // parsed as fill=red. normalizeInlineStyles should drop it (not a hex value).
+    const svg = await renderMermaid(`graph TD
+      A --> B
+      style A fill:red`, { output: 'static' })
+    assertStaticSvg(svg)
+    // 'red' is not hex, so normalizer drops it → falls back to theme default
+    expect(svg).not.toContain('fill="red"')
+  })
+})
+
+// ============================================================================
+// Backward compatibility: output: 'dynamic' (default) still uses vars
+// ============================================================================
+
+describe('renderMermaid – output: dynamic (default)', () => {
+  it('uses CSS variables by default', async () => {
+    const svg = await renderMermaid('graph TD\n  A --> B')
+    expect(svg).toContain('var(--')
+    expect(svg).toContain('@import')
+    expect(svg).toContain('color-mix(')
+  })
+
+  it('uses CSS variables when explicitly set to dynamic', async () => {
+    const svg = await renderMermaid('graph TD\n  A --> B', { output: 'dynamic' })
+    expect(svg).toContain('var(--')
+  })
+})

--- a/src/sequence/renderer.ts
+++ b/src/sequence/renderer.ts
@@ -1,6 +1,6 @@
 import type { PositionedSequenceDiagram, PositionedActor, Lifeline, PositionedMessage, Activation, PositionedBlock, PositionedNote } from './types.ts'
-import type { DiagramColors } from '../theme.ts'
-import { svgOpenTag, buildStyleBlock } from '../theme.ts'
+import type { DiagramColors, ResolvedColors } from '../theme.ts'
+import { svgOpenTag, buildStyleBlock, svgOpenTagStatic, buildStaticStyleBlock, createColorFn } from '../theme.ts'
 import { FONT_SIZES, FONT_WEIGHTS, STROKE_WIDTHS, ARROW_HEAD, estimateTextWidth, TEXT_BASELINE_SHIFT } from '../styles.ts'
 
 // ============================================================================
@@ -24,51 +24,64 @@ import { FONT_SIZES, FONT_WEIGHTS, STROKE_WIDTHS, ARROW_HEAD, estimateTextWidth,
  * @param colors - DiagramColors with bg/fg and optional enrichment variables.
  * @param transparent - If true, renders with transparent background.
  */
+/** Color accessor function type */
+type ColorFn = ReturnType<typeof createColorFn>
+
 export function renderSequenceSvg(
   diagram: PositionedSequenceDiagram,
   colors: DiagramColors,
   font: string = 'Inter',
-  transparent: boolean = false
+  transparent: boolean = false,
+  resolved: ResolvedColors | null = null,
+  noStyleBlock: boolean = false,
+  markerId: string = ''
 ): string {
   const parts: string[] = []
+  const c = createColorFn(resolved)
+  const mid = markerId ? `${markerId}-` : ''
 
   // SVG root with CSS variables + style block + defs
-  parts.push(svgOpenTag(diagram.width, diagram.height, colors, transparent))
-  parts.push(buildStyleBlock(font, false))
+  if (resolved) {
+    parts.push(svgOpenTagStatic(diagram.width, diagram.height, resolved.bg, transparent, font, noStyleBlock))
+    parts.push(buildStaticStyleBlock(font, false, noStyleBlock))
+  } else {
+    parts.push(svgOpenTag(diagram.width, diagram.height, colors, transparent))
+    parts.push(buildStyleBlock(font, false))
+  }
   parts.push('<defs>')
 
   // Arrow marker definitions
-  parts.push(arrowMarkerDefs())
+  parts.push(arrowMarkerDefs(c, mid))
   parts.push('</defs>')
 
   // 1. Block backgrounds (loop/alt/opt rectangles)
   for (const block of diagram.blocks) {
-    parts.push(renderBlock(block))
+    parts.push(renderBlock(block, c))
   }
 
   // 2. Lifelines (dashed vertical lines from actor to bottom)
   for (const lifeline of diagram.lifelines) {
-    parts.push(renderLifeline(lifeline))
+    parts.push(renderLifeline(lifeline, c))
   }
 
   // 3. Activation boxes
   for (const activation of diagram.activations) {
-    parts.push(renderActivation(activation))
+    parts.push(renderActivation(activation, c))
   }
 
   // 4. Messages (horizontal arrows with labels)
   for (const message of diagram.messages) {
-    parts.push(renderMessage(message))
+    parts.push(renderMessage(message, c, mid))
   }
 
   // 5. Notes
   for (const note of diagram.notes) {
-    parts.push(renderNote(note))
+    parts.push(renderNote(note, c))
   }
 
   // 6. Actor boxes at top (rendered last so they're on top)
   for (const actor of diagram.actors) {
-    parts.push(renderActor(actor))
+    parts.push(renderActor(actor, c))
   }
 
   parts.push('</svg>')
@@ -79,16 +92,16 @@ export function renderSequenceSvg(
 // Arrow marker definitions
 // ============================================================================
 
-function arrowMarkerDefs(): string {
+function arrowMarkerDefs(c: ColorFn, mid: string): string {
   const w = ARROW_HEAD.width
   const h = ARROW_HEAD.height
   return (
-    `  <marker id="seq-arrow" markerWidth="${w}" markerHeight="${h}" refX="${w}" refY="${h / 2}" orient="auto-start-reverse">` +
-    `\n    <polygon points="0 0, ${w} ${h / 2}, 0 ${h}" fill="var(--_arrow)" />` +
+    `  <marker id="${mid}seq-arrow" markerWidth="${w}" markerHeight="${h}" refX="${w}" refY="${h / 2}" orient="auto-start-reverse">` +
+    `\n    <polygon points="0 0, ${w} ${h / 2}, 0 ${h}" fill="${c('_arrow')}" />` +
     `\n  </marker>` +
     // Open arrow head (just lines, no fill)
-    `\n  <marker id="seq-arrow-open" markerWidth="${w}" markerHeight="${h}" refX="${w}" refY="${h / 2}" orient="auto-start-reverse">` +
-    `\n    <polyline points="0 0, ${w} ${h / 2}, 0 ${h}" fill="none" stroke="var(--_arrow)" stroke-width="1" />` +
+    `\n  <marker id="${mid}seq-arrow-open" markerWidth="${w}" markerHeight="${h}" refX="${w}" refY="${h / 2}" orient="auto-start-reverse">` +
+    `\n    <polyline points="0 0, ${w} ${h / 2}, 0 ${h}" fill="none" stroke="${c('_arrow')}" stroke-width="1" />` +
     `\n  </marker>`
   )
 }
@@ -98,31 +111,23 @@ function arrowMarkerDefs(): string {
 // ============================================================================
 
 /** Render an actor box (participant = rectangle, actor = stick figure) */
-function renderActor(actor: PositionedActor): string {
+function renderActor(actor: PositionedActor, c: ColorFn): string {
   const { x, y, width, height, label, type } = actor
 
   if (type === 'actor') {
-    // Circle-person icon: outer circle + head circle + shoulders arc.
-    // Defined in a 24×24 coordinate space, scaled to 90% of the actor box height
-    // and centered both horizontally and vertically within the box.
-    // Stroke width is inverse-scaled so the visual thickness matches STROKE_WIDTHS.outerBox.
     const s = (height / 24) * 0.9
-    const tx = x - 12 * s            // center icon horizontally on actor.x
-    const ty = y + (height - 24 * s) / 2  // center icon vertically in actor box
-    const sw = STROKE_WIDTHS.outerBox / s  // compensate for scale transform
-    const iconStroke = 'var(--_line)'      // use line color for actor icon strokes
+    const tx = x - 12 * s
+    const ty = y + (height - 24 * s) / 2
+    const sw = STROKE_WIDTHS.outerBox / s
+    const iconStroke = c('_line')
 
     return (
       `<g transform="translate(${tx},${ty}) scale(${s})">` +
-      // Outer circle
       `\n  <path d="M21 12C21 16.9706 16.9706 21 12 21C7.02944 21 3 16.9706 3 12C3 7.02944 7.02944 3 12 3C16.9706 3 21 7.02944 21 12Z" fill="none" stroke="${iconStroke}" stroke-width="${sw}" />` +
-      // Head
       `\n  <path d="M15 10C15 11.6569 13.6569 13 12 13C10.3431 13 9 11.6569 9 10C9 8.34315 10.3431 7 12 7C13.6569 7 15 8.34315 15 10Z" fill="none" stroke="${iconStroke}" stroke-width="${sw}" />` +
-      // Shoulders
       `\n  <path d="M5.62842 18.3563C7.08963 17.0398 9.39997 16 12 16C14.6 16 16.9104 17.0398 18.3716 18.3563" fill="none" stroke="${iconStroke}" stroke-width="${sw}" />` +
       `\n</g>` +
-      // Label below the icon
-      `\n<text x="${x}" y="${y + height + 14}" text-anchor="middle" font-size="${FONT_SIZES.nodeLabel}" font-weight="${FONT_WEIGHTS.nodeLabel}" fill="var(--_text)">${escapeXml(label)}</text>`
+      `\n<text x="${x}" y="${y + height + 14}" text-anchor="middle" font-size="${FONT_SIZES.nodeLabel}" font-weight="${FONT_WEIGHTS.nodeLabel}" fill="${c('_text')}">${escapeXml(label)}</text>`
     )
   }
 
@@ -130,33 +135,33 @@ function renderActor(actor: PositionedActor): string {
   const boxX = x - width / 2
   return (
     `<rect x="${boxX}" y="${y}" width="${width}" height="${height}" rx="4" ry="4" ` +
-    `fill="var(--_node-fill)" stroke="var(--_node-stroke)" stroke-width="${STROKE_WIDTHS.outerBox}" />` +
+    `fill="${c('_node-fill')}" stroke="${c('_node-stroke')}" stroke-width="${STROKE_WIDTHS.outerBox}" />` +
     `\n<text x="${x}" y="${y + height / 2}" text-anchor="middle" dy="${TEXT_BASELINE_SHIFT}" ` +
-    `font-size="${FONT_SIZES.nodeLabel}" font-weight="${FONT_WEIGHTS.nodeLabel}" fill="var(--_text)">${escapeXml(label)}</text>`
+    `font-size="${FONT_SIZES.nodeLabel}" font-weight="${FONT_WEIGHTS.nodeLabel}" fill="${c('_text')}">${escapeXml(label)}</text>`
   )
 }
 
 /** Render a lifeline (dashed vertical line from actor to bottom) */
-function renderLifeline(lifeline: Lifeline): string {
+function renderLifeline(lifeline: Lifeline, c: ColorFn): string {
   return (
     `<line x1="${lifeline.x}" y1="${lifeline.topY}" x2="${lifeline.x}" y2="${lifeline.bottomY}" ` +
-    `stroke="var(--_line)" stroke-width="0.75" stroke-dasharray="6 4" />`
+    `stroke="${c('_line')}" stroke-width="0.75" stroke-dasharray="6 4" />`
   )
 }
 
 /** Render an activation box (narrow filled rectangle on lifeline) */
-function renderActivation(activation: Activation): string {
+function renderActivation(activation: Activation, c: ColorFn): string {
   return (
     `<rect x="${activation.x}" y="${activation.topY}" width="${activation.width}" height="${activation.bottomY - activation.topY}" ` +
-    `fill="var(--_node-fill)" stroke="var(--_node-stroke)" stroke-width="${STROKE_WIDTHS.innerBox}" />`
+    `fill="${c('_node-fill')}" stroke="${c('_node-stroke')}" stroke-width="${STROKE_WIDTHS.innerBox}" />`
   )
 }
 
 /** Render a message arrow with label */
-function renderMessage(msg: PositionedMessage): string {
+function renderMessage(msg: PositionedMessage, c: ColorFn, mid: string): string {
   const parts: string[] = []
   const dashArray = msg.lineStyle === 'dashed' ? ' stroke-dasharray="6 4"' : ''
-  const markerId = msg.arrowHead === 'filled' ? 'seq-arrow' : 'seq-arrow-open'
+  const markerDefId = msg.arrowHead === 'filled' ? `${mid}seq-arrow` : `${mid}seq-arrow-open`
 
   if (msg.isSelf) {
     // Self-message: curved loop going right and back
@@ -164,24 +169,24 @@ function renderMessage(msg: PositionedMessage): string {
     const loopH = 20
     parts.push(
       `<polyline points="${msg.x1},${msg.y} ${msg.x1 + loopW},${msg.y} ${msg.x1 + loopW},${msg.y + loopH} ${msg.x2},${msg.y + loopH}" ` +
-      `fill="none" stroke="var(--_line)" stroke-width="${STROKE_WIDTHS.connector}"${dashArray} marker-end="url(#${markerId})" />`
+      `fill="none" stroke="${c('_line')}" stroke-width="${STROKE_WIDTHS.connector}"${dashArray} marker-end="url(#${markerDefId})" />`
     )
     // Label to the right of the loop
     parts.push(
       `<text x="${msg.x1 + loopW + 6}" y="${msg.y + loopH / 2}" dy="${TEXT_BASELINE_SHIFT}" ` +
-      `font-size="${FONT_SIZES.edgeLabel}" font-weight="${FONT_WEIGHTS.edgeLabel}" fill="var(--_text-muted)">${escapeXml(msg.label)}</text>`
+      `font-size="${FONT_SIZES.edgeLabel}" font-weight="${FONT_WEIGHTS.edgeLabel}" fill="${c('_text-muted')}">${escapeXml(msg.label)}</text>`
     )
   } else {
     // Normal message: horizontal arrow
     parts.push(
       `<line x1="${msg.x1}" y1="${msg.y}" x2="${msg.x2}" y2="${msg.y}" ` +
-      `stroke="var(--_line)" stroke-width="${STROKE_WIDTHS.connector}"${dashArray} marker-end="url(#${markerId})" />`
+      `stroke="${c('_line')}" stroke-width="${STROKE_WIDTHS.connector}"${dashArray} marker-end="url(#${markerDefId})" />`
     )
     // Label above the arrow, centered
     const midX = (msg.x1 + msg.x2) / 2
     parts.push(
       `<text x="${midX}" y="${msg.y - 6}" text-anchor="middle" ` +
-      `font-size="${FONT_SIZES.edgeLabel}" font-weight="${FONT_WEIGHTS.edgeLabel}" fill="var(--_text-muted)">${escapeXml(msg.label)}</text>`
+      `font-size="${FONT_SIZES.edgeLabel}" font-weight="${FONT_WEIGHTS.edgeLabel}" fill="${c('_text-muted')}">${escapeXml(msg.label)}</text>`
     )
   }
 
@@ -189,13 +194,13 @@ function renderMessage(msg: PositionedMessage): string {
 }
 
 /** Render a block background (loop/alt/opt) */
-function renderBlock(block: PositionedBlock): string {
+function renderBlock(block: PositionedBlock, c: ColorFn): string {
   const parts: string[] = []
 
   // Outer rectangle
   parts.push(
     `<rect x="${block.x}" y="${block.y}" width="${block.width}" height="${block.height}" ` +
-    `rx="0" ry="0" fill="none" stroke="var(--_node-stroke)" stroke-width="${STROKE_WIDTHS.outerBox}" />`
+    `rx="0" ry="0" fill="none" stroke="${c('_node-stroke')}" stroke-width="${STROKE_WIDTHS.outerBox}" />`
   )
 
   // Type label tab (top-left corner)
@@ -205,23 +210,23 @@ function renderBlock(block: PositionedBlock): string {
 
   parts.push(
     `<rect x="${block.x}" y="${block.y}" width="${tabWidth}" height="${tabHeight}" ` +
-    `fill="var(--_group-hdr)" stroke="var(--_node-stroke)" stroke-width="${STROKE_WIDTHS.outerBox}" />`
+    `fill="${c('_group-hdr')}" stroke="${c('_node-stroke')}" stroke-width="${STROKE_WIDTHS.outerBox}" />`
   )
   parts.push(
     `<text x="${block.x + 6}" y="${block.y + tabHeight / 2}" dy="${TEXT_BASELINE_SHIFT}" ` +
-    `font-size="${FONT_SIZES.edgeLabel}" font-weight="${FONT_WEIGHTS.groupHeader}" fill="var(--_text-sec)">${escapeXml(labelText)}</text>`
+    `font-size="${FONT_SIZES.edgeLabel}" font-weight="${FONT_WEIGHTS.groupHeader}" fill="${c('_text-sec')}">${escapeXml(labelText)}</text>`
   )
 
   // Divider lines (for alt/else, par/and)
   for (const divider of block.dividers) {
     parts.push(
       `<line x1="${block.x}" y1="${divider.y}" x2="${block.x + block.width}" y2="${divider.y}" ` +
-      `stroke="var(--_line)" stroke-width="0.75" stroke-dasharray="6 4" />`
+      `stroke="${c('_line')}" stroke-width="0.75" stroke-dasharray="6 4" />`
     )
     if (divider.label) {
       parts.push(
         `<text x="${block.x + 8}" y="${divider.y + 14}" font-size="${FONT_SIZES.edgeLabel}" ` +
-        `font-weight="${FONT_WEIGHTS.edgeLabel}" fill="var(--_text-muted)">[${escapeXml(divider.label)}]</text>`
+        `font-weight="${FONT_WEIGHTS.edgeLabel}" fill="${c('_text-muted')}">[${escapeXml(divider.label)}]</text>`
       )
     }
   }
@@ -230,18 +235,18 @@ function renderBlock(block: PositionedBlock): string {
 }
 
 /** Render a note box */
-function renderNote(note: PositionedNote): string {
+function renderNote(note: PositionedNote, c: ColorFn): string {
   // Folded corner effect: note rectangle + small triangle in top-right
   const foldSize = 6
   return (
     `<rect x="${note.x}" y="${note.y}" width="${note.width}" height="${note.height}" ` +
-    `fill="var(--_group-hdr)" stroke="var(--_node-stroke)" stroke-width="${STROKE_WIDTHS.innerBox}" />` +
+    `fill="${c('_group-hdr')}" stroke="${c('_node-stroke')}" stroke-width="${STROKE_WIDTHS.innerBox}" />` +
     // Fold triangle
     `\n<polygon points="${note.x + note.width - foldSize},${note.y} ${note.x + note.width},${note.y + foldSize} ${note.x + note.width - foldSize},${note.y + foldSize}" ` +
-    `fill="var(--_inner-stroke)" />` +
+    `fill="${c('_inner-stroke')}" />` +
     // Note text
     `\n<text x="${note.x + note.width / 2}" y="${note.y + note.height / 2}" text-anchor="middle" dy="${TEXT_BASELINE_SHIFT}" ` +
-    `font-size="${FONT_SIZES.edgeLabel}" font-weight="${FONT_WEIGHTS.edgeLabel}" fill="var(--_text-muted)">${escapeXml(note.text)}</text>`
+    `font-size="${FONT_SIZES.edgeLabel}" font-weight="${FONT_WEIGHTS.edgeLabel}" fill="${c('_text-muted')}">${escapeXml(note.text)}</text>`
   )
 }
 

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -218,6 +218,323 @@ export function fromShikiTheme(theme: ShikiThemeLike): DiagramColors {
 }
 
 // ============================================================================
+// Static color resolution - for PDF/print output where CSS vars don't work
+//
+// When output is 'static', all var(--_xxx) references are replaced with
+// literal hex colors. This produces SVG that renders correctly in PDF engines,
+// Inkscape, and other static renderers that don't evaluate CSS custom properties.
+// ============================================================================
+
+/** Parsed RGBA color (alpha is optional - absent means fully opaque) */
+export interface RGBA { r: number; g: number; b: number; a?: number }
+
+/**
+ * Parse a hex color string (#RGB, #RRGGBB, or #RRGGBBAA) to RGBA.
+ * Throws on invalid hex lengths (e.g. #RGBBA, #RRGGB, empty).
+ */
+export function parseHex(hex: string): RGBA {
+  let h = hex.replace(/^#/, '')
+  // Expand shorthand (#RGB → #RRGGBB)
+  if (h.length === 3) h = h[0]! + h[0]! + h[1]! + h[1]! + h[2]! + h[2]!
+  if (h.length !== 6 && h.length !== 8) {
+    throw new Error(
+      `Invalid hex color: '${hex}'. Expected #RGB (3), #RRGGBB (6), or #RRGGBBAA (8) hex digits.`
+    )
+  }
+  const result: RGBA = {
+    r: parseInt(h.slice(0, 2), 16),
+    g: parseInt(h.slice(2, 4), 16),
+    b: parseInt(h.slice(4, 6), 16),
+  }
+  // Preserve alpha channel from #RRGGBBAA, clamped to 0–255
+  if (h.length === 8) {
+    result.a = Math.max(0, Math.min(255, parseInt(h.slice(6, 8), 16)))
+  }
+  return result
+}
+
+/** Convert RGBA to hex string. Emits #RRGGBBAA when alpha is present and not 255, otherwise #RRGGBB. */
+export function toHex(rgba: RGBA): string {
+  const c = (n: number) => Math.round(Math.max(0, Math.min(255, n))).toString(16).padStart(2, '0')
+  const hex = `#${c(rgba.r)}${c(rgba.g)}${c(rgba.b)}`
+  if (rgba.a !== undefined && rgba.a !== 255) {
+    return `${hex}${c(rgba.a)}`
+  }
+  return hex
+}
+
+/**
+ * Linear interpolation of two hex colors in sRGB space.
+ * Equivalent to `color-mix(in srgb, fg pct%, bg)`.
+ *
+ * Performs component-wise linear interpolation in sRGB space (straight alpha,
+ * not premultiplied). Each channel is interpolated independently:
+ *   result.c = bg.c + t * (fg.c - bg.c)
+ * Alpha, when present on either input, is interpolated the same way and
+ * clamped to 0–255. Missing alpha defaults to 255 (fully opaque).
+ *
+ * Note on precision: rounds to the nearest integer per channel. The CSS
+ * color-mix(in srgb) spec uses the same model, but browser implementations
+ * may round differently at integer boundaries (±1). Visually imperceptible.
+ *
+ * @param fg - Foreground color (hex)
+ * @param bg - Background color (hex)
+ * @param pct - Percentage of fg (0–100)
+ * @returns Blended hex color
+ */
+export function colorMix(fg: string, bg: string, pct: number): string {
+  const f = parseHex(fg)
+  const b = parseHex(bg)
+  const t = pct / 100
+  const result: RGBA = {
+    r: b.r + t * (f.r - b.r),
+    g: b.g + t * (f.g - b.g),
+    b: b.b + t * (f.b - b.b),
+  }
+  // Interpolate alpha when either input has an explicit alpha channel
+  if (f.a !== undefined || b.a !== undefined) {
+    const fa = f.a ?? 255
+    const ba = b.a ?? 255
+    result.a = Math.max(0, Math.min(255, ba + t * (fa - ba)))
+  }
+  return toHex(result)
+}
+
+/**
+ * Hex color pattern: matches #RGB, #RRGGBB, or #RRGGBBAA.
+ * Single source of truth - used by both validateHexColor() and
+ * normalizeInlineStyles() to keep validation and normalization aligned.
+ */
+export const HEX_RE = /^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/
+
+/**
+ * Validate that a color string is a hex value.
+ * Throws if the value is rgb(), hsl(), a named color, var(), or any other non-hex format.
+ */
+export function validateHexColor(value: string, label: string): void {
+  if (!HEX_RE.test(value)) {
+    throw new Error(
+      `Invalid color for '${label}': '${value}'. ` +
+      `Only hex colors (#RGB, #RRGGBB, #RRGGBBAA) are supported. ` +
+      `Got a non-hex value - convert to hex before passing.`
+    )
+  }
+}
+
+// ============================================================================
+// Color derivation graph - single source of truth
+//
+// Each entry maps a CSS variable name to its derivation rule. Both the CSS
+// style block (buildStyleBlock) and the JS resolver (resolveColors) are
+// driven from this graph, eliminating drift between the two code paths.
+//
+// Rule types:
+//   'fg'       → uses --fg directly
+//   'bg'       → uses --bg directly
+//   'override' → uses an optional enrichment var with mix fallback
+//   'mix'      → always mixes fg into bg at the given percentage
+// ============================================================================
+
+interface DeriveRule {
+  /** CSS variable name without leading -- (e.g. '_text') */
+  cssVar: string
+  /** Which MIX constant to use for the color-mix fallback */
+  mixKey: keyof typeof MIX | null
+  /** Which optional DiagramColors key overrides the mix (null = no override) */
+  override: keyof DiagramColors | null
+  /** Special source: 'fg' = use fg directly, 'bg' = use bg directly, null = standard mix */
+  source: 'fg' | 'bg' | null
+}
+
+/**
+ * Derivation graph for all internal CSS color variables.
+ * Drives both CSS generation and JS-side static resolution.
+ */
+export const COLOR_GRAPH: readonly DeriveRule[] = [
+  { cssVar: '_text',         mixKey: 'text',        override: null,      source: 'fg' },
+  { cssVar: '_text-sec',     mixKey: 'textSec',     override: 'muted',   source: null },
+  { cssVar: '_text-muted',   mixKey: 'textMuted',   override: 'muted',   source: null },
+  { cssVar: '_text-faint',   mixKey: 'textFaint',   override: null,      source: null },
+  { cssVar: '_line',         mixKey: 'line',         override: 'line',    source: null },
+  { cssVar: '_arrow',        mixKey: 'arrow',        override: 'accent',  source: null },
+  { cssVar: '_node-fill',    mixKey: 'nodeFill',     override: 'surface', source: null },
+  { cssVar: '_node-stroke',  mixKey: 'nodeStroke',   override: 'border',  source: null },
+  { cssVar: '_group-fill',   mixKey: null,           override: null,      source: 'bg' },
+  { cssVar: '_group-hdr',    mixKey: 'groupHeader',  override: null,      source: null },
+  { cssVar: '_inner-stroke', mixKey: 'innerStroke',  override: null,      source: null },
+  { cssVar: '_key-badge',    mixKey: 'keyBadge',     override: null,      source: null },
+] as const
+
+/** All 14 derived color values resolved to literal hex strings */
+export interface ResolvedColors {
+  bg: string
+  _text: string
+  '_text-sec': string
+  '_text-muted': string
+  '_text-faint': string
+  _line: string
+  _arrow: string
+  '_node-fill': string
+  '_node-stroke': string
+  '_group-fill': string
+  '_group-hdr': string
+  '_inner-stroke': string
+  '_key-badge': string
+}
+
+/**
+ * Resolve the full color cascade from DiagramColors to literal hex values.
+ *
+ * Driven by COLOR_GRAPH - the same derivation rules that generate CSS
+ * variable declarations in buildStyleBlock(). This guarantees that static
+ * (hex) output matches what the CSS path would produce in a browser.
+ *
+ * Input colors must be hex (#RGB, #RRGGBB, or #RRGGBBAA). Non-hex values
+ * (rgb(), hsl(), named colors, var()) will throw.
+ *
+ * Note on precision: colorMix() uses linear sRGB interpolation, which may
+ * differ from the CSS color-mix(in srgb) result by ±1 in any channel due
+ * to rounding at integer boundaries. This is visually imperceptible.
+ */
+export function resolveColors(colors: DiagramColors): ResolvedColors {
+  const { bg, fg } = colors
+  validateHexColor(bg, 'bg')
+  validateHexColor(fg, 'fg')
+
+  const result: Record<string, string> = { bg }
+
+  for (const rule of COLOR_GRAPH) {
+    let value: string
+    if (rule.source === 'fg') {
+      value = fg
+    } else if (rule.source === 'bg') {
+      value = bg
+    } else {
+      const overrideValue = rule.override ? colors[rule.override] : undefined
+      if (overrideValue) {
+        validateHexColor(overrideValue, rule.override!)
+        value = overrideValue
+      } else {
+        value = colorMix(fg, bg, MIX[rule.mixKey!])
+      }
+    }
+    result[rule.cssVar] = value
+  }
+
+  return result as unknown as ResolvedColors
+}
+
+/**
+ * Build a minimal <style> block with only font-family rules.
+ * No CSS variables, no @import, no color-mix() - safe for static SVG.
+ *
+ * Returns empty string when `noStyleBlock` is true - for environments
+ * (email clients, some PDF renderers) that strip `<style>` entirely.
+ * In that case, font-family attributes should be inlined on text elements.
+ */
+export function buildStaticStyleBlock(font: string, hasMonoFont: boolean, noStyleBlock?: boolean): string {
+  if (noStyleBlock) return ''
+  return [
+    '<style>',
+    `  text { font-family: '${font}', system-ui, sans-serif; }`,
+    ...(hasMonoFont ? [`  .mono { font-family: 'JetBrains Mono', 'SF Mono', 'Fira Code', ui-monospace, monospace; }`] : []),
+    '</style>',
+  ].join('\n')
+}
+
+/**
+ * Build the SVG opening tag with literal background color.
+ * No CSS custom properties - safe for static SVG.
+ *
+ * When transparent is true, uses explicit `background:none` rather than
+ * omitting the property, ensuring renderers that assume a default opaque
+ * background still get transparent output. (Dynamic mode omits the
+ * background style entirely for transparency.)
+ *
+ * When noStyleBlock is true and font is provided, inlines `font-family`
+ * on the SVG root `style` attribute, since there is no `<style>` block
+ * to set it.
+ */
+export function svgOpenTagStatic(
+  width: number,
+  height: number,
+  bg: string,
+  transparent?: boolean,
+  font?: string,
+  noStyleBlock?: boolean,
+): string {
+  const bgStyle = transparent ? 'background:none' : `background:${bg}`
+  let fontStyle = ''
+  if (noStyleBlock && font) {
+    // Escape single quotes in font name to prevent malformed SVG attribute values
+    const safeFont = font.replace(/'/g, '&#39;')
+    fontStyle = `;font-family:'${safeFont}',system-ui,sans-serif`
+  }
+  return (
+    `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${width} ${height}" ` +
+    `width="${width}" height="${height}" style="${bgStyle}${fontStyle}">`
+  )
+}
+
+/** Keys accepted by the color accessor function */
+export type ColorKey = keyof Omit<ResolvedColors, 'bg'>
+
+// Compile-time assertion: every COLOR_GRAPH entry must map to a valid ColorKey or 'bg'.
+// If a new entry is added to COLOR_GRAPH without a matching ResolvedColors field,
+// this will produce a type error.
+type _AssertColorGraphKeys = {
+  [K in (typeof COLOR_GRAPH)[number]['cssVar']]: K extends ColorKey ? true : K extends never ? never : true
+}
+
+// Reverse assertion: every ResolvedColors key (except bg) must have a COLOR_GRAPH entry.
+// Catches adding a field to ResolvedColors without a matching COLOR_GRAPH rule.
+type _AssertResolvedColorsHasGraph = {
+  [K in Exclude<keyof ResolvedColors, 'bg'>]: K extends (typeof COLOR_GRAPH)[number]['cssVar'] ? true : never
+}
+
+/**
+ * Create a color accessor function.
+ *
+ * When `resolved` is null (CSS mode), returns `var(--_key)` strings.
+ * When `resolved` is provided (static mode), returns literal hex values.
+ *
+ * Also provides a `bg()` method for the background color, which uses
+ * `var(--bg)` in CSS mode and the literal color in static mode.
+ */
+export function createColorFn(resolved: ResolvedColors | null): {
+  (key: ColorKey): string
+  bg: () => string
+} {
+  const fn = ((key: ColorKey) => {
+    if (resolved) return resolved[key]
+    return `var(--${key})`
+  }) as { (key: ColorKey): string; bg: () => string }
+  fn.bg = () => resolved ? resolved.bg : 'var(--bg)'
+  return fn
+}
+
+/**
+ * Generate a unique marker ID prefix for multi-SVG isolation.
+ * When multiple SVGs share a DOM, marker IDs can collide. This generates
+ * a short random suffix to namespace all marker definitions.
+ *
+ * @param length - Number of hex characters (must be >= 1). Default: 4.
+ * @throws If length is less than 1.
+ */
+export function generateMarkerId(length: number = 4): string {
+  if (length < 1) {
+    throw new Error(`generateMarkerId: length must be >= 1, got ${length}`)
+  }
+  // Build hex string from one or more Math.random() calls to guarantee
+  // full requested entropy even when a single call yields fewer digits.
+  let hex = ''
+  while (hex.length < length) {
+    hex += Math.random().toString(16).slice(2)
+  }
+  return `m${hex.slice(0, length)}`
+}
+
+// ============================================================================
 // SVG style block — the CSS variable derivation system
 //
 // Generates the <style> content that maps user-facing variables (--bg, --fg,
@@ -227,6 +544,9 @@ export function fromShikiTheme(theme: ShikiThemeLike): DiagramColors {
 
 /**
  * Build the CSS variable derivation rules for the SVG <style> block.
+ *
+ * Driven by COLOR_GRAPH - the same derivation rules that resolveColors()
+ * uses, ensuring parity between CSS and static output.
  *
  * When an optional variable (--line, --accent, etc.) is set on the SVG or
  * a parent element, it's used directly. When unset, the fallback computes
@@ -240,29 +560,29 @@ export function buildStyleBlock(font: string, hasMonoFont: boolean): string {
       : []),
   ]
 
-  // Derived CSS variables: use override if set, else mix from bg+fg.
-  // The --_ prefix signals "private/derived" — not meant for external override.
-  const derivedVars = `
-    /* Derived from --bg and --fg (overridable via --line, --accent, etc.) */
-    --_text:          var(--fg);
-    --_text-sec:      var(--muted, color-mix(in srgb, var(--fg) ${MIX.textSec}%, var(--bg)));
-    --_text-muted:    var(--muted, color-mix(in srgb, var(--fg) ${MIX.textMuted}%, var(--bg)));
-    --_text-faint:    color-mix(in srgb, var(--fg) ${MIX.textFaint}%, var(--bg));
-    --_line:          var(--line, color-mix(in srgb, var(--fg) ${MIX.line}%, var(--bg)));
-    --_arrow:         var(--accent, color-mix(in srgb, var(--fg) ${MIX.arrow}%, var(--bg)));
-    --_node-fill:     var(--surface, color-mix(in srgb, var(--fg) ${MIX.nodeFill}%, var(--bg)));
-    --_node-stroke:   var(--border, color-mix(in srgb, var(--fg) ${MIX.nodeStroke}%, var(--bg)));
-    --_group-fill:    var(--bg);
-    --_group-hdr:     color-mix(in srgb, var(--fg) ${MIX.groupHeader}%, var(--bg));
-    --_inner-stroke:  color-mix(in srgb, var(--fg) ${MIX.innerStroke}%, var(--bg));
-    --_key-badge:     color-mix(in srgb, var(--fg) ${MIX.keyBadge}%, var(--bg));`
+  // Generate CSS variable declarations from COLOR_GRAPH
+  const varLines: string[] = ['    /* Derived from --bg and --fg (overridable via --line, --accent, etc.) */']
+  for (const rule of COLOR_GRAPH) {
+    const name = `--${rule.cssVar}`
+    let expr: string
+    if (rule.source === 'fg') {
+      expr = 'var(--fg)'
+    } else if (rule.source === 'bg') {
+      expr = 'var(--bg)'
+    } else {
+      const mixExpr = `color-mix(in srgb, var(--fg) ${MIX[rule.mixKey!]}%, var(--bg))`
+      expr = rule.override ? `var(--${rule.override}, ${mixExpr})` : mixExpr
+    }
+    varLines.push(`    ${name}:${' '.repeat(Math.max(1, 18 - name.length))}${expr};`)
+  }
 
   return [
     '<style>',
     `  ${fontImports.join('\n  ')}`,
     `  text { font-family: '${font}', system-ui, sans-serif; }`,
     ...(hasMonoFont ? [`  .mono { font-family: 'JetBrains Mono', 'SF Mono', 'Fira Code', ui-monospace, monospace; }`] : []),
-    `  svg {${derivedVars}`,
+    `  svg {`,
+    ...varLines,
     `  }`,
     '</style>',
   ].join('\n')

--- a/src/types.ts
+++ b/src/types.ts
@@ -151,6 +151,55 @@ export interface RenderOptions {
   nodeSpacing?: number
   /** Vertical spacing between layers. Default: 40 */
   layerSpacing?: number
-  /** Render with transparent background (no background style on SVG). Default: false */
+  /**
+   * Render with transparent background. Default: false.
+   *
+   * In static mode, uses explicit `background:none` on the SVG root.
+   * In dynamic mode, omits the background style entirely.
+   */
   transparent?: boolean
+  /**
+   * Output mode for color handling. Default: 'dynamic'.
+   *
+   * - `'dynamic'` - colors are set via CSS custom properties on the `<svg>` tag
+   *   with `color-mix()` fallbacks in a `<style>` block. Produces compact,
+   *   themeable SVG that works in modern browsers.
+   *
+   * - `'static'` - all colors are resolved to literal hex values at render time.
+   *   Produces PDF-compatible SVG for renderers (Typst, WeasyPrint, Inkscape,
+   *   librsvg) that don't evaluate CSS custom properties or `color-mix()`.
+   */
+  output?: 'dynamic' | 'static'
+
+  /**
+   * Pre-resolved color palette. When provided, skips resolveColors() computation.
+   * Useful for rendering multiple diagrams with the same palette - resolve once,
+   * reuse across calls. Implies output: 'static'.
+   *
+   * @example
+   * ```ts
+   * const palette = resolveColors({ bg: '#1a1b26', fg: '#a9b1d6' })
+   * const svg1 = await renderMermaid(diagram1, { resolvedColors: palette })
+   * const svg2 = await renderMermaid(diagram2, { resolvedColors: palette })
+   * ```
+   */
+  resolvedColors?: import('./theme.ts').ResolvedColors
+
+  /**
+   * When true, omits the `<style>` block entirely from static SVG output.
+   * Font-family attributes are inlined directly on `<text>` elements instead.
+   * Only applies when output is 'static' (or resolvedColors is set).
+   *
+   * Useful for environments that strip `<style>` blocks (email clients,
+   * some PDF renderers, SVG sanitizers).
+   */
+  noStyleBlock?: boolean
+
+  /**
+   * Custom marker ID prefix for multi-SVG isolation.
+   * When multiple SVGs share a DOM, marker IDs (arrowheads, etc.) can collide.
+   * Set this to a unique string per diagram, or leave unset for auto-generation.
+   * Pass `false` to disable namespacing (use bare IDs like 'arrowhead').
+   */
+  markerId?: string | false
 }


### PR DESCRIPTION
beautiful-mermaid generates SVGs that use CSS custom properties for theming. This works in browsers but fails in PDF renderers, they don't evaluate CSS variables, so every diagram renders as black shapes on a white background.

This commit introduces a new `output: 'static'` render mode resolves all CSS variables to literal hex colors at render time. The resulting SVG is self-contained with no CSS dependencies, making it safe for any renderer.

All changes are backward compatible, existing dynamic-mode usage is unaffected.