### PR TITLE
Add C4 and ArchiMate diagram support

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "beautiful-mermaid",

--- a/index.ts
+++ b/index.ts
@@ -105,6 +105,8 @@ async function generateHtml(): Promise<string> {
     Sequence: '#10b981',
     Class: '#f59e0b',
     ER: '#ef4444',
+    C4: '#0ea5e9',
+    ArchiMate: '#d97706',
     'Theme Showcase': '#06b6d4',
   }
 
@@ -114,6 +116,8 @@ async function generateHtml(): Promise<string> {
     'Sequence': 'Sequence: ',
     'Class': 'Class: ',
     'ER': 'ER: ',
+    'C4': 'C4: ',
+    'ArchiMate': 'ArchiMate: ',
     'Theme Showcase': 'Theme: ',
   }
 

--- a/samples-data.ts
+++ b/samples-data.ts
@@ -1098,4 +1098,215 @@ export const samples: Sample[] = [
   STUDENT ||--o{ ENROLLMENT : enrolled
   COURSE ||--o{ ENROLLMENT : has`,
   },
+
+  // ══════════════════════════════════════════════════════════════════════════
+  //  C4 — System Context, Container, Component diagrams
+  // ══════════════════════════════════════════════════════════════════════════
+
+  {
+    title: 'C4: System Context',
+    category: 'C4',
+    description: 'C4 System Context diagram showing a banking customer interacting with the Internet Banking System.',
+    source: `C4Context
+  title System Context diagram for Internet Banking System
+  Person(customer, "Banking Customer", "A customer of the bank")
+  System(bankingSystem, "Internet Banking System", "Allows customers to view information about their bank accounts")
+  System_Ext(mailSystem, "E-mail System", "The internal Microsoft Exchange e-mail system")
+  Rel(customer, bankingSystem, "Uses")
+  Rel(bankingSystem, mailSystem, "Sends e-mails using")`,
+  },
+  {
+    title: 'C4: Container Diagram',
+    category: 'C4',
+    description: 'C4 Container diagram with system boundary, web app, API, and database containers.',
+    source: `C4Container
+  title Container diagram for Internet Banking System
+  Person(customer, "Customer", "A banking customer")
+  System_Boundary(bank, "Internet Banking") {
+    Container(web, "Web Application", "Java, Spring MVC", "Delivers static content and the single page app")
+    Container(api, "API Application", "Java, Spring Boot", "Provides Internet banking functionality via API")
+    ContainerDb(db, "Database", "Oracle 12c", "Stores user registration, authentication, and access logs")
+  }
+  System_Ext(mail, "E-mail System", "Microsoft Exchange")
+  Rel(customer, web, "Uses", "HTTPS")
+  Rel(web, api, "Makes API calls to", "JSON/HTTPS")
+  Rel(api, db, "Reads from and writes to", "JDBC")
+  Rel(api, mail, "Sends e-mails using", "SMTP")`,
+  },
+  {
+    title: 'C4: Component Diagram',
+    category: 'C4',
+    description: 'C4 Component diagram showing internal structure of the API Application.',
+    source: `C4Component
+  title Component diagram for API Application
+  Container_Boundary(api, "API Application") {
+    Component(auth, "Auth Controller", "Spring MVC", "Handles authentication")
+    Component(accounts, "Accounts Controller", "Spring MVC", "Provides account information")
+    Component(security, "Security Component", "Spring Security", "Authentication and authorization")
+    ComponentDb(repo, "Account Repository", "Spring Data", "Accesses account data")
+  }
+  ContainerDb(db, "Database", "Oracle 12c")
+  Rel(auth, security, "Uses")
+  Rel(accounts, repo, "Uses")
+  Rel(security, db, "Reads from", "JDBC")
+  Rel(repo, db, "Reads from and writes to", "JDBC")`,
+  },
+  {
+    title: 'C4: Simple Microservices',
+    category: 'C4',
+    description: 'A simple C4 Context diagram showing microservice architecture.',
+    source: `C4Context
+  Person(user, "User", "End user of the platform")
+  System(gateway, "API Gateway", "Routes requests to microservices")
+  System(auth, "Auth Service", "Handles authentication and authorization")
+  System(orders, "Order Service", "Manages customer orders")
+  System_Ext(payment, "Payment Provider", "External payment processing")
+  Rel(user, gateway, "Sends requests to")
+  Rel(gateway, auth, "Authenticates via")
+  Rel(gateway, orders, "Routes to")
+  Rel(orders, payment, "Processes payments via")`,
+  },
+  {
+    title: 'C4: Deployment Diagram',
+    category: 'C4',
+    description: 'C4 Deployment diagram showing infrastructure topology.',
+    source: `C4Deployment
+  title Deployment Diagram for Internet Banking System
+  Deployment_Node(aws, "AWS", "Amazon Web Services") {
+    Deployment_Node(ec2, "EC2 Instance", "t3.large") {
+      Container(web, "Web Application", "Java, Spring MVC")
+    }
+    Deployment_Node(rds, "Amazon RDS", "db.r5.large") {
+      ContainerDb(db, "Database", "Oracle 12c")
+    }
+  }
+  Deployment_Node(client, "Customer Device", "Browser") {
+    Container(browser, "Web Browser", "Chrome, Firefox, Safari")
+  }
+  Rel(browser, web, "Makes requests to", "HTTPS")
+  Rel(web, db, "Reads from and writes to", "JDBC")`,
+  },
+
+  // ══════════════════════════════════════════════════════════════════════════
+  //  ARCHIMATE — Enterprise Architecture diagrams
+  // ══════════════════════════════════════════════════════════════════════════
+
+  {
+    title: 'ArchiMate: Simple Layered',
+    category: 'ArchiMate',
+    description: 'Simple ArchiMate layered view with Business, Application, and Technology layers.',
+    source: `archimate-layered
+  business:
+    actor Customer
+    service "Online Banking" as OB
+  application:
+    component "Web App" as WA
+    service "Auth Service" as AS
+  technology:
+    node "AWS EC2" as EC2
+  Customer -->|serves| OB
+  OB -->|realization| WA
+  WA -->|assignment| EC2`,
+  },
+  {
+    title: 'ArchiMate: Business Process',
+    category: 'ArchiMate',
+    description: 'ArchiMate diagram showing a business process with supporting application components.',
+    source: `archimate-layered
+  business:
+    actor "Sales Rep" as SR
+    process "Order Processing" as OP
+    service "Order Fulfillment" as OF
+    object "Order" as O
+  application:
+    component "CRM System" as CRM
+    component "ERP System" as ERP
+    dataObject "Order DB" as ODB
+  SR -->|triggering| OP
+  OP -->|realization| OF
+  OP -->|access| O
+  CRM -->|serving| OP
+  ERP -->|serving| OF
+  ERP -->|access| ODB`,
+  },
+  {
+    title: 'ArchiMate: Full Stack',
+    category: 'ArchiMate',
+    description: 'A comprehensive ArchiMate diagram spanning Business, Application, and Technology layers.',
+    source: `archimate-layered
+  business:
+    actor Customer
+    service "Banking Service" as BS
+    process "Payment" as Pay
+    process "Account Mgmt" as AM
+  application:
+    component "Mobile App" as MA
+    component "Web Portal" as WP
+    component "Core Banking" as CB
+    dataObject "Account Data" as AD
+  technology:
+    node "App Server" as AS
+    node "Database Server" as DBS
+    artifact "Docker" as D
+    device "Load Balancer" as LB
+  Customer -->|serves| BS
+  BS -->|realization| Pay
+  BS -->|realization| AM
+  MA -->|serving| Customer
+  WP -->|serving| Customer
+  CB -->|realization| Pay
+  CB -->|realization| AM
+  CB -->|access| AD
+  AS -->|assignment| CB
+  DBS -->|assignment| AD
+  D -->|assignment| AS
+  LB -->|serving| AS`,
+  },
+  {
+    title: 'ArchiMate: Strategy & Motivation',
+    category: 'ArchiMate',
+    description: 'ArchiMate diagram with Strategy and Motivation layers.',
+    source: `archimate-layered
+  strategy:
+    capability "Digital Transformation" as DT
+    resource "IT Budget" as ITB
+    courseOfAction "Cloud Migration" as CM
+  motivation:
+    goal "Reduce Costs" as RC
+    driver "Market Competition" as MC
+    principle "Cloud First" as CF
+  business:
+    process "Service Delivery" as SD
+  MC -->|influence| RC
+  RC -->|realization| CF
+  CF -->|realization| CM
+  CM -->|realization| DT
+  ITB -->|assignment| DT
+  DT -->|realization| SD`,
+  },
+  {
+    title: 'ArchiMate: Implementation',
+    category: 'ArchiMate',
+    description: 'ArchiMate Implementation & Migration view showing work packages and deliverables.',
+    source: `archimate-layered
+  implementation:
+    workPackage "Phase 1" as P1
+    workPackage "Phase 2" as P2
+    deliverable "API Gateway" as AG
+    deliverable "Microservices" as MS
+    plateau "Current State" as CS
+    plateau "Target State" as TS
+  application:
+    component "Legacy System" as LS
+    component "New Platform" as NP
+  P1 -->|realization| AG
+  P2 -->|realization| MS
+  AG -->|association| NP
+  MS -->|association| NP
+  CS -->|triggering| P1
+  P1 -->|triggering| P2
+  P2 -->|realization| TS
+  LS -->|association| CS
+  NP -->|association| TS`,
+  },
 ]

--- a/src/archimate/layout.ts
+++ b/src/archimate/layout.ts
@@ -1,0 +1,264 @@
+// @ts-expect-error — dagre types are declared for the package root, not the dist path;
+// importing the pre-built browser bundle avoids Bun.build hanging on 30+ CJS file resolution
+import dagre from '@dagrejs/dagre/dist/dagre.js'
+import type {
+  ArchiMateDiagram,
+  ArchiMateLayer,
+  PositionedArchiMateDiagram,
+  PositionedArchiMateElement,
+  PositionedArchiMateLayer,
+  PositionedArchiMateRelationship,
+} from './types.ts'
+import type { RenderOptions } from '../types.ts'
+import { estimateTextWidth, FONT_SIZES, FONT_WEIGHTS } from '../styles.ts'
+import { centerToTopLeft, snapToOrthogonal, clipEndpointsToNodes } from '../dagre-adapter.ts'
+
+// ============================================================================
+// ArchiMate diagram layout engine
+//
+// Uses dagre for positioning elements, then computes layer band bounding
+// boxes from the positions of the elements within each layer.
+//
+// Layer order (top to bottom):
+//   strategy → motivation → business → application → technology →
+//   physical → implementation
+//
+// Elements within the same layer share a dagre rank via invisible edges
+// to a virtual "layer anchor" node. This groups them visually.
+// ============================================================================
+
+/** Canonical layer ordering from top to bottom */
+const LAYER_ORDER: readonly ArchiMateLayer[] = [
+  'strategy',
+  'motivation',
+  'business',
+  'application',
+  'technology',
+  'physical',
+  'implementation',
+]
+
+/** Layout constants */
+const ARCHIMATE = {
+  /** Canvas padding around the entire diagram */
+  padding: 40,
+  /** Minimum element box width */
+  minElementWidth: 120,
+  /** Element box height */
+  elementHeight: 50,
+  /** Padding inside layer bands — all sides */
+  layerPadding: 20,
+  /** Extra top padding in layer bands for the layer label */
+  layerLabelHeight: 24,
+  /** Spacing between nodes within a rank */
+  nodeSpacing: 40,
+  /** Spacing between ranks (layers) */
+  layerSpacing: 60,
+  /** Font size for element type indicator */
+  typeIndicatorSize: 9,
+} as const
+
+/**
+ * Lay out a parsed ArchiMate diagram using dagre.
+ * Returns positioned elements, layer bands, and relationship paths.
+ *
+ * Kept async for API compatibility — dagre itself is synchronous.
+ */
+export async function layoutArchiMateDiagram(
+  diagram: ArchiMateDiagram,
+  _options: RenderOptions = {}
+): Promise<PositionedArchiMateDiagram> {
+  if (diagram.elements.size === 0) {
+    return { width: 0, height: 0, layers: [], elements: [], relationships: [] }
+  }
+
+  // 1. Determine which layers are present and their order
+  const presentLayers: ArchiMateLayer[] = LAYER_ORDER.filter(
+    layer => diagram.layers.has(layer) && diagram.layers.get(layer)!.length > 0
+  )
+
+  // 2. Calculate element box dimensions
+  const elementSizes = new Map<string, { width: number; height: number }>()
+
+  for (const [id, element] of diagram.elements) {
+    const labelWidth = estimateTextWidth(
+      element.label, FONT_SIZES.nodeLabel, FONT_WEIGHTS.nodeLabel
+    )
+    // Type indicator adds a bit of extra width
+    const typeWidth = estimateTextWidth(
+      element.type, ARCHIMATE.typeIndicatorSize, 400
+    )
+    const width = Math.max(
+      ARCHIMATE.minElementWidth,
+      labelWidth + 24,
+      typeWidth + labelWidth / 2 + 24
+    )
+    elementSizes.set(id, { width, height: ARCHIMATE.elementHeight })
+  }
+
+  // 3. Build dagre graph
+  const g = new dagre.graphlib.Graph({ directed: true })
+  g.setGraph({
+    rankdir: 'TB',
+    acyclicer: 'greedy',
+    nodesep: ARCHIMATE.nodeSpacing,
+    ranksep: ARCHIMATE.layerSpacing,
+    marginx: ARCHIMATE.padding,
+    marginy: ARCHIMATE.padding,
+  })
+  g.setDefaultEdgeLabel(() => ({}))
+
+  // Add element nodes
+  for (const [id, element] of diagram.elements) {
+    const size = elementSizes.get(id)!
+    g.setNode(id, { width: size.width, height: size.height, layer: element.layer })
+  }
+
+  // Enforce layer ordering by adding invisible edges between elements
+  // of consecutive layers. This ensures elements in higher layers
+  // (strategy, business) appear above elements in lower layers
+  // (application, technology).
+  for (let i = 1; i < presentLayers.length; i++) {
+    const upperLayer = presentLayers[i - 1]!
+    const lowerLayer = presentLayers[i]!
+    const upperElements = diagram.layers.get(upperLayer) ?? []
+    const lowerElements = diagram.layers.get(lowerLayer) ?? []
+
+    // Connect first element of upper layer to first element of lower layer
+    // with a high-weight edge to enforce vertical ordering
+    if (upperElements.length > 0 && lowerElements.length > 0) {
+      g.setEdge(upperElements[0]!.id, lowerElements[0]!.id, {
+        minlen: 2,
+        weight: 10,
+        _layerEdge: true,
+      })
+    }
+  }
+
+  // Add real relationship edges
+  for (let i = 0; i < diagram.relationships.length; i++) {
+    const rel = diagram.relationships[i]!
+    // Only add edge if both endpoints exist
+    if (diagram.elements.has(rel.source) && diagram.elements.has(rel.target)) {
+      g.setEdge(rel.source, rel.target, {
+        _index: i,
+        label: rel.label ?? '',
+        width: rel.label
+          ? estimateTextWidth(rel.label, FONT_SIZES.edgeLabel, FONT_WEIGHTS.edgeLabel) + 8
+          : 0,
+        height: rel.label ? FONT_SIZES.edgeLabel + 6 : 0,
+        labelpos: 'c',
+      })
+    }
+  }
+
+  // 4. Run dagre layout
+  try {
+    dagre.layout(g)
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    throw new Error(`Dagre layout failed (ArchiMate diagram): ${message}`)
+  }
+
+  // 5. Extract positioned elements (skip anchor nodes)
+  const positionedElements: PositionedArchiMateElement[] = []
+
+  for (const [id, element] of diagram.elements) {
+    const dagreNode = g.node(id)
+    if (!dagreNode) continue
+    const topLeft = centerToTopLeft(dagreNode.x, dagreNode.y, dagreNode.width, dagreNode.height)
+    positionedElements.push({
+      id,
+      label: element.label,
+      type: element.type,
+      layer: element.layer,
+      x: topLeft.x,
+      y: topLeft.y,
+      width: dagreNode.width ?? elementSizes.get(id)!.width,
+      height: dagreNode.height ?? elementSizes.get(id)!.height,
+    })
+  }
+
+  // 6. Compute layer band positions from element bounding boxes
+  const positionedLayers: PositionedArchiMateLayer[] = []
+
+  for (const layer of presentLayers) {
+    const layerElements = positionedElements.filter(e => e.layer === layer)
+    if (layerElements.length === 0) continue
+
+    let minX = Infinity
+    let minY = Infinity
+    let maxX = -Infinity
+    let maxY = -Infinity
+
+    for (const el of layerElements) {
+      minX = Math.min(minX, el.x)
+      minY = Math.min(minY, el.y)
+      maxX = Math.max(maxX, el.x + el.width)
+      maxY = Math.max(maxY, el.y + el.height)
+    }
+
+    // Add padding around the layer band
+    positionedLayers.push({
+      name: layer,
+      x: minX - ARCHIMATE.layerPadding,
+      y: minY - ARCHIMATE.layerPadding - ARCHIMATE.layerLabelHeight,
+      width: (maxX - minX) + ARCHIMATE.layerPadding * 2,
+      height: (maxY - minY) + ARCHIMATE.layerPadding * 2 + ARCHIMATE.layerLabelHeight,
+    })
+  }
+
+  // Normalize layer band widths so they all share the same x and width
+  if (positionedLayers.length > 0) {
+    const globalMinX = Math.min(...positionedLayers.map(l => l.x))
+    const globalMaxRight = Math.max(...positionedLayers.map(l => l.x + l.width))
+    const globalWidth = globalMaxRight - globalMinX
+
+    for (const layer of positionedLayers) {
+      layer.x = globalMinX
+      layer.width = globalWidth
+    }
+  }
+
+  // 7. Extract relationship paths
+  const relationships: PositionedArchiMateRelationship[] = []
+
+  for (const edgeObj of g.edges()) {
+    const dagreEdge = g.edge(edgeObj)
+    // Skip invisible layer-ordering edges
+    if (dagreEdge._layerEdge) continue
+
+    const index = dagreEdge._index as number | undefined
+    if (index === undefined) continue
+
+    const rel = diagram.relationships[index]!
+    const rawPoints = dagreEdge.points ?? []
+    // TB layout → vertical-first bends
+    const orthoPoints = snapToOrthogonal(rawPoints, true)
+
+    // Clip endpoints to node boundaries
+    const srcNode = g.node(edgeObj.v)
+    const tgtNode = g.node(edgeObj.w)
+    const points = clipEndpointsToNodes(
+      orthoPoints,
+      srcNode ? { cx: srcNode.x, cy: srcNode.y, hw: srcNode.width / 2, hh: srcNode.height / 2 } : null,
+      tgtNode ? { cx: tgtNode.x, cy: tgtNode.y, hw: tgtNode.width / 2, hh: tgtNode.height / 2 } : null,
+    )
+
+    relationships.push({
+      source: rel.source,
+      target: rel.target,
+      type: rel.type,
+      label: rel.label,
+      points,
+    })
+  }
+
+  return {
+    width: (g.graph().width as number) ?? 600,
+    height: (g.graph().height as number) ?? 400,
+    layers: positionedLayers,
+    elements: positionedElements,
+    relationships,
+  }
+}

--- a/src/archimate/parser.ts
+++ b/src/archimate/parser.ts
@@ -1,0 +1,257 @@
+import type {
+  ArchiMateDiagram,
+  ArchiMateElement,
+  ArchiMateElementType,
+  ArchiMateLayer,
+  ArchiMateRelationship,
+  ArchiMateRelationshipType,
+} from './types.ts'
+
+// ============================================================================
+// ArchiMate diagram parser
+//
+// Parses the archimate-layered DSL syntax into an ArchiMateDiagram structure.
+//
+// Supported syntax:
+//   archimate-layered
+//     business:
+//       actor Customer
+//       service "Online Banking" as OB
+//     application:
+//       component "Web App" as WA
+//     Customer -->|serves| OB
+//     OB -->|realizes| WA
+//
+// Layer blocks: business:, application:, technology:, strategy:,
+//               motivation:, physical:, implementation:
+//
+// Element syntax:
+//   elementType alias                    → id=alias, label=alias
+//   elementType "Label" as alias         → id=alias, label=Label
+//   elementType "Label"                  → id=Label (spaces → _), label=Label
+//
+// Relationship syntax:
+//   source -->|type| target              → typed relationship
+//   source --> target                    → association (default)
+// ============================================================================
+
+/** Valid element types per layer */
+const LAYER_ELEMENT_TYPES: Record<ArchiMateLayer, ReadonlySet<string>> = {
+  business: new Set([
+    'actor', 'role', 'process', 'function', 'service', 'object',
+    'event', 'interface', 'collaboration', 'interaction',
+    'contract', 'representation', 'product',
+  ]),
+  application: new Set([
+    'component', 'collaboration', 'interface', 'function', 'interaction',
+    'process', 'event', 'service', 'dataObject',
+  ]),
+  technology: new Set([
+    'node', 'device', 'systemSoftware', 'artifact',
+    'communicationNetwork', 'path', 'interface', 'function',
+    'process', 'interaction', 'event', 'service',
+  ]),
+  strategy: new Set([
+    'resource', 'capability', 'valueStream', 'courseOfAction',
+  ]),
+  motivation: new Set([
+    'stakeholder', 'driver', 'assessment', 'goal', 'outcome',
+    'principle', 'requirement', 'constraint', 'meaning', 'value',
+  ]),
+  physical: new Set([
+    'equipment', 'facility', 'distributionNetwork', 'material',
+  ]),
+  implementation: new Set([
+    'workPackage', 'deliverable', 'implementationEvent', 'plateau', 'gap',
+  ]),
+}
+
+/** All valid relationship type names */
+const RELATIONSHIP_TYPES: ReadonlySet<string> = new Set([
+  'composition', 'aggregation', 'assignment', 'realization',
+  'serving', 'access', 'influence', 'triggering', 'flow',
+  'specialization', 'association',
+])
+
+/** All valid layer names */
+const LAYER_NAMES: ReadonlySet<string> = new Set([
+  'business', 'application', 'technology', 'strategy',
+  'motivation', 'physical', 'implementation',
+])
+
+/** Build a set of all valid element type names across all layers */
+function buildAllElementTypes(): ReadonlySet<string> {
+  const all = new Set<string>()
+  for (const types of Object.values(LAYER_ELEMENT_TYPES)) {
+    for (const t of types) all.add(t)
+  }
+  return all
+}
+
+const ALL_ELEMENT_TYPES = buildAllElementTypes()
+
+/**
+ * Parse a Mermaid ArchiMate diagram.
+ * Expects the first non-empty, non-comment line to be "archimate-layered".
+ */
+export function parseArchimate(lines: string[]): ArchiMateDiagram {
+  const diagram: ArchiMateDiagram = {
+    layers: new Map(),
+    elements: new Map(),
+    relationships: [],
+  }
+
+  let currentLayer: ArchiMateLayer | null = null
+
+  // Start from index 1 — skip the "archimate-layered" header
+  for (let i = 1; i < lines.length; i++) {
+    const raw = lines[i]!
+    const trimmed = raw.trim()
+
+    // Skip empty lines and comments
+    if (trimmed.length === 0 || trimmed.startsWith('%%')) continue
+
+    // Check for layer block header (e.g., "business:", "application:")
+    const layerMatch = trimmed.match(/^(\w+):$/)
+    if (layerMatch && LAYER_NAMES.has(layerMatch[1]!)) {
+      currentLayer = layerMatch[1]! as ArchiMateLayer
+      if (!diagram.layers.has(currentLayer)) {
+        diagram.layers.set(currentLayer, [])
+      }
+      continue
+    }
+
+    // Try to parse a relationship (can appear anywhere)
+    const rel = parseRelationship(trimmed)
+    if (rel) {
+      diagram.relationships.push(rel)
+      continue
+    }
+
+    // Try to parse an element declaration (only valid inside a layer block)
+    if (currentLayer) {
+      const element = parseElement(trimmed, currentLayer)
+      if (element) {
+        diagram.elements.set(element.id, element)
+        const layerElements = diagram.layers.get(currentLayer)
+        if (layerElements) {
+          layerElements.push(element)
+        } else {
+          diagram.layers.set(currentLayer, [element])
+        }
+        continue
+      }
+    }
+
+    // Lines outside a layer block that aren't relationships are ignored.
+    // If we're inside a layer block and the line doesn't match any pattern,
+    // check if it could be a top-level construct that resets the layer context.
+    if (currentLayer && !raw.match(/^\s/) && !layerMatch) {
+      // Non-indented line that's not a layer header — we're leaving the block
+      currentLayer = null
+      // Re-try as a relationship
+      const topRel = parseRelationship(trimmed)
+      if (topRel) {
+        diagram.relationships.push(topRel)
+      }
+    }
+  }
+
+  return diagram
+}
+
+/**
+ * Parse an element declaration line.
+ *
+ * Formats:
+ *   elementType alias                    → id=alias, label=alias
+ *   elementType "Label" as alias         → id=alias, label=Label
+ *   elementType "Label"                  → id=Label (spaces→_), label=Label
+ */
+function parseElement(line: string, layer: ArchiMateLayer): ArchiMateElement | null {
+  // Try: elementType "Label" as alias
+  const quotedAliasMatch = line.match(/^(\w+)\s+"([^"]+)"\s+as\s+(\w+)$/)
+  if (quotedAliasMatch) {
+    const typeName = quotedAliasMatch[1]!
+    if (!isValidElementType(typeName, layer)) return null
+    return {
+      id: quotedAliasMatch[3]!,
+      label: quotedAliasMatch[2]!,
+      type: typeName as ArchiMateElementType,
+      layer,
+    }
+  }
+
+  // Try: elementType "Label"
+  const quotedMatch = line.match(/^(\w+)\s+"([^"]+)"$/)
+  if (quotedMatch) {
+    const typeName = quotedMatch[1]!
+    if (!isValidElementType(typeName, layer)) return null
+    const label = quotedMatch[2]!
+    return {
+      id: label.replace(/\s+/g, '_'),
+      label,
+      type: typeName as ArchiMateElementType,
+      layer,
+    }
+  }
+
+  // Try: elementType alias
+  const simpleMatch = line.match(/^(\w+)\s+(\w+)$/)
+  if (simpleMatch) {
+    const typeName = simpleMatch[1]!
+    if (!isValidElementType(typeName, layer)) return null
+    const alias = simpleMatch[2]!
+    return {
+      id: alias,
+      label: alias,
+      type: typeName as ArchiMateElementType,
+      layer,
+    }
+  }
+
+  return null
+}
+
+/** Check if a type name is a valid element type for the given layer */
+function isValidElementType(typeName: string, layer: ArchiMateLayer): boolean {
+  // Check layer-specific types first, then fall back to all types
+  // (some types like 'service', 'interface', 'function' appear in multiple layers)
+  const layerTypes = LAYER_ELEMENT_TYPES[layer]
+  if (layerTypes && layerTypes.has(typeName)) return true
+  // Also accept any valid element type — the layer just provides context
+  return ALL_ELEMENT_TYPES.has(typeName)
+}
+
+/**
+ * Parse a relationship line.
+ *
+ * Formats:
+ *   source -->|type| target        → typed relationship
+ *   source --> target              → association (default)
+ */
+function parseRelationship(line: string): ArchiMateRelationship | null {
+  // Try: source -->|type| target
+  const typedMatch = line.match(/^(\w+)\s+-->\|(\w+)\|\s+(\w+)$/)
+  if (typedMatch) {
+    const relType = typedMatch[2]!
+    if (!RELATIONSHIP_TYPES.has(relType)) return null
+    return {
+      source: typedMatch[1]!,
+      target: typedMatch[3]!,
+      type: relType as ArchiMateRelationshipType,
+    }
+  }
+
+  // Try: source --> target (default association)
+  const simpleMatch = line.match(/^(\w+)\s+-->\s+(\w+)$/)
+  if (simpleMatch) {
+    return {
+      source: simpleMatch[1]!,
+      target: simpleMatch[2]!,
+      type: 'association',
+    }
+  }
+
+  return null
+}

--- a/src/archimate/renderer.ts
+++ b/src/archimate/renderer.ts
@@ -1,0 +1,425 @@
+import type {
+  PositionedArchiMateDiagram,
+  PositionedArchiMateElement,
+  PositionedArchiMateLayer,
+  PositionedArchiMateRelationship,
+  ArchiMateLayer,
+  ArchiMateRelationshipType,
+} from './types.ts'
+import type { DiagramColors } from '../theme.ts'
+import { svgOpenTag, buildStyleBlock } from '../theme.ts'
+import { FONT_SIZES, FONT_WEIGHTS, STROKE_WIDTHS, estimateTextWidth, TEXT_BASELINE_SHIFT } from '../styles.ts'
+
+// ============================================================================
+// ArchiMate diagram SVG renderer
+//
+// Renders positioned ArchiMate diagrams to SVG.
+// All colors use CSS custom properties (var(--_xxx)) from the theme system.
+//
+// Render order:
+//   1. Layer bands (background rectangles with color tints)
+//   2. Relationship lines (behind element boxes)
+//   3. Element boxes (rounded rectangles with type indicators)
+//   4. Relationship labels
+//   5. Relationship markers (arrowheads, diamonds)
+// ============================================================================
+
+/** ArchiMate-specific font sizes */
+const ARCHIMATE_FONT = {
+  typeIndicatorSize: 9,
+  typeIndicatorWeight: 400,
+  layerLabelSize: 11,
+  layerLabelWeight: 600,
+} as const
+
+/** Layer color tints — mixed with var(--bg) at 12% for subtle background fill */
+const LAYER_TINTS: Record<ArchiMateLayer, string> = {
+  business:       'color-mix(in srgb, #F0C040 12%, var(--bg))',
+  application:    'color-mix(in srgb, #4488CC 12%, var(--bg))',
+  technology:     'color-mix(in srgb, #44AA66 12%, var(--bg))',
+  strategy:       'color-mix(in srgb, #CCB366 12%, var(--bg))',
+  motivation:     'color-mix(in srgb, #AA77CC 12%, var(--bg))',
+  physical:       'color-mix(in srgb, #66BB99 12%, var(--bg))',
+  implementation: 'color-mix(in srgb, #CC6666 12%, var(--bg))',
+}
+
+/** Layer border colors — slightly stronger tint for the border stroke */
+const LAYER_BORDERS: Record<ArchiMateLayer, string> = {
+  business:       'color-mix(in srgb, #F0C040 30%, var(--_node-stroke))',
+  application:    'color-mix(in srgb, #4488CC 30%, var(--_node-stroke))',
+  technology:     'color-mix(in srgb, #44AA66 30%, var(--_node-stroke))',
+  strategy:       'color-mix(in srgb, #CCB366 30%, var(--_node-stroke))',
+  motivation:     'color-mix(in srgb, #AA77CC 30%, var(--_node-stroke))',
+  physical:       'color-mix(in srgb, #66BB99 30%, var(--_node-stroke))',
+  implementation: 'color-mix(in srgb, #CC6666 30%, var(--_node-stroke))',
+}
+
+/** Human-readable layer display names */
+const LAYER_LABELS: Record<ArchiMateLayer, string> = {
+  business:       'Business',
+  application:    'Application',
+  technology:     'Technology',
+  strategy:       'Strategy',
+  motivation:     'Motivation',
+  physical:       'Physical',
+  implementation: 'Implementation & Migration',
+}
+
+/**
+ * Render a positioned ArchiMate diagram as an SVG string.
+ *
+ * @param diagram - Positioned ArchiMate diagram with coordinates
+ * @param colors - DiagramColors with bg/fg and optional enrichment variables
+ * @param font - Font family for text rendering. Default: 'Inter'
+ * @param transparent - If true, renders with transparent background
+ */
+export function renderArchiMateSvg(
+  diagram: PositionedArchiMateDiagram,
+  colors: DiagramColors,
+  font: string = 'Inter',
+  transparent: boolean = false
+): string {
+  const parts: string[] = []
+
+  // SVG root with CSS variables + style block + defs
+  parts.push(svgOpenTag(diagram.width, diagram.height, colors, transparent))
+  parts.push(buildStyleBlock(font, false))
+  parts.push(buildDefs())
+
+  // 1. Layer bands
+  for (const layer of diagram.layers) {
+    parts.push(renderLayerBand(layer))
+  }
+
+  // 2. Relationship lines (behind boxes)
+  for (const rel of diagram.relationships) {
+    parts.push(renderRelationshipLine(rel))
+  }
+
+  // 3. Element boxes
+  for (const element of diagram.elements) {
+    parts.push(renderElementBox(element))
+  }
+
+  // 4. Relationship labels
+  for (const rel of diagram.relationships) {
+    parts.push(renderRelationshipLabel(rel))
+  }
+
+  // 5. Relationship markers (arrowheads, diamonds)
+  for (const rel of diagram.relationships) {
+    parts.push(renderRelationshipMarkers(rel))
+  }
+
+  parts.push('</svg>')
+  return parts.join('\n')
+}
+
+// ============================================================================
+// SVG marker definitions
+// ============================================================================
+
+/** Build SVG <defs> with arrow and diamond markers */
+function buildDefs(): string {
+  const parts: string[] = ['<defs>']
+
+  // Filled arrowhead (for triggering, flow, assignment, access)
+  parts.push(
+    `<marker id="archimate-arrow-filled" markerWidth="10" markerHeight="8" refX="9" refY="4" orient="auto" markerUnits="userSpaceOnUse">` +
+    `<path d="M0,0 L10,4 L0,8 Z" fill="var(--_line)" />` +
+    `</marker>`
+  )
+
+  // Open arrowhead (for serving, realization, influence)
+  parts.push(
+    `<marker id="archimate-arrow-open" markerWidth="10" markerHeight="8" refX="9" refY="4" orient="auto" markerUnits="userSpaceOnUse">` +
+    `<path d="M0,0 L10,4 L0,8" fill="none" stroke="var(--_line)" stroke-width="1.25" />` +
+    `</marker>`
+  )
+
+  // Open triangle (for specialization)
+  parts.push(
+    `<marker id="archimate-triangle-open" markerWidth="12" markerHeight="10" refX="11" refY="5" orient="auto" markerUnits="userSpaceOnUse">` +
+    `<path d="M0,0 L12,5 L0,10 Z" fill="var(--bg)" stroke="var(--_line)" stroke-width="1" />` +
+    `</marker>`
+  )
+
+  // Filled diamond (for composition)
+  parts.push(
+    `<marker id="archimate-diamond-filled" markerWidth="12" markerHeight="8" refX="1" refY="4" orient="auto" markerUnits="userSpaceOnUse">` +
+    `<path d="M6,0 L12,4 L6,8 L0,4 Z" fill="var(--_line)" />` +
+    `</marker>`
+  )
+
+  // Open diamond (for aggregation)
+  parts.push(
+    `<marker id="archimate-diamond-open" markerWidth="12" markerHeight="8" refX="1" refY="4" orient="auto" markerUnits="userSpaceOnUse">` +
+    `<path d="M6,0 L12,4 L6,8 L0,4 Z" fill="var(--bg)" stroke="var(--_line)" stroke-width="1" />` +
+    `</marker>`
+  )
+
+  // Filled circle (for assignment — start marker)
+  parts.push(
+    `<marker id="archimate-circle-filled" markerWidth="8" markerHeight="8" refX="4" refY="4" orient="auto" markerUnits="userSpaceOnUse">` +
+    `<circle cx="4" cy="4" r="3" fill="var(--_line)" />` +
+    `</marker>`
+  )
+
+  parts.push('</defs>')
+  return parts.join('\n')
+}
+
+// ============================================================================
+// Layer band rendering
+// ============================================================================
+
+/** Render a layer band — background rectangle with layer label */
+function renderLayerBand(layer: PositionedArchiMateLayer): string {
+  const parts: string[] = []
+  const tint = LAYER_TINTS[layer.name]
+  const border = LAYER_BORDERS[layer.name]
+  const label = LAYER_LABELS[layer.name]
+
+  // Background rectangle
+  parts.push(
+    `<rect x="${layer.x}" y="${layer.y}" width="${layer.width}" height="${layer.height}" ` +
+    `rx="4" ry="4" fill="${tint}" stroke="${border}" stroke-width="${STROKE_WIDTHS.outerBox}" />`
+  )
+
+  // Layer label in the top-left corner
+  parts.push(
+    `<text x="${layer.x + 8}" y="${layer.y + 16}" ` +
+    `font-size="${ARCHIMATE_FONT.layerLabelSize}" font-weight="${ARCHIMATE_FONT.layerLabelWeight}" ` +
+    `fill="var(--_text-muted)">${escapeXml(label)}</text>`
+  )
+
+  return parts.join('\n')
+}
+
+// ============================================================================
+// Element box rendering
+// ============================================================================
+
+/** Render an element box — rounded rectangle with label and type indicator */
+function renderElementBox(element: PositionedArchiMateElement): string {
+  const { x, y, width, height, label, type } = element
+  const parts: string[] = []
+
+  // Outer rounded rectangle
+  parts.push(
+    `<rect x="${x}" y="${y}" width="${width}" height="${height}" ` +
+    `rx="4" ry="4" fill="var(--_node-fill)" stroke="var(--_node-stroke)" stroke-width="${STROKE_WIDTHS.outerBox}" />`
+  )
+
+  // Element label — centered
+  parts.push(
+    `<text x="${x + width / 2}" y="${y + height / 2 + 2}" text-anchor="middle" dy="${TEXT_BASELINE_SHIFT}" ` +
+    `font-size="${FONT_SIZES.nodeLabel}" font-weight="${FONT_WEIGHTS.nodeLabel}" fill="var(--_text)">${escapeXml(label)}</text>`
+  )
+
+  // Type indicator — small text in the top-right corner
+  const typeLabel = formatTypeName(type)
+  parts.push(
+    `<text x="${x + width - 6}" y="${y + 12}" text-anchor="end" ` +
+    `font-size="${ARCHIMATE_FONT.typeIndicatorSize}" font-weight="${ARCHIMATE_FONT.typeIndicatorWeight}" ` +
+    `fill="var(--_text-faint)">${escapeXml(typeLabel)}</text>`
+  )
+
+  return parts.join('\n')
+}
+
+/** Convert camelCase type names to human-readable form */
+function formatTypeName(type: string): string {
+  // Insert space before uppercase letters: "dataObject" → "data Object" → "Data Object"
+  const spaced = type.replace(/([a-z])([A-Z])/g, '$1 $2')
+  return spaced.charAt(0).toUpperCase() + spaced.slice(1)
+}
+
+// ============================================================================
+// Relationship rendering
+// ============================================================================
+
+/** Get SVG attributes for a relationship line based on its type */
+function getRelationshipLineStyle(type: ArchiMateRelationshipType): {
+  dashArray: string
+  markerStart: string
+  markerEnd: string
+} {
+  switch (type) {
+    case 'composition':
+      return {
+        dashArray: '',
+        markerStart: 'url(#archimate-diamond-filled)',
+        markerEnd: '',
+      }
+    case 'aggregation':
+      return {
+        dashArray: '',
+        markerStart: 'url(#archimate-diamond-open)',
+        markerEnd: '',
+      }
+    case 'assignment':
+      return {
+        dashArray: '',
+        markerStart: 'url(#archimate-circle-filled)',
+        markerEnd: 'url(#archimate-arrow-filled)',
+      }
+    case 'realization':
+      return {
+        dashArray: '6 4',
+        markerStart: '',
+        markerEnd: 'url(#archimate-arrow-open)',
+      }
+    case 'serving':
+      return {
+        dashArray: '',
+        markerStart: '',
+        markerEnd: 'url(#archimate-arrow-open)',
+      }
+    case 'access':
+      return {
+        dashArray: '6 4',
+        markerStart: '',
+        markerEnd: 'url(#archimate-arrow-filled)',
+      }
+    case 'influence':
+      return {
+        dashArray: '6 4',
+        markerStart: '',
+        markerEnd: 'url(#archimate-arrow-open)',
+      }
+    case 'triggering':
+      return {
+        dashArray: '',
+        markerStart: '',
+        markerEnd: 'url(#archimate-arrow-filled)',
+      }
+    case 'flow':
+      return {
+        dashArray: '6 4',
+        markerStart: '',
+        markerEnd: 'url(#archimate-arrow-filled)',
+      }
+    case 'specialization':
+      return {
+        dashArray: '',
+        markerStart: '',
+        markerEnd: 'url(#archimate-triangle-open)',
+      }
+    case 'association':
+      return {
+        dashArray: '',
+        markerStart: '',
+        markerEnd: '',
+      }
+  }
+}
+
+/** Render a relationship line (polyline) */
+function renderRelationshipLine(rel: PositionedArchiMateRelationship): string {
+  if (rel.points.length < 2) return ''
+
+  const style = getRelationshipLineStyle(rel.type)
+  const pathData = rel.points.map(p => `${p.x},${p.y}`).join(' ')
+
+  const attrs: string[] = [
+    `points="${pathData}"`,
+    'fill="none"',
+    'stroke="var(--_line)"',
+    `stroke-width="${STROKE_WIDTHS.connector}"`,
+  ]
+
+  if (style.dashArray) {
+    attrs.push(`stroke-dasharray="${style.dashArray}"`)
+  }
+  if (style.markerStart) {
+    attrs.push(`marker-start="${style.markerStart}"`)
+  }
+  if (style.markerEnd) {
+    attrs.push(`marker-end="${style.markerEnd}"`)
+  }
+
+  return `<polyline ${attrs.join(' ')} />`
+}
+
+/** Render a relationship label at the arc-length midpoint */
+function renderRelationshipLabel(rel: PositionedArchiMateRelationship): string {
+  if (!rel.label || rel.points.length < 2) return ''
+
+  const mid = midpoint(rel.points)
+  const textWidth = estimateTextWidth(rel.label, FONT_SIZES.edgeLabel, FONT_WEIGHTS.edgeLabel)
+
+  // Background pill for readability
+  const bgW = textWidth + 8
+  const bgH = FONT_SIZES.edgeLabel + 6
+
+  return (
+    `<rect x="${mid.x - bgW / 2}" y="${mid.y - bgH / 2}" width="${bgW}" height="${bgH}" rx="2" ry="2" ` +
+    `fill="var(--bg)" stroke="var(--_inner-stroke)" stroke-width="0.5" />` +
+    `\n<text x="${mid.x}" y="${mid.y}" text-anchor="middle" dy="${TEXT_BASELINE_SHIFT}" ` +
+    `font-size="${FONT_SIZES.edgeLabel}" font-weight="${FONT_WEIGHTS.edgeLabel}" fill="var(--_text-muted)">${escapeXml(rel.label)}</text>`
+  )
+}
+
+/** Render relationship endpoint markers that aren't handled by SVG marker defs */
+function renderRelationshipMarkers(rel: PositionedArchiMateRelationship): string {
+  // All markers are handled via SVG <marker> defs on the polyline
+  // This function is a placeholder for any additional custom markers
+  // that might be needed in the future (e.g., inline decorations)
+  if (rel.points.length < 2) return ''
+  return ''
+}
+
+// ============================================================================
+// Geometry utilities
+// ============================================================================
+
+/** Compute the arc-length midpoint of a polyline path.
+ *  Walks along each segment, finds the point at exactly 50% of total path length.
+ *  This ensures the label sits ON the path even for orthogonal routes with bends. */
+function midpoint(points: Array<{ x: number; y: number }>): { x: number; y: number } {
+  if (points.length === 0) return { x: 0, y: 0 }
+  if (points.length === 1) return points[0]!
+
+  // Compute total path length
+  let totalLen = 0
+  for (let i = 1; i < points.length; i++) {
+    const dx = points[i]!.x - points[i - 1]!.x
+    const dy = points[i]!.y - points[i - 1]!.y
+    totalLen += Math.sqrt(dx * dx + dy * dy)
+  }
+
+  if (totalLen === 0) return points[0]!
+
+  // Walk to 50% of total length
+  const halfLen = totalLen / 2
+  let walked = 0
+  for (let i = 1; i < points.length; i++) {
+    const dx = points[i]!.x - points[i - 1]!.x
+    const dy = points[i]!.y - points[i - 1]!.y
+    const segLen = Math.sqrt(dx * dx + dy * dy)
+    if (walked + segLen >= halfLen) {
+      const t = segLen > 0 ? (halfLen - walked) / segLen : 0
+      return {
+        x: points[i - 1]!.x + dx * t,
+        y: points[i - 1]!.y + dy * t,
+      }
+    }
+    walked += segLen
+  }
+
+  return points[points.length - 1]!
+}
+
+// ============================================================================
+// Utilities
+// ============================================================================
+
+function escapeXml(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+}

--- a/src/archimate/types.ts
+++ b/src/archimate/types.ts
@@ -1,0 +1,106 @@
+// ============================================================================
+// ArchiMate diagram types
+//
+// Models ArchiMate 3.2 enterprise architecture diagrams.
+// Supports layered views with Business, Application, Technology, Strategy,
+// Motivation, Physical, and Implementation & Migration layers.
+// ============================================================================
+
+/** ArchiMate layer names */
+export type ArchiMateLayer =
+  | 'business'
+  | 'application'
+  | 'technology'
+  | 'strategy'
+  | 'motivation'
+  | 'physical'
+  | 'implementation'
+
+/** ArchiMate element type (union of all layer-specific element types) */
+export type ArchiMateElementType =
+  // Business
+  | 'actor' | 'role' | 'process' | 'function' | 'service' | 'object'
+  | 'event' | 'interface' | 'collaboration' | 'interaction'
+  | 'contract' | 'representation' | 'product'
+  // Application
+  | 'component' | 'dataObject'
+  // Technology
+  | 'node' | 'device' | 'systemSoftware' | 'artifact'
+  | 'communicationNetwork' | 'path'
+  // Strategy
+  | 'resource' | 'capability' | 'valueStream' | 'courseOfAction'
+  // Motivation
+  | 'stakeholder' | 'driver' | 'assessment' | 'goal' | 'outcome'
+  | 'principle' | 'requirement' | 'constraint' | 'meaning' | 'value'
+  // Physical
+  | 'equipment' | 'facility' | 'distributionNetwork' | 'material'
+  // Implementation & Migration
+  | 'workPackage' | 'deliverable' | 'implementationEvent' | 'plateau' | 'gap'
+
+/** ArchiMate relationship types */
+export type ArchiMateRelationshipType =
+  | 'composition' | 'aggregation' | 'assignment' | 'realization'
+  | 'serving' | 'access' | 'influence' | 'triggering' | 'flow'
+  | 'specialization' | 'association'
+
+/** An element in the ArchiMate diagram */
+export interface ArchiMateElement {
+  id: string
+  label: string
+  type: ArchiMateElementType
+  layer: ArchiMateLayer
+}
+
+/** A relationship between elements */
+export interface ArchiMateRelationship {
+  source: string
+  target: string
+  type: ArchiMateRelationshipType
+  label?: string
+}
+
+/** Parsed ArchiMate diagram */
+export interface ArchiMateDiagram {
+  layers: Map<ArchiMateLayer, ArchiMateElement[]>
+  elements: Map<string, ArchiMateElement>
+  relationships: ArchiMateRelationship[]
+}
+
+// ============================================================================
+// Positioned ArchiMate diagram — ready for SVG rendering
+// ============================================================================
+
+export interface PositionedArchiMateDiagram {
+  width: number
+  height: number
+  layers: PositionedArchiMateLayer[]
+  elements: PositionedArchiMateElement[]
+  relationships: PositionedArchiMateRelationship[]
+}
+
+export interface PositionedArchiMateLayer {
+  name: ArchiMateLayer
+  x: number
+  y: number
+  width: number
+  height: number
+}
+
+export interface PositionedArchiMateElement {
+  id: string
+  label: string
+  type: ArchiMateElementType
+  layer: ArchiMateLayer
+  x: number
+  y: number
+  width: number
+  height: number
+}
+
+export interface PositionedArchiMateRelationship {
+  source: string
+  target: string
+  type: ArchiMateRelationshipType
+  label?: string
+  points: Array<{ x: number; y: number }>
+}

--- a/src/ascii/archimate-diagram.ts
+++ b/src/ascii/archimate-diagram.ts
@@ -1,0 +1,539 @@
+// ============================================================================
+// ASCII renderer — ArchiMate diagrams
+//
+// Renders archimate-layered text to ASCII/Unicode art.
+// Each element is a box with label and type indicator.
+// Layer bands are horizontal sections with layer name labels.
+// Relationships are drawn as lines between elements with type markers.
+//
+// Layout: elements are placed in layer bands from top to bottom.
+// Within each layer, elements are arranged horizontally.
+// Relationship lines use Manhattan routing between element boxes.
+// ============================================================================
+
+import { parseArchimate } from '../archimate/parser.ts'
+import type {
+  ArchiMateDiagram,
+  ArchiMateElement,
+  ArchiMateLayer,
+  ArchiMateRelationshipType,
+} from '../archimate/types.ts'
+import type { Canvas, AsciiConfig } from './types.ts'
+import { mkCanvas, canvasToString, increaseSize } from './canvas.ts'
+import { drawMultiBox } from './draw.ts'
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+/** Canonical layer ordering from top to bottom */
+const LAYER_ORDER: readonly ArchiMateLayer[] = [
+  'strategy',
+  'motivation',
+  'business',
+  'application',
+  'technology',
+  'physical',
+  'implementation',
+]
+
+/** Human-readable layer display names */
+const LAYER_LABELS: Record<ArchiMateLayer, string> = {
+  business:       'Business',
+  application:    'Application',
+  technology:     'Technology',
+  strategy:       'Strategy',
+  motivation:     'Motivation',
+  physical:       'Physical',
+  implementation: 'Implementation',
+}
+
+// ============================================================================
+// Element box content
+// ============================================================================
+
+/** Convert camelCase type names to human-readable form */
+function formatTypeName(type: string): string {
+  const spaced = type.replace(/([a-z])([A-Z])/g, '$1 $2')
+  return spaced.charAt(0).toUpperCase() + spaced.slice(1)
+}
+
+/** Build sections for an element box: [header with type] */
+function buildElementSections(element: ArchiMateElement): string[][] {
+  const typeLabel = `<<${formatTypeName(element.type)}>>`
+  return [[typeLabel, element.label]]
+}
+
+// ============================================================================
+// Relationship markers
+// ============================================================================
+
+/** Get ASCII relationship line character and arrow marker */
+function getRelationshipMarker(
+  type: ArchiMateRelationshipType,
+  useAscii: boolean,
+  direction: 'up' | 'down' | 'left' | 'right'
+): { lineH: string; lineV: string; startMarker: string; endMarker: string } {
+  const H = useAscii ? '-' : '─'
+  const V = useAscii ? '|' : '│'
+  const dashH = useAscii ? '.' : '╌'
+  const dashV = useAscii ? ':' : '┊'
+
+  const arrowUp = useAscii ? '^' : '▲'
+  const arrowDown = useAscii ? 'v' : '▼'
+  const arrowLeft = useAscii ? '<' : '◄'
+  const arrowRight = useAscii ? '>' : '►'
+
+  const openUp = useAscii ? '^' : '△'
+  const openDown = useAscii ? 'v' : '▽'
+  const openLeft = useAscii ? '<' : '◁'
+  const openRight = useAscii ? '>' : '▷'
+
+  const diamond = useAscii ? '*' : '◆'
+  const openDiamond = useAscii ? 'o' : '◇'
+  const circle = useAscii ? 'o' : '●'
+
+  function dirArrow(up: string, down: string, left: string, right: string): string {
+    switch (direction) {
+      case 'up': return up
+      case 'down': return down
+      case 'left': return left
+      case 'right': return right
+    }
+  }
+
+  switch (type) {
+    case 'composition':
+      return { lineH: H, lineV: V, startMarker: diamond, endMarker: '' }
+    case 'aggregation':
+      return { lineH: H, lineV: V, startMarker: openDiamond, endMarker: '' }
+    case 'assignment':
+      return {
+        lineH: H, lineV: V,
+        startMarker: circle,
+        endMarker: dirArrow(arrowUp, arrowDown, arrowLeft, arrowRight),
+      }
+    case 'realization':
+      return {
+        lineH: dashH, lineV: dashV,
+        startMarker: '',
+        endMarker: dirArrow(openUp, openDown, openLeft, openRight),
+      }
+    case 'serving':
+      return {
+        lineH: H, lineV: V,
+        startMarker: '',
+        endMarker: dirArrow(openUp, openDown, openLeft, openRight),
+      }
+    case 'access':
+      return {
+        lineH: dashH, lineV: dashV,
+        startMarker: '',
+        endMarker: dirArrow(arrowUp, arrowDown, arrowLeft, arrowRight),
+      }
+    case 'influence':
+      return {
+        lineH: dashH, lineV: dashV,
+        startMarker: '',
+        endMarker: dirArrow(openUp, openDown, openLeft, openRight),
+      }
+    case 'triggering':
+      return {
+        lineH: H, lineV: V,
+        startMarker: '',
+        endMarker: dirArrow(arrowUp, arrowDown, arrowLeft, arrowRight),
+      }
+    case 'flow':
+      return {
+        lineH: dashH, lineV: dashV,
+        startMarker: '',
+        endMarker: dirArrow(arrowUp, arrowDown, arrowLeft, arrowRight),
+      }
+    case 'specialization':
+      return {
+        lineH: H, lineV: V,
+        startMarker: '',
+        endMarker: dirArrow(openUp, openDown, openLeft, openRight),
+      }
+    case 'association':
+      return { lineH: H, lineV: V, startMarker: '', endMarker: '' }
+  }
+}
+
+// ============================================================================
+// Positioned element
+// ============================================================================
+
+interface PlacedElement {
+  element: ArchiMateElement
+  sections: string[][]
+  x: number
+  y: number
+  width: number
+  height: number
+}
+
+interface PlacedLayerBand {
+  name: ArchiMateLayer
+  label: string
+  x: number
+  y: number
+  width: number
+  height: number
+}
+
+// ============================================================================
+// Layout and rendering
+// ============================================================================
+
+/**
+ * Render a Mermaid ArchiMate diagram to ASCII/Unicode text.
+ *
+ * Pipeline: parse → build boxes → layer layout → draw layers → draw boxes → draw relationships → string.
+ */
+export function renderArchimateAscii(text: string, config: AsciiConfig): string {
+  const lines = text.split('\n').map(l => l.trim()).filter(l => l.length > 0 && !l.startsWith('%%'))
+  const diagram = parseArchimate(lines)
+
+  if (diagram.elements.size === 0) return ''
+
+  const useAscii = config.useAscii
+  const hGap = 4   // horizontal gap between element boxes
+  const vGap = 3   // vertical gap between layers
+  const layerPadX = 2 // horizontal padding inside layer band
+  const layerPadY = 2 // vertical padding inside layer band (below label)
+  const layerLabelHeight = 1 // rows for the layer label
+
+  // --- Determine present layers in order ---
+  const presentLayers: ArchiMateLayer[] = LAYER_ORDER.filter(
+    layer => diagram.layers.has(layer) && diagram.layers.get(layer)!.length > 0
+  )
+
+  // --- Build element box dimensions ---
+  const elementSections = new Map<string, string[][]>()
+  const elementBoxW = new Map<string, number>()
+  const elementBoxH = new Map<string, number>()
+
+  for (const [id, element] of diagram.elements) {
+    const sections = buildElementSections(element)
+    elementSections.set(id, sections)
+
+    let maxTextW = 0
+    for (const section of sections) {
+      for (const line of section) maxTextW = Math.max(maxTextW, line.length)
+    }
+    const boxW = maxTextW + 4 // 2 border + 2 padding
+
+    let totalLines = 0
+    for (const section of sections) totalLines += Math.max(section.length, 1)
+    const boxH = totalLines + (sections.length - 1) + 2
+
+    elementBoxW.set(id, boxW)
+    elementBoxH.set(id, boxH)
+  }
+
+  // --- Layout: place elements in layer bands ---
+  const placed = new Map<string, PlacedElement>()
+  const layerBands: PlacedLayerBand[] = []
+  let currentY = 0
+
+  for (const layer of presentLayers) {
+    const layerElements = diagram.layers.get(layer) ?? []
+    if (layerElements.length === 0) continue
+
+    const bandStartY = currentY
+    // Layer label row
+    const elementsStartY = bandStartY + layerLabelHeight + layerPadY
+
+    let currentX = layerPadX
+    let maxRowH = 0
+
+    for (const element of layerElements) {
+      const w = elementBoxW.get(element.id)!
+      const h = elementBoxH.get(element.id)!
+
+      placed.set(element.id, {
+        element,
+        sections: elementSections.get(element.id)!,
+        x: currentX,
+        y: elementsStartY,
+        width: w,
+        height: h,
+      })
+
+      currentX += w + hGap
+      maxRowH = Math.max(maxRowH, h)
+    }
+
+    const bandWidth = currentX - hGap + layerPadX
+    const bandHeight = layerLabelHeight + layerPadY + maxRowH + layerPadY
+
+    layerBands.push({
+      name: layer,
+      label: LAYER_LABELS[layer],
+      x: 0,
+      y: bandStartY,
+      width: bandWidth,
+      height: bandHeight,
+    })
+
+    currentY = bandStartY + bandHeight + vGap
+  }
+
+  // Normalize layer band widths to the maximum
+  const maxBandWidth = Math.max(...layerBands.map(b => b.width), 0)
+  for (const band of layerBands) {
+    band.width = maxBandWidth
+  }
+
+  // --- Create canvas ---
+  let totalW = maxBandWidth + 4
+  let totalH = currentY + 2
+
+  // Account for elements that may extend beyond layer bands
+  for (const p of placed.values()) {
+    totalW = Math.max(totalW, p.x + p.width + 2)
+    totalH = Math.max(totalH, p.y + p.height + 2)
+  }
+
+  const canvas = mkCanvas(totalW - 1, totalH - 1)
+
+  // --- Draw layer bands ---
+  for (const band of layerBands) {
+    drawLayerBand(canvas, band, useAscii)
+  }
+
+  // --- Draw element boxes ---
+  for (const p of placed.values()) {
+    const boxCanvas = drawMultiBox(p.sections, useAscii)
+    for (let bx = 0; bx < boxCanvas.length; bx++) {
+      for (let by = 0; by < boxCanvas[0]!.length; by++) {
+        const ch = boxCanvas[bx]![by]!
+        if (ch !== ' ') {
+          const cx = p.x + bx
+          const cy = p.y + by
+          if (cx < totalW && cy < totalH) {
+            canvas[cx]![cy] = ch
+          }
+        }
+      }
+    }
+  }
+
+  // --- Draw relationships ---
+  for (const rel of diagram.relationships) {
+    const srcP = placed.get(rel.source)
+    const tgtP = placed.get(rel.target)
+    if (!srcP || !tgtP) continue
+
+    drawRelationship(canvas, srcP, tgtP, rel.type, rel.label, useAscii, totalW, totalH)
+  }
+
+  return canvasToString(canvas)
+}
+
+// ============================================================================
+// Drawing helpers
+// ============================================================================
+
+/** Draw a layer band border on the canvas */
+function drawLayerBand(canvas: Canvas, band: PlacedLayerBand, useAscii: boolean): void {
+  const { x, y, width, height, label } = band
+  const right = x + width - 1
+  const bottom = y + height - 1
+
+  // Ensure canvas is large enough
+  increaseSize(canvas, right + 1, bottom + 1)
+
+  const hLine = useAscii ? '-' : '─'
+  const vLine = useAscii ? '|' : '│'
+  const tl = useAscii ? '+' : '┌'
+  const tr = useAscii ? '+' : '┐'
+  const bl = useAscii ? '+' : '└'
+  const br = useAscii ? '+' : '┘'
+
+  // Top border
+  canvas[x]![y] = tl
+  for (let cx = x + 1; cx < right; cx++) canvas[cx]![y] = hLine
+  canvas[right]![y] = tr
+
+  // Bottom border
+  canvas[x]![bottom] = bl
+  for (let cx = x + 1; cx < right; cx++) canvas[cx]![bottom] = hLine
+  canvas[right]![bottom] = br
+
+  // Left and right borders
+  for (let cy = y + 1; cy < bottom; cy++) {
+    canvas[x]![cy] = vLine
+    canvas[right]![cy] = vLine
+  }
+
+  // Layer label (inside the band, near top-left)
+  const labelX = x + 2
+  const labelY = y + 1
+  for (let i = 0; i < label.length; i++) {
+    if (labelX + i < right) {
+      canvas[labelX + i]![labelY] = label[i]!
+    }
+  }
+}
+
+/** Draw a relationship line between two placed elements */
+function drawRelationship(
+  canvas: Canvas,
+  srcP: PlacedElement,
+  tgtP: PlacedElement,
+  type: ArchiMateRelationshipType,
+  label: string | undefined,
+  useAscii: boolean,
+  totalW: number,
+  totalH: number,
+): void {
+  const srcCX = srcP.x + Math.floor(srcP.width / 2)
+  const srcCY = srcP.y + Math.floor(srcP.height / 2)
+  const tgtCX = tgtP.x + Math.floor(tgtP.width / 2)
+  const tgtCY = tgtP.y + Math.floor(tgtP.height / 2)
+
+  // Determine primary direction
+  const dx = Math.abs(tgtCX - srcCX)
+  const dy = Math.abs(tgtCY - srcCY)
+
+  if (dy >= dx) {
+    // Primarily vertical connection
+    const goingDown = tgtCY > srcCY
+    const direction = goingDown ? 'down' : 'up'
+    const marker = getRelationshipMarker(type, useAscii, direction)
+
+    const startY = goingDown ? srcP.y + srcP.height : srcP.y - 1
+    const endY = goingDown ? tgtP.y - 1 : tgtP.y + tgtP.height
+
+    // Vertical line from source
+    if (goingDown) {
+      for (let y = startY; y <= endY; y++) {
+        if (y >= 0 && y < totalH) canvas[srcCX]![y] = marker.lineV
+      }
+    } else {
+      for (let y = startY; y >= endY; y--) {
+        if (y >= 0 && y < totalH) canvas[srcCX]![y] = marker.lineV
+      }
+    }
+
+    // Horizontal segment if needed
+    if (srcCX !== tgtCX) {
+      const midY = Math.floor((startY + endY) / 2)
+      const lx = Math.min(srcCX, tgtCX)
+      const rx = Math.max(srcCX, tgtCX)
+      for (let x = lx; x <= rx; x++) {
+        if (x < totalW && midY >= 0 && midY < totalH) canvas[x]![midY] = marker.lineH
+      }
+      // Vertical from midY to target
+      if (goingDown) {
+        for (let y = midY + 1; y <= endY; y++) {
+          if (y >= 0 && y < totalH) canvas[tgtCX]![y] = marker.lineV
+        }
+      } else {
+        for (let y = midY - 1; y >= endY; y--) {
+          if (y >= 0 && y < totalH) canvas[tgtCX]![y] = marker.lineV
+        }
+      }
+    }
+
+    // Start marker
+    if (marker.startMarker) {
+      if (startY >= 0 && startY < totalH) {
+        canvas[srcCX]![startY] = marker.startMarker
+      }
+    }
+
+    // End marker
+    if (marker.endMarker) {
+      if (endY >= 0 && endY < totalH) {
+        canvas[tgtCX]![endY] = marker.endMarker
+      }
+    }
+
+    // Label
+    if (label) {
+      const midY = Math.floor((startY + endY) / 2)
+      const labelX = (srcCX !== tgtCX ? Math.floor((srcCX + tgtCX) / 2) : srcCX) + 2
+      for (let i = 0; i < label.length; i++) {
+        const lx = labelX + i
+        if (lx >= 0 && midY >= 0) {
+          increaseSize(canvas, lx + 1, midY + 1)
+          canvas[lx]![midY] = label[i]!
+        }
+      }
+    }
+  } else {
+    // Primarily horizontal connection
+    const goingRight = tgtCX > srcCX
+    const direction = goingRight ? 'right' : 'left'
+    const marker = getRelationshipMarker(type, useAscii, direction)
+
+    const startX = goingRight ? srcP.x + srcP.width : srcP.x - 1
+    const endX = goingRight ? tgtP.x - 1 : tgtP.x + tgtP.width
+    const lineY = srcCY
+
+    // Horizontal line
+    if (goingRight) {
+      for (let x = startX; x <= endX; x++) {
+        if (x >= 0 && x < totalW && lineY < totalH) canvas[x]![lineY] = marker.lineH
+      }
+    } else {
+      for (let x = startX; x >= endX; x--) {
+        if (x >= 0 && x < totalW && lineY < totalH) canvas[x]![lineY] = marker.lineH
+      }
+    }
+
+    // Vertical segment if needed
+    if (srcCY !== tgtCY) {
+      const midX = Math.floor((startX + endX) / 2)
+      const ly = Math.min(srcCY, tgtCY)
+      const ry = Math.max(srcCY, tgtCY)
+      for (let y = ly; y <= ry; y++) {
+        if (midX >= 0 && midX < totalW && y < totalH) canvas[midX]![y] = marker.lineV
+      }
+      // Horizontal from midX to target
+      const targetY = tgtCY
+      if (goingRight) {
+        for (let x = midX + 1; x <= endX; x++) {
+          if (x >= 0 && x < totalW && targetY < totalH) canvas[x]![targetY] = marker.lineH
+        }
+      } else {
+        for (let x = midX - 1; x >= endX; x--) {
+          if (x >= 0 && x < totalW && targetY < totalH) canvas[x]![targetY] = marker.lineH
+        }
+      }
+    }
+
+    // Start marker
+    if (marker.startMarker) {
+      if (startX >= 0 && startX < totalW && lineY < totalH) {
+        canvas[startX]![lineY] = marker.startMarker
+      }
+    }
+
+    // End marker
+    if (marker.endMarker) {
+      const targetY = srcCY !== tgtCY ? tgtCY : lineY
+      if (endX >= 0 && endX < totalW && targetY < totalH) {
+        canvas[endX]![targetY] = marker.endMarker
+      }
+    }
+
+    // Label
+    if (label) {
+      const midX = Math.floor((startX + endX) / 2)
+      const labelStart = midX - Math.floor(label.length / 2)
+      const labelY = lineY - 1
+      if (labelY >= 0) {
+        for (let i = 0; i < label.length; i++) {
+          const lx = labelStart + i
+          if (lx >= 0 && lx < totalW) {
+            canvas[lx]![labelY] = label[i]!
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/ascii/c4-diagram.ts
+++ b/src/ascii/c4-diagram.ts
@@ -1,0 +1,518 @@
+// ============================================================================
+// ASCII renderer — C4 diagrams
+//
+// Renders C4 diagram text to ASCII/Unicode art.
+// Elements are multi-section boxes with label, technology, and description.
+// Person elements get a stick figure silhouette above the box.
+// Boundaries are dashed-line boxes surrounding their content.
+// Relationships are drawn as horizontal/vertical lines between elements.
+//
+// Layout: elements are placed in a grid pattern (multiple rows if needed).
+// Relationship lines use Manhattan routing between element boxes.
+// ============================================================================
+
+import { parseC4 } from '../c4/parser.ts'
+import type { C4Diagram, C4Element, C4Boundary, C4Relationship } from '../c4/types.ts'
+import type { Canvas, AsciiConfig } from './types.ts'
+import { mkCanvas, canvasToString, increaseSize, drawText } from './canvas.ts'
+import { drawMultiBox } from './draw.ts'
+
+// ============================================================================
+// Element box content
+// ============================================================================
+
+/** Build sections for an element box: [label], [technology + description] */
+function buildElementSections(element: C4Element): string[][] {
+  const header = [element.label]
+  const details: string[] = []
+
+  if (element.technology) {
+    details.push(`[${element.technology}]`)
+  }
+  if (element.description) {
+    details.push(element.description)
+  }
+
+  if (details.length === 0) return [header]
+  return [header, details]
+}
+
+/** Compute box dimensions for an element's sections */
+function computeBoxSize(sections: string[][]): { width: number; height: number } {
+  let maxTextW = 0
+  for (const section of sections) {
+    for (const line of section) maxTextW = Math.max(maxTextW, line.length)
+  }
+  const boxW = maxTextW + 4 // 2 border + 2 padding
+
+  let totalLines = 0
+  for (const section of sections) totalLines += Math.max(section.length, 1)
+  const boxH = totalLines + (sections.length - 1) + 2
+
+  return { width: boxW, height: boxH }
+}
+
+// ============================================================================
+// Person stick figure
+// ============================================================================
+
+/** Height of the stick figure above the person box */
+const PERSON_FIGURE_HEIGHT = 3
+
+/**
+ * Draw a person stick figure on the canvas.
+ * The figure is drawn above the box at (boxX, boxY).
+ *
+ * Unicode:
+ *    ┌─┐
+ *    │ │
+ *   ─┴─┴─
+ *
+ * ASCII:
+ *    +-+
+ *    | |
+ *   -+-+-
+ */
+function drawPersonFigure(
+  canvas: Canvas,
+  boxX: number,
+  boxY: number,
+  boxWidth: number,
+  useAscii: boolean,
+): void {
+  const cx = boxX + Math.floor(boxWidth / 2)
+  const figureY = boxY - PERSON_FIGURE_HEIGHT
+
+  if (figureY < 0) return
+
+  if (useAscii) {
+    // Head: +-+
+    const headX = cx - 1
+    if (headX >= 0) {
+      increaseSize(canvas, headX + 2 + 1, figureY + 1)
+      canvas[headX]![figureY] = '+'
+      canvas[headX + 1]![figureY] = '-'
+      canvas[headX + 2]![figureY] = '+'
+    }
+    // Body: | |
+    if (headX >= 0) {
+      increaseSize(canvas, headX + 2 + 1, figureY + 1 + 1)
+      canvas[headX]![figureY + 1] = '|'
+      canvas[headX + 1]![figureY + 1] = ' '
+      canvas[headX + 2]![figureY + 1] = '|'
+    }
+    // Base: -+-+-
+    const baseX = cx - 2
+    if (baseX >= 0) {
+      increaseSize(canvas, baseX + 4 + 1, figureY + 2 + 1)
+      canvas[baseX]![figureY + 2] = '-'
+      canvas[baseX + 1]![figureY + 2] = '+'
+      canvas[baseX + 2]![figureY + 2] = '-'
+      canvas[baseX + 3]![figureY + 2] = '+'
+      canvas[baseX + 4]![figureY + 2] = '-'
+    }
+  } else {
+    // Head: ┌─┐
+    const headX = cx - 1
+    if (headX >= 0) {
+      increaseSize(canvas, headX + 2 + 1, figureY + 1)
+      canvas[headX]![figureY] = '\u250C'     // ┌
+      canvas[headX + 1]![figureY] = '\u2500'  // ─
+      canvas[headX + 2]![figureY] = '\u2510'  // ┐
+    }
+    // Body: │ │
+    if (headX >= 0) {
+      increaseSize(canvas, headX + 2 + 1, figureY + 1 + 1)
+      canvas[headX]![figureY + 1] = '\u2502'      // │
+      canvas[headX + 1]![figureY + 1] = ' '
+      canvas[headX + 2]![figureY + 1] = '\u2502'  // │
+    }
+    // Base: ─┴─┴─
+    const baseX = cx - 2
+    if (baseX >= 0) {
+      increaseSize(canvas, baseX + 4 + 1, figureY + 2 + 1)
+      canvas[baseX]![figureY + 2] = '\u2500'      // ─
+      canvas[baseX + 1]![figureY + 2] = '\u2534'  // ┴
+      canvas[baseX + 2]![figureY + 2] = '\u2500'  // ─
+      canvas[baseX + 3]![figureY + 2] = '\u2534'  // ┴
+      canvas[baseX + 4]![figureY + 2] = '\u2500'  // ─
+    }
+  }
+}
+
+// ============================================================================
+// Boundary box drawing
+// ============================================================================
+
+/**
+ * Draw a dashed-line boundary box on the canvas.
+ *
+ * Unicode uses box-drawing dashes: ╌ (horizontal) and ┊ (vertical).
+ * ASCII uses . (horizontal) and : (vertical).
+ */
+function drawBoundaryBox(
+  canvas: Canvas,
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+  label: string,
+  useAscii: boolean,
+): void {
+  if (width <= 0 || height <= 0) return
+  // Clamp negative coordinates to 0
+  if (x < 0) { width += x; x = 0 }
+  if (y < 0) { height += y; y = 0 }
+  if (width <= 0 || height <= 0) return
+
+  const right = x + width - 1
+  const bottom = y + height - 1
+
+  increaseSize(canvas, right + 1, bottom + 1)
+
+  const hDash = useAscii ? '.' : '\u254C' // ╌
+  const vDash = useAscii ? ':' : '\u250A' // ┊
+  const corner = useAscii ? '+' : '+'
+
+  // Corners
+  canvas[x]![y] = corner
+  canvas[right]![y] = corner
+  canvas[x]![bottom] = corner
+  canvas[right]![bottom] = corner
+
+  // Top and bottom edges
+  for (let cx = x + 1; cx < right; cx++) {
+    canvas[cx]![y] = hDash
+    canvas[cx]![bottom] = hDash
+  }
+
+  // Left and right edges
+  for (let cy = y + 1; cy < bottom; cy++) {
+    canvas[x]![cy] = vDash
+    canvas[right]![cy] = vDash
+  }
+
+  // Label in top-left corner, inside the border
+  if (label.length > 0) {
+    const labelX = x + 2
+    const labelY = y + 1
+    if (labelY < bottom) {
+      for (let i = 0; i < label.length; i++) {
+        const lx = labelX + i
+        if (lx < right) {
+          canvas[lx]![labelY] = label[i]!
+        }
+      }
+    }
+  }
+}
+
+// ============================================================================
+// Positioned element
+// ============================================================================
+
+interface PlacedElement {
+  element: C4Element
+  sections: string[][]
+  x: number
+  y: number
+  width: number
+  height: number
+}
+
+// ============================================================================
+// Layout and rendering
+// ============================================================================
+
+/**
+ * Render a Mermaid C4 diagram to ASCII/Unicode text.
+ *
+ * Pipeline: parse -> build boxes -> grid layout -> draw boundaries -> draw boxes -> draw relationships -> string.
+ */
+export function renderC4Ascii(text: string, config: AsciiConfig): string {
+  const lines = text.split('\n').map(l => l.trim()).filter(l => l.length > 0 && !l.startsWith('%%'))
+  const diagram = parseC4(lines)
+
+  if (diagram.elements.length === 0) return ''
+
+  const useAscii = config.useAscii
+  const hGap = 6  // horizontal gap between element boxes
+  const vGap = 4  // vertical gap between rows
+
+  // --- Build element box dimensions ---
+  const elementSections = new Map<string, string[][]>()
+  const elementBoxW = new Map<string, number>()
+  const elementBoxH = new Map<string, number>()
+
+  for (const el of diagram.elements) {
+    const sections = buildElementSections(el)
+    elementSections.set(el.alias, sections)
+
+    const size = computeBoxSize(sections)
+
+    // Person elements need extra height for the stick figure
+    const extraH = el.kind === 'Person' ? PERSON_FIGURE_HEIGHT : 0
+
+    elementBoxW.set(el.alias, Math.max(size.width, 16))
+    elementBoxH.set(el.alias, size.height + extraH)
+  }
+
+  // --- Layout: place elements in rows ---
+  const maxPerRow = Math.max(2, Math.ceil(Math.sqrt(diagram.elements.length)))
+
+  const placed = new Map<string, PlacedElement>()
+  let currentX = 0
+  let currentY = 0
+  let maxRowH = 0
+  let colCount = 0
+
+  for (const el of diagram.elements) {
+    const w = elementBoxW.get(el.alias)!
+    const h = elementBoxH.get(el.alias)!
+
+    if (colCount >= maxPerRow) {
+      currentY += maxRowH + vGap
+      currentX = 0
+      maxRowH = 0
+      colCount = 0
+    }
+
+    placed.set(el.alias, {
+      element: el,
+      sections: elementSections.get(el.alias)!,
+      x: currentX,
+      y: currentY,
+      width: w,
+      height: h,
+    })
+
+    currentX += w + hGap
+    maxRowH = Math.max(maxRowH, h)
+    colCount++
+  }
+
+  // --- Create canvas ---
+  let totalW = 0
+  let totalH = 0
+  for (const p of placed.values()) {
+    totalW = Math.max(totalW, p.x + p.width)
+    totalH = Math.max(totalH, p.y + p.height)
+  }
+  totalW += 4
+  totalH += 2
+
+  const canvas = mkCanvas(totalW - 1, totalH - 1)
+
+  // --- Draw boundary boxes ---
+  drawBoundariesRecursive(canvas, diagram.boundaries, placed, useAscii)
+
+  // --- Draw element boxes ---
+  for (const p of placed.values()) {
+    const isPerson = p.element.kind === 'Person'
+    const boxY = isPerson ? p.y + PERSON_FIGURE_HEIGHT : p.y
+    const boxSections = p.sections
+
+    const boxCanvas = drawMultiBox(boxSections, useAscii)
+    for (let bx = 0; bx < boxCanvas.length; bx++) {
+      for (let by = 0; by < boxCanvas[0]!.length; by++) {
+        const ch = boxCanvas[bx]![by]!
+        if (ch !== ' ') {
+          const cx = p.x + bx
+          const cy = boxY + by
+          if (cx < totalW && cy < totalH) {
+            canvas[cx]![cy] = ch
+          }
+        }
+      }
+    }
+
+    // Draw stick figure for Person elements
+    if (isPerson) {
+      const boxW = computeBoxSize(boxSections).width
+      drawPersonFigure(canvas, p.x, boxY, boxW, useAscii)
+    }
+  }
+
+  // --- Draw relationships ---
+  const H = useAscii ? '-' : '\u2500'  // ─
+  const V = useAscii ? '|' : '\u2502'  // │
+
+  for (const rel of diagram.relationships) {
+    const e1 = placed.get(rel.from)
+    const e2 = placed.get(rel.to)
+    if (!e1 || !e2) continue
+
+    const e1CX = e1.x + Math.floor(e1.width / 2)
+    const e1CY = e1.y + Math.floor(e1.height / 2)
+    const e2CX = e2.x + Math.floor(e2.width / 2)
+    const e2CY = e2.y + Math.floor(e2.height / 2)
+
+    const sameRow = Math.abs(e1CY - e2CY) < Math.max(e1.height, e2.height)
+
+    if (sameRow) {
+      // Horizontal connection
+      const [left, right] = e1CX < e2CX ? [e1, e2] : [e2, e1]
+      const startX = left.x + left.width
+      const endX = right.x - 1
+      const lineY = left.y + Math.floor(left.height / 2)
+
+      for (let lx = startX; lx <= endX; lx++) {
+        if (lx < totalW) canvas[lx]![lineY] = H
+      }
+
+      // Arrow head at right end
+      if (endX >= 0 && endX < totalW) {
+        canvas[endX]![lineY] = useAscii ? '>' : '\u25BA' // ►
+      }
+
+      // Relationship label centered in the gap, above the line
+      const labelText = buildRelLabel(rel)
+      if (labelText) {
+        const gapMid = Math.floor((startX + endX) / 2)
+        const labelStart = Math.max(startX, gapMid - Math.floor(labelText.length / 2))
+        const labelY = lineY - 1
+        if (labelY >= 0) {
+          for (let i = 0; i < labelText.length; i++) {
+            const lx = labelStart + i
+            if (lx >= startX && lx <= endX && lx < totalW) {
+              canvas[lx]![labelY] = labelText[i]!
+            }
+          }
+        }
+      }
+    } else {
+      // Vertical connection
+      const [upper, lower] = e1CY < e2CY ? [e1, e2] : [e2, e1]
+      const startY = upper.y + upper.height
+      const endY = lower.y - 1
+      const lineX = upper.x + Math.floor(upper.width / 2)
+
+      for (let ly = startY; ly <= endY; ly++) {
+        if (ly < totalH) canvas[lineX]![ly] = V
+      }
+
+      // Arrow head at bottom end
+      if (endY >= 0 && endY < totalH) {
+        canvas[lineX]![endY] = useAscii ? 'v' : '\u25BC' // ▼
+      }
+
+      // Horizontal adjustment if needed
+      const lowerCX = lower.x + Math.floor(lower.width / 2)
+      if (lineX !== lowerCX) {
+        const midY = Math.floor((startY + endY) / 2)
+        const lx = Math.min(lineX, lowerCX)
+        const rx = Math.max(lineX, lowerCX)
+        for (let lxi = lx; lxi <= rx; lxi++) {
+          if (lxi < totalW && midY < totalH) canvas[lxi]![midY] = H
+        }
+        for (let ly = midY + 1; ly <= endY; ly++) {
+          if (ly < totalH) canvas[lowerCX]![ly] = V
+        }
+        // Arrow head at bottom of adjusted line
+        if (endY >= 0 && endY < totalH) {
+          canvas[lowerCX]![endY] = useAscii ? 'v' : '\u25BC' // ▼
+        }
+      }
+
+      // Relationship label to the right of the vertical line
+      const labelText = buildRelLabel(rel)
+      if (labelText) {
+        const midY = Math.floor((startY + endY) / 2)
+        const labelX = lineX + 2
+        if (midY >= 0) {
+          for (let i = 0; i < labelText.length; i++) {
+            const lx = labelX + i
+            if (lx >= 0) {
+              increaseSize(canvas, lx + 1, midY + 1)
+              canvas[lx]![midY] = labelText[i]!
+            }
+          }
+        }
+      }
+    }
+  }
+
+  return canvasToString(canvas)
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/** Build a relationship label combining label and optional technology */
+function buildRelLabel(rel: C4Relationship): string {
+  if (rel.technology) {
+    return `${rel.label} [${rel.technology}]`
+  }
+  return rel.label
+}
+
+/** Recursively draw boundary boxes around their child elements */
+function drawBoundariesRecursive(
+  canvas: Canvas,
+  boundaries: C4Boundary[],
+  placed: Map<string, PlacedElement>,
+  useAscii: boolean,
+): void {
+  for (const boundary of boundaries) {
+    // Find bounding box of all elements in this boundary
+    let minX = Infinity
+    let minY = Infinity
+    let maxX = -Infinity
+    let maxY = -Infinity
+
+    for (const el of boundary.elements) {
+      const p = placed.get(el.alias)
+      if (p) {
+        minX = Math.min(minX, p.x)
+        minY = Math.min(minY, p.y)
+        maxX = Math.max(maxX, p.x + p.width)
+        maxY = Math.max(maxY, p.y + p.height)
+      }
+    }
+
+    // Include child boundaries in the bounding box
+    collectChildBoundaryBounds(boundary.childBoundaries, placed, {
+      update(x1: number, y1: number, x2: number, y2: number) {
+        minX = Math.min(minX, x1)
+        minY = Math.min(minY, y1)
+        maxX = Math.max(maxX, x2)
+        maxY = Math.max(maxY, y2)
+      },
+    })
+
+    if (minX !== Infinity) {
+      // Add padding around elements
+      const padX = 2
+      const padY = 2
+      const headerH = 2 // space for boundary label
+
+      const bx = minX - padX
+      const by = minY - padY - headerH
+      const bw = (maxX - minX) + padX * 2 + 1
+      const bh = (maxY - minY) + padY * 2 + headerH + 1
+
+      drawBoundaryBox(canvas, bx, by, bw, bh, boundary.label, useAscii)
+    }
+
+    // Recursively draw child boundaries
+    drawBoundariesRecursive(canvas, boundary.childBoundaries, placed, useAscii)
+  }
+}
+
+/** Collect bounding box coordinates from nested child boundaries */
+function collectChildBoundaryBounds(
+  boundaries: C4Boundary[],
+  placed: Map<string, PlacedElement>,
+  accumulator: { update(x1: number, y1: number, x2: number, y2: number): void },
+): void {
+  for (const boundary of boundaries) {
+    for (const el of boundary.elements) {
+      const p = placed.get(el.alias)
+      if (p) {
+        accumulator.update(p.x, p.y, p.x + p.width, p.y + p.height)
+      }
+    }
+    collectChildBoundaryBounds(boundary.childBoundaries, placed, accumulator)
+  }
+}

--- a/src/ascii/index.ts
+++ b/src/ascii/index.ts
@@ -10,6 +10,8 @@
 //   - Sequence diagrams (sequenceDiagram) — column-based timeline layout
 //   - Class diagrams (classDiagram) — level-based UML layout
 //   - ER diagrams (erDiagram) — grid layout with crow's foot notation
+//   - C4 diagrams (C4Context / C4Container / C4Component / C4Dynamic / C4Deployment)
+//   - ArchiMate diagrams (archimate-layered)
 //
 // Usage:
 //   import { renderMermaidAscii } from 'beautiful-mermaid'
@@ -24,6 +26,8 @@ import { canvasToString, flipCanvasVertically } from './canvas.ts'
 import { renderSequenceAscii } from './sequence.ts'
 import { renderClassAscii } from './class-diagram.ts'
 import { renderErAscii } from './er-diagram.ts'
+import { renderC4Ascii } from './c4-diagram.ts'
+import { renderArchimateAscii } from './archimate-diagram.ts'
 import type { AsciiConfig } from './types.ts'
 
 export interface AsciiRenderOptions {
@@ -41,12 +45,14 @@ export interface AsciiRenderOptions {
  * Detect the diagram type from the mermaid source text.
  * Mirrors the detection logic in src/index.ts for the SVG renderer.
  */
-function detectDiagramType(text: string): 'flowchart' | 'sequence' | 'class' | 'er' {
-  const firstLine = text.trim().split('\n')[0]?.trim().toLowerCase() ?? ''
+function detectDiagramType(text: string): 'flowchart' | 'sequence' | 'class' | 'er' | 'c4' | 'archimate' {
+  const firstLine = text.trim().split('\n')[0]?.trim() ?? ''
 
-  if (/^sequencediagram\s*$/.test(firstLine)) return 'sequence'
-  if (/^classdiagram\s*$/.test(firstLine)) return 'class'
-  if (/^erdiagram\s*$/.test(firstLine)) return 'er'
+  if (/^sequencediagram\s*$/i.test(firstLine)) return 'sequence'
+  if (/^classdiagram\s*$/i.test(firstLine)) return 'class'
+  if (/^erdiagram\s*$/i.test(firstLine)) return 'er'
+  if (/^c4(context|container|component|dynamic|deployment)\s*$/i.test(firstLine)) return 'c4'
+  if (/^archimate-layered\s*$/i.test(firstLine)) return 'archimate'
 
   // Default: flowchart/state (handled by parseMermaid internally)
   return 'flowchart'
@@ -101,6 +107,12 @@ export function renderMermaidAscii(
 
     case 'er':
       return renderErAscii(text, config)
+
+    case 'c4':
+      return renderC4Ascii(text, config)
+
+    case 'archimate':
+      return renderArchimateAscii(text, config)
 
     case 'flowchart':
     default: {

--- a/src/c4/layout.ts
+++ b/src/c4/layout.ts
@@ -1,0 +1,305 @@
+// @ts-expect-error — dagre types are declared for the package root, not the dist path;
+// importing the pre-built browser bundle avoids Bun.build hanging on 30+ CJS file resolution
+import dagre from '@dagrejs/dagre/dist/dagre.js'
+import type {
+  C4Diagram,
+  C4Element,
+  C4Boundary,
+  PositionedC4Diagram,
+  PositionedC4Element,
+  PositionedC4Relationship,
+  PositionedC4Boundary,
+} from './types.ts'
+import type { RenderOptions } from '../types.ts'
+import { estimateTextWidth, FONT_SIZES, FONT_WEIGHTS } from '../styles.ts'
+import { centerToTopLeft, snapToOrthogonal, clipEndpointsToNodes } from '../dagre-adapter.ts'
+
+// ============================================================================
+// C4 diagram layout engine
+//
+// Uses dagre for positioning element boxes, then calculates boundary positions
+// by finding the bounding box of their child elements with padding.
+//
+// Element box sizing:
+//   - Person: 160 wide, 180 tall (taller for stick figure silhouette)
+//   - System/Container/Component: min 160 wide, height based on text content
+//   - Boundaries: wrap children with padding
+// ============================================================================
+
+/** Layout constants for C4 diagrams */
+const C4 = {
+  padding: 40,
+  boxPadX: 16,
+  boxPadY: 12,
+  personWidth: 160,
+  personHeight: 180,
+  minBoxWidth: 160,
+  minBoxHeight: 80,
+  lineHeight: 18,
+  boundaryPadding: 30,
+  boundaryHeaderHeight: 28,
+  nodeSpacing: 60,
+  layerSpacing: 80,
+  titleFontSize: 14,
+  titleFontWeight: 600,
+  descFontSize: 11,
+  descFontWeight: 400,
+  techFontSize: 10,
+  techFontWeight: 400,
+} as const
+
+/**
+ * Lay out a parsed C4 diagram using dagre.
+ * Returns positioned element boxes, relationship paths, and boundary rectangles.
+ *
+ * Kept async for API compatibility — dagre itself is synchronous.
+ */
+export async function layoutC4Diagram(
+  diagram: C4Diagram,
+  _options: RenderOptions = {}
+): Promise<PositionedC4Diagram> {
+  if (diagram.elements.length === 0) {
+    return { width: 0, height: 0, elements: [], relationships: [], boundaries: [] }
+  }
+
+  // 1. Calculate box dimensions for each element
+  const elementSizes = new Map<string, { width: number; height: number }>()
+
+  for (const element of diagram.elements) {
+    const size = calculateElementSize(element)
+    elementSizes.set(element.alias, size)
+  }
+
+  // 2. Build dagre graph
+  const g = new dagre.graphlib.Graph({ directed: true })
+  g.setGraph({
+    rankdir: 'TB',
+    acyclicer: 'greedy',
+    nodesep: C4.nodeSpacing,
+    ranksep: C4.layerSpacing,
+    marginx: C4.padding,
+    marginy: C4.padding,
+  })
+  g.setDefaultEdgeLabel(() => ({}))
+
+  for (const element of diagram.elements) {
+    const size = elementSizes.get(element.alias)!
+    g.setNode(element.alias, { width: size.width, height: size.height })
+  }
+
+  for (let i = 0; i < diagram.relationships.length; i++) {
+    const rel = diagram.relationships[i]!
+    const labelText = rel.technology ? `${rel.label} [${rel.technology}]` : rel.label
+    g.setEdge(rel.from, rel.to, {
+      _index: i,
+      label: labelText,
+      width: estimateTextWidth(labelText, FONT_SIZES.edgeLabel, FONT_WEIGHTS.edgeLabel) + 8,
+      height: FONT_SIZES.edgeLabel + 6,
+      labelpos: 'c',
+    })
+  }
+
+  // 3. Run dagre layout
+  try {
+    dagre.layout(g)
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    throw new Error(`Dagre layout failed (C4 diagram): ${message}`)
+  }
+
+  // 4. Extract positioned elements
+  const positionedElements: PositionedC4Element[] = diagram.elements.map(element => {
+    const dagreNode = g.node(element.alias)
+    const size = elementSizes.get(element.alias)!
+    const topLeft = centerToTopLeft(dagreNode.x, dagreNode.y, dagreNode.width, dagreNode.height)
+    return {
+      kind: element.kind,
+      alias: element.alias,
+      label: element.label,
+      description: element.description,
+      technology: element.technology,
+      external: element.external,
+      x: topLeft.x,
+      y: topLeft.y,
+      width: dagreNode.width ?? size.width,
+      height: dagreNode.height ?? size.height,
+    }
+  })
+
+  // Build element lookup for boundary calculation
+  const elementLookup = new Map<string, PositionedC4Element>()
+  for (const el of positionedElements) {
+    elementLookup.set(el.alias, el)
+  }
+
+  // 5. Extract relationship paths
+  const relationships: PositionedC4Relationship[] = g.edges().map(edgeObj => {
+    const dagreEdge = g.edge(edgeObj)
+    const rel = diagram.relationships[dagreEdge._index as number]!
+    const rawPoints = dagreEdge.points ?? []
+    // TB layout -> vertical-first bends
+    const orthoPoints = snapToOrthogonal(rawPoints, true)
+
+    const srcNode = g.node(edgeObj.v)
+    const tgtNode = g.node(edgeObj.w)
+    const points = clipEndpointsToNodes(
+      orthoPoints,
+      srcNode ? { cx: srcNode.x, cy: srcNode.y, hw: srcNode.width / 2, hh: srcNode.height / 2 } : null,
+      tgtNode ? { cx: tgtNode.x, cy: tgtNode.y, hw: tgtNode.width / 2, hh: tgtNode.height / 2 } : null,
+    )
+
+    return {
+      from: rel.from,
+      to: rel.to,
+      label: rel.label,
+      technology: rel.technology,
+      points,
+    }
+  })
+
+  // 6. Calculate boundary positions from child element bounding boxes
+  const positionedBoundaries = layoutBoundaries(diagram.boundaries, elementLookup)
+
+  // 7. Calculate overall diagram size
+  // Account for boundaries that may extend beyond element positions
+  let maxW = g.graph().width ?? 600
+  let maxH = g.graph().height ?? 400
+  for (const b of flattenBoundaries(positionedBoundaries)) {
+    maxW = Math.max(maxW, b.x + b.width + C4.padding)
+    maxH = Math.max(maxH, b.y + b.height + C4.padding)
+  }
+
+  return {
+    width: maxW,
+    height: maxH,
+    title: diagram.title,
+    elements: positionedElements,
+    relationships,
+    boundaries: positionedBoundaries,
+  }
+}
+
+// ============================================================================
+// Element sizing
+// ============================================================================
+
+/** Calculate the box size for a C4 element based on its text content */
+function calculateElementSize(element: C4Element): { width: number; height: number } {
+  if (element.kind === 'Person') {
+    return { width: C4.personWidth, height: C4.personHeight }
+  }
+
+  // Calculate width from text content
+  const labelW = estimateTextWidth(element.label, FONT_SIZES.nodeLabel, FONT_WEIGHTS.nodeLabel)
+  let maxTextW = labelW
+
+  if (element.technology) {
+    const techText = `[${element.technology}]`
+    const techW = estimateTextWidth(techText, C4.techFontSize, C4.techFontWeight)
+    maxTextW = Math.max(maxTextW, techW)
+  }
+
+  if (element.description) {
+    const descW = estimateTextWidth(element.description, C4.descFontSize, C4.descFontWeight)
+    maxTextW = Math.max(maxTextW, descW)
+  }
+
+  const width = Math.max(C4.minBoxWidth, maxTextW + C4.boxPadX * 2)
+
+  // Calculate height from text lines
+  let textLines = 1 // label
+  if (element.technology) textLines++
+  if (element.description) textLines++
+
+  const height = Math.max(C4.minBoxHeight, textLines * C4.lineHeight + C4.boxPadY * 2)
+
+  return { width, height }
+}
+
+// ============================================================================
+// Boundary layout
+// ============================================================================
+
+/** Recursively lay out boundaries based on their child element positions */
+function layoutBoundaries(
+  boundaries: C4Boundary[],
+  elementLookup: Map<string, PositionedC4Element>,
+): PositionedC4Boundary[] {
+  return boundaries.map(boundary => {
+    // Recursively position child boundaries first
+    const children = layoutBoundaries(boundary.childBoundaries, elementLookup)
+
+    // Collect all bounding rects: direct child elements + child boundary rects
+    const rects: Array<{ x: number; y: number; right: number; bottom: number }> = []
+
+    for (const element of boundary.elements) {
+      const pos = elementLookup.get(element.alias)
+      if (pos) {
+        rects.push({
+          x: pos.x,
+          y: pos.y,
+          right: pos.x + pos.width,
+          bottom: pos.y + pos.height,
+        })
+      }
+    }
+
+    for (const child of children) {
+      rects.push({
+        x: child.x,
+        y: child.y,
+        right: child.x + child.width,
+        bottom: child.y + child.height,
+      })
+    }
+
+    if (rects.length === 0) {
+      // Empty boundary — give it a minimal size
+      return {
+        alias: boundary.alias,
+        label: boundary.label,
+        kind: boundary.kind,
+        x: 0,
+        y: 0,
+        width: C4.minBoxWidth,
+        height: C4.minBoxHeight,
+        children,
+      }
+    }
+
+    // Find bounding box of all children
+    let minX = Infinity
+    let minY = Infinity
+    let maxX = -Infinity
+    let maxY = -Infinity
+
+    for (const rect of rects) {
+      minX = Math.min(minX, rect.x)
+      minY = Math.min(minY, rect.y)
+      maxX = Math.max(maxX, rect.right)
+      maxY = Math.max(maxY, rect.bottom)
+    }
+
+    // Add padding around children
+    return {
+      alias: boundary.alias,
+      label: boundary.label,
+      kind: boundary.kind,
+      x: minX - C4.boundaryPadding,
+      y: minY - C4.boundaryPadding - C4.boundaryHeaderHeight,
+      width: (maxX - minX) + C4.boundaryPadding * 2,
+      height: (maxY - minY) + C4.boundaryPadding * 2 + C4.boundaryHeaderHeight,
+      children,
+    }
+  })
+}
+
+/** Flatten nested boundaries into a single array for size calculations */
+function flattenBoundaries(boundaries: PositionedC4Boundary[]): PositionedC4Boundary[] {
+  const result: PositionedC4Boundary[] = []
+  for (const b of boundaries) {
+    result.push(b)
+    result.push(...flattenBoundaries(b.children))
+  }
+  return result
+}

--- a/src/c4/parser.ts
+++ b/src/c4/parser.ts
@@ -1,0 +1,298 @@
+import type {
+  C4Diagram,
+  C4DiagramType,
+  C4Element,
+  C4ElementKind,
+  C4Relationship,
+  C4Boundary,
+  C4BoundaryKind,
+} from './types.ts'
+
+// ============================================================================
+// C4 diagram parser
+//
+// Parses Mermaid C4 diagram syntax into a C4Diagram structure.
+//
+// Supported syntax:
+//   C4Context / C4Container / C4Component / C4Dynamic / C4Deployment
+//
+//   Person(alias, "label", "description")
+//   Person_Ext(alias, "label", "description")
+//   System(alias, "label", "description")
+//   System_Ext(alias, "label", "description")
+//   Container(alias, "label", "technology", "description")
+//   ContainerDb(alias, "label", "technology", "description")
+//   ContainerQueue(alias, "label", "technology", "description")
+//   Component(alias, "label", "technology", "description")
+//   ComponentDb(alias, "label", "technology", "description")
+//   ComponentQueue(alias, "label", "technology", "description")
+//   *_Ext variants for external elements
+//
+//   System_Boundary(alias, "label") { ... }
+//   Container_Boundary(alias, "label") { ... }
+//   Enterprise_Boundary(alias, "label") { ... }
+//   Boundary(alias, "label") { ... }
+//   Deployment_Node(alias, "label", "technology") { ... }
+//
+//   Rel(from, to, "label", "technology")
+//   Rel_D / Rel_U / Rel_L / Rel_R / Rel_Back(from, to, "label", "technology")
+//   BiRel(from, to, "label", "technology")
+// ============================================================================
+
+const DIAGRAM_TYPES: ReadonlySet<string> = new Set([
+  'C4Context', 'C4Container', 'C4Component', 'C4Dynamic', 'C4Deployment',
+])
+
+/** Element keywords mapped to their kind and argument order */
+interface ElementSpec {
+  kind: C4ElementKind
+  /** Whether args are (alias, label, desc) or (alias, label, tech, desc) */
+  hasTechnology: boolean
+}
+
+const ELEMENT_SPECS: ReadonlyMap<string, ElementSpec> = new Map([
+  // Person variants
+  ['Person',           { kind: 'Person',         hasTechnology: false }],
+  ['Person_Ext',       { kind: 'Person',         hasTechnology: false }],
+  // System variants
+  ['System',           { kind: 'System',         hasTechnology: false }],
+  ['System_Ext',       { kind: 'System',         hasTechnology: false }],
+  // Container variants
+  ['Container',        { kind: 'Container',      hasTechnology: true }],
+  ['Container_Ext',    { kind: 'Container',      hasTechnology: true }],
+  ['ContainerDb',      { kind: 'ContainerDb',    hasTechnology: true }],
+  ['ContainerDb_Ext',  { kind: 'ContainerDb',    hasTechnology: true }],
+  ['ContainerQueue',   { kind: 'ContainerQueue', hasTechnology: true }],
+  ['ContainerQueue_Ext', { kind: 'ContainerQueue', hasTechnology: true }],
+  // Component variants
+  ['Component',        { kind: 'Component',      hasTechnology: true }],
+  ['Component_Ext',    { kind: 'Component',      hasTechnology: true }],
+  ['ComponentDb',      { kind: 'ComponentDb',     hasTechnology: true }],
+  ['ComponentDb_Ext',  { kind: 'ComponentDb',     hasTechnology: true }],
+  ['ComponentQueue',   { kind: 'ComponentQueue',  hasTechnology: true }],
+  ['ComponentQueue_Ext', { kind: 'ComponentQueue', hasTechnology: true }],
+])
+
+const BOUNDARY_KINDS: ReadonlyMap<string, C4BoundaryKind> = new Map([
+  ['Boundary',             'Boundary'],
+  ['System_Boundary',      'System_Boundary'],
+  ['Container_Boundary',   'Container_Boundary'],
+  ['Enterprise_Boundary',  'Enterprise_Boundary'],
+  ['Deployment_Node',      'Deployment_Node'],
+])
+
+/** Direction suffixes for Rel variants */
+const REL_DIRECTIONS: ReadonlyMap<string, C4Relationship['direction']> = new Map([
+  ['Rel_D',    'D'],
+  ['Rel_U',    'U'],
+  ['Rel_L',    'L'],
+  ['Rel_R',    'R'],
+  ['Rel_Back', 'Back'],
+])
+
+/**
+ * Parse a Mermaid C4 diagram.
+ * Expects the first line to be a C4 diagram type keyword.
+ */
+export function parseC4(lines: string[]): C4Diagram {
+  const firstLine = lines[0]?.trim() ?? ''
+  const diagramType = (DIAGRAM_TYPES.has(firstLine) ? firstLine : 'C4Context') as C4DiagramType
+
+  const diagram: C4Diagram = {
+    type: diagramType,
+    elements: [],
+    relationships: [],
+    boundaries: [],
+  }
+
+  // Boundary nesting stack — the current scope for elements
+  const boundaryStack: C4Boundary[] = []
+
+  for (let i = 1; i < lines.length; i++) {
+    const line = lines[i]!
+
+    // --- Title ---
+    const titleMatch = line.match(/^title\s+(.+)$/i)
+    if (titleMatch) {
+      diagram.title = unquote(titleMatch[1]!.trim())
+      continue
+    }
+
+    // --- Closing brace ---
+    if (line === '}') {
+      boundaryStack.pop()
+      continue
+    }
+
+    // --- Boundary opening ---
+    const boundaryMatch = line.match(/^(\w+)\s*\(([^)]*)\)\s*\{$/)
+    if (boundaryMatch) {
+      const keyword = boundaryMatch[1]!
+      const boundaryKind = BOUNDARY_KINDS.get(keyword)
+      if (boundaryKind) {
+        const args = parseArgs(boundaryMatch[2]!)
+        const alias = unquote(args[0] ?? '')
+        const label = unquote(args[1] ?? alias)
+        const parentAlias = boundaryStack.length > 0
+          ? boundaryStack[boundaryStack.length - 1]!.alias
+          : undefined
+
+        const boundary: C4Boundary = {
+          alias,
+          label,
+          kind: boundaryKind,
+          elements: [],
+          childBoundaries: [],
+          parentBoundary: parentAlias,
+        }
+
+        if (boundaryStack.length > 0) {
+          boundaryStack[boundaryStack.length - 1]!.childBoundaries.push(boundary)
+        } else {
+          diagram.boundaries.push(boundary)
+        }
+
+        boundaryStack.push(boundary)
+        continue
+      }
+    }
+
+    // --- Element declaration ---
+    const elementMatch = line.match(/^(\w+)\s*\(([^)]*)\)$/)
+    if (elementMatch) {
+      const keyword = elementMatch[1]!
+      const spec = ELEMENT_SPECS.get(keyword)
+      if (spec) {
+        const element = parseElement(keyword, spec, elementMatch[2]!, boundaryStack)
+        if (boundaryStack.length > 0) {
+          boundaryStack[boundaryStack.length - 1]!.elements.push(element)
+        }
+        diagram.elements.push(element)
+        continue
+      }
+
+      // --- Relationship declaration ---
+      const rel = parseRelationship(keyword, elementMatch[2]!)
+      if (rel) {
+        diagram.relationships.push(rel)
+        continue
+      }
+    }
+  }
+
+  return diagram
+}
+
+// ============================================================================
+// Argument parsing
+// ============================================================================
+
+/**
+ * Parse a comma-separated argument list, handling quoted strings.
+ * Supports both quoted ("value") and unquoted (value) arguments.
+ */
+function parseArgs(argsStr: string): string[] {
+  const args: string[] = []
+  let current = ''
+  let inQuotes = false
+
+  for (let i = 0; i < argsStr.length; i++) {
+    const ch = argsStr[i]!
+
+    if (ch === '"') {
+      inQuotes = !inQuotes
+      current += ch
+    } else if (ch === ',' && !inQuotes) {
+      args.push(current.trim())
+      current = ''
+    } else {
+      current += ch
+    }
+  }
+
+  if (current.trim().length > 0) {
+    args.push(current.trim())
+  }
+
+  return args
+}
+
+/** Remove surrounding quotes from a string */
+function unquote(s: string): string {
+  if (s.length >= 2 && s[0] === '"' && s[s.length - 1] === '"') {
+    return s.slice(1, -1)
+  }
+  return s
+}
+
+// ============================================================================
+// Element parsing
+// ============================================================================
+
+function parseElement(
+  keyword: string,
+  spec: ElementSpec,
+  argsStr: string,
+  boundaryStack: C4Boundary[],
+): C4Element {
+  const args = parseArgs(argsStr)
+  const external = keyword.endsWith('_Ext')
+  const parentBoundary = boundaryStack.length > 0
+    ? boundaryStack[boundaryStack.length - 1]!.alias
+    : undefined
+
+  if (spec.hasTechnology) {
+    // (alias, label, technology, description)
+    return {
+      kind: spec.kind,
+      alias: unquote(args[0] ?? ''),
+      label: unquote(args[1] ?? ''),
+      technology: args[2] ? unquote(args[2]) : undefined,
+      description: args[3] ? unquote(args[3]) : undefined,
+      external,
+      parentBoundary,
+    }
+  }
+
+  // (alias, label, description)
+  return {
+    kind: spec.kind,
+    alias: unquote(args[0] ?? ''),
+    label: unquote(args[1] ?? ''),
+    description: args[2] ? unquote(args[2]) : undefined,
+    external,
+    parentBoundary,
+  }
+}
+
+// ============================================================================
+// Relationship parsing
+// ============================================================================
+
+function parseRelationship(keyword: string, argsStr: string): C4Relationship | null {
+  const isRel = keyword === 'Rel'
+  const isBiRel = keyword === 'BiRel'
+  const direction = REL_DIRECTIONS.get(keyword)
+
+  if (!isRel && !isBiRel && direction === undefined) {
+    return null
+  }
+
+  const args = parseArgs(argsStr)
+  if (args.length < 3) return null
+
+  const from = unquote(args[0]!)
+  const to = unquote(args[1]!)
+  const label = unquote(args[2]!)
+  const technology = args[3] ? unquote(args[3]) : undefined
+
+  const rel: C4Relationship = { from, to, label, technology, direction }
+
+  if (isBiRel) {
+    // BiRel is undirected — no direction, but we can note it is bidirectional
+    // by omitting direction (the renderer can handle it)
+    return rel
+  }
+
+  return rel
+}

--- a/src/c4/renderer.ts
+++ b/src/c4/renderer.ts
@@ -1,0 +1,407 @@
+import type {
+  PositionedC4Diagram,
+  PositionedC4Element,
+  PositionedC4Relationship,
+  PositionedC4Boundary,
+} from './types.ts'
+import type { DiagramColors } from '../theme.ts'
+import { svgOpenTag, buildStyleBlock } from '../theme.ts'
+import { FONT_SIZES, FONT_WEIGHTS, STROKE_WIDTHS, estimateTextWidth, TEXT_BASELINE_SHIFT } from '../styles.ts'
+
+// ============================================================================
+// C4 diagram SVG renderer
+//
+// Renders positioned C4 diagrams to SVG.
+// All colors use CSS custom properties (var(--_xxx)) from the theme system.
+//
+// Render order:
+//   1. Boundary boxes (dashed border, label in top-left corner)
+//   2. Element boxes (rounded rect with title, technology, description)
+//   3. Person shapes (rounded rect with circle head silhouette)
+//   4. Relationship arrows with labels
+//   5. Title (if present)
+// ============================================================================
+
+/** Font sizes specific to C4 diagrams */
+const C4_FONT = {
+  titleSize: 16,
+  titleWeight: 700,
+  labelSize: 13,
+  labelWeight: 600,
+  techSize: 10,
+  techWeight: 400,
+  descSize: 11,
+  descWeight: 400,
+  boundaryLabelSize: 12,
+  boundaryLabelWeight: 600,
+} as const
+
+/** Person silhouette dimensions */
+const PERSON = {
+  headRadius: 14,
+  headOffsetY: 18,
+  bodyTopY: 34,
+} as const
+
+/** Arrow marker dimensions */
+const ARROW = {
+  width: 8,
+  height: 5,
+} as const
+
+/**
+ * Render a positioned C4 diagram as an SVG string.
+ *
+ * @param colors - DiagramColors with bg/fg and optional enrichment variables.
+ * @param font - Font family for text rendering. Default: 'Inter'.
+ * @param transparent - If true, renders with transparent background.
+ */
+export function renderC4Svg(
+  diagram: PositionedC4Diagram,
+  colors: DiagramColors,
+  font: string = 'Inter',
+  transparent: boolean = false
+): string {
+  const parts: string[] = []
+
+  // SVG root with CSS variables + style block + defs
+  parts.push(svgOpenTag(diagram.width, diagram.height, colors, transparent))
+  parts.push(buildStyleBlock(font, false))
+  parts.push(buildDefs())
+
+  // 1. Title
+  if (diagram.title) {
+    parts.push(renderTitle(diagram.title, diagram.width))
+  }
+
+  // 2. Boundary boxes (behind everything else)
+  for (const boundary of flattenBoundaries(diagram.boundaries)) {
+    parts.push(renderBoundaryBox(boundary))
+  }
+
+  // 3. Element boxes
+  for (const element of diagram.elements) {
+    if (element.kind === 'Person') {
+      parts.push(renderPersonBox(element))
+    } else {
+      parts.push(renderElementBox(element))
+    }
+  }
+
+  // 4. Relationship arrows
+  for (const rel of diagram.relationships) {
+    parts.push(renderRelationship(rel))
+  }
+
+  parts.push('</svg>')
+  return parts.join('\n')
+}
+
+// ============================================================================
+// Defs — arrow markers
+// ============================================================================
+
+function buildDefs(): string {
+  return [
+    '<defs>',
+    `  <marker id="c4-arrow" viewBox="0 0 ${ARROW.width} ${ARROW.height * 2}" ` +
+    `refX="${ARROW.width}" refY="${ARROW.height}" ` +
+    `markerWidth="${ARROW.width}" markerHeight="${ARROW.height * 2}" orient="auto">`,
+    `    <path d="M 0 0 L ${ARROW.width} ${ARROW.height} L 0 ${ARROW.height * 2} Z" fill="var(--_arrow)" />`,
+    '  </marker>',
+    '</defs>',
+  ].join('\n')
+}
+
+// ============================================================================
+// Title rendering
+// ============================================================================
+
+function renderTitle(title: string, diagramWidth: number): string {
+  const cx = diagramWidth / 2
+  return (
+    `<text x="${cx}" y="24" text-anchor="middle" dy="${TEXT_BASELINE_SHIFT}" ` +
+    `font-size="${C4_FONT.titleSize}" font-weight="${C4_FONT.titleWeight}" ` +
+    `fill="var(--_text)">${escapeXml(title)}</text>`
+  )
+}
+
+// ============================================================================
+// Boundary box rendering
+// ============================================================================
+
+function renderBoundaryBox(boundary: PositionedC4Boundary): string {
+  const { x, y, width, height, label, kind } = boundary
+  const parts: string[] = []
+  const rx = 2
+
+  // Dashed border rectangle
+  parts.push(
+    `<rect x="${x}" y="${y}" width="${width}" height="${height}" ` +
+    `rx="${rx}" ry="${rx}" fill="none" stroke="var(--_node-stroke)" ` +
+    `stroke-width="${STROKE_WIDTHS.outerBox}" stroke-dasharray="8 4" />`
+  )
+
+  // Kind label in top-left corner (e.g., "[System_Boundary]")
+  const kindLabel = `[${kind.replace(/_/g, ' ')}]`
+  parts.push(
+    `<text x="${x + 10}" y="${y + 16}" dy="${TEXT_BASELINE_SHIFT}" ` +
+    `font-size="${C4_FONT.techSize}" font-weight="${C4_FONT.techWeight}" ` +
+    `font-style="italic" fill="var(--_text-muted)">${escapeXml(kindLabel)}</text>`
+  )
+
+  // Boundary label
+  parts.push(
+    `<text x="${x + 10}" y="${y + 30}" dy="${TEXT_BASELINE_SHIFT}" ` +
+    `font-size="${C4_FONT.boundaryLabelSize}" font-weight="${C4_FONT.boundaryLabelWeight}" ` +
+    `fill="var(--_text-sec)">${escapeXml(label)}</text>`
+  )
+
+  return parts.join('\n')
+}
+
+// ============================================================================
+// Element box rendering
+// ============================================================================
+
+/** Render a standard C4 element box (System, Container, Component, etc.) */
+function renderElementBox(element: PositionedC4Element): string {
+  const { x, y, width, height, label, technology, description, external } = element
+  const parts: string[] = []
+  const rx = 6
+  const fill = external ? 'var(--_text-muted)' : 'var(--_node-fill)'
+  const stroke = 'var(--_node-stroke)'
+
+  // Background rounded rectangle
+  parts.push(
+    `<rect x="${x}" y="${y}" width="${width}" height="${height}" ` +
+    `rx="${rx}" ry="${rx}" fill="${fill}" stroke="${stroke}" ` +
+    `stroke-width="${STROKE_WIDTHS.outerBox}" />`
+  )
+
+  // Calculate text positions — vertically center all text lines
+  const cx = x + width / 2
+  const lines = buildTextLines(label, technology, description)
+  const totalTextHeight = lines.length * 18
+  let textY = y + (height - totalTextHeight) / 2 + 12
+
+  for (const line of lines) {
+    parts.push(
+      `<text x="${cx}" y="${textY}" text-anchor="middle" dy="${TEXT_BASELINE_SHIFT}" ` +
+      `font-size="${line.fontSize}" font-weight="${line.fontWeight}" ` +
+      `${line.italic ? 'font-style="italic" ' : ''}` +
+      `fill="${line.color}">${escapeXml(line.text)}</text>`
+    )
+    textY += 18
+  }
+
+  return parts.join('\n')
+}
+
+/** Render a Person element with a circle head silhouette above the box */
+function renderPersonBox(element: PositionedC4Element): string {
+  const { x, y, width, height, label, description, external } = element
+  const parts: string[] = []
+  const cx = x + width / 2
+  const fill = external ? 'var(--_text-muted)' : 'var(--_node-fill)'
+  const stroke = 'var(--_node-stroke)'
+
+  // Circle head
+  parts.push(
+    `<circle cx="${cx}" cy="${y + PERSON.headOffsetY}" r="${PERSON.headRadius}" ` +
+    `fill="${fill}" stroke="${stroke}" stroke-width="${STROKE_WIDTHS.outerBox}" />`
+  )
+
+  // Body rectangle (below the head)
+  const bodyY = y + PERSON.bodyTopY
+  const bodyHeight = height - PERSON.bodyTopY
+  const rx = 6
+
+  parts.push(
+    `<rect x="${x}" y="${bodyY}" width="${width}" height="${bodyHeight}" ` +
+    `rx="${rx}" ry="${rx}" fill="${fill}" stroke="${stroke}" ` +
+    `stroke-width="${STROKE_WIDTHS.outerBox}" />`
+  )
+
+  // Text lines inside the body
+  const lines = buildTextLines(label, undefined, description)
+  const totalTextHeight = lines.length * 18
+  let textY = bodyY + (bodyHeight - totalTextHeight) / 2 + 12
+
+  for (const line of lines) {
+    parts.push(
+      `<text x="${cx}" y="${textY}" text-anchor="middle" dy="${TEXT_BASELINE_SHIFT}" ` +
+      `font-size="${line.fontSize}" font-weight="${line.fontWeight}" ` +
+      `${line.italic ? 'font-style="italic" ' : ''}` +
+      `fill="${line.color}">${escapeXml(line.text)}</text>`
+    )
+    textY += 18
+  }
+
+  return parts.join('\n')
+}
+
+// ============================================================================
+// Text line helpers
+// ============================================================================
+
+interface TextLine {
+  text: string
+  fontSize: number
+  fontWeight: number
+  italic: boolean
+  color: string
+}
+
+/** Build the array of text lines for a C4 element */
+function buildTextLines(
+  label: string,
+  technology: string | undefined,
+  description: string | undefined,
+): TextLine[] {
+  const lines: TextLine[] = []
+
+  // Label (bold, primary color)
+  lines.push({
+    text: label,
+    fontSize: C4_FONT.labelSize,
+    fontWeight: C4_FONT.labelWeight,
+    italic: false,
+    color: 'var(--_text)',
+  })
+
+  // Technology in brackets (italic, muted)
+  if (technology) {
+    lines.push({
+      text: `[${technology}]`,
+      fontSize: C4_FONT.techSize,
+      fontWeight: C4_FONT.techWeight,
+      italic: true,
+      color: 'var(--_text-muted)',
+    })
+  }
+
+  // Description (normal, secondary color)
+  if (description) {
+    lines.push({
+      text: description,
+      fontSize: C4_FONT.descSize,
+      fontWeight: C4_FONT.descWeight,
+      italic: false,
+      color: 'var(--_text-sec)',
+    })
+  }
+
+  return lines
+}
+
+// ============================================================================
+// Relationship rendering
+// ============================================================================
+
+function renderRelationship(rel: PositionedC4Relationship): string {
+  if (rel.points.length < 2) return ''
+  const parts: string[] = []
+
+  // Polyline path with arrow marker
+  const pathData = rel.points.map(p => `${p.x},${p.y}`).join(' ')
+  parts.push(
+    `<polyline points="${pathData}" fill="none" stroke="var(--_line)" ` +
+    `stroke-width="${STROKE_WIDTHS.connector}" marker-end="url(#c4-arrow)" />`
+  )
+
+  // Label at midpoint
+  const mid = midpoint(rel.points)
+  const labelText = rel.technology ? `${rel.label}` : rel.label
+  const techText = rel.technology ? `[${rel.technology}]` : ''
+
+  // Background pill for readability
+  const fullLabel = techText ? `${labelText} ${techText}` : labelText
+  const textWidth = estimateTextWidth(fullLabel, FONT_SIZES.edgeLabel, FONT_WEIGHTS.edgeLabel)
+  const bgW = textWidth + 12
+  const bgH = techText ? 28 : 18
+
+  parts.push(
+    `<rect x="${mid.x - bgW / 2}" y="${mid.y - bgH / 2}" width="${bgW}" height="${bgH}" ` +
+    `rx="2" ry="2" fill="var(--bg)" stroke="var(--_inner-stroke)" stroke-width="0.5" />`
+  )
+
+  // Label text
+  if (techText) {
+    // Two lines: label above, technology below
+    parts.push(
+      `<text x="${mid.x}" y="${mid.y - 5}" text-anchor="middle" dy="${TEXT_BASELINE_SHIFT}" ` +
+      `font-size="${FONT_SIZES.edgeLabel}" font-weight="${FONT_WEIGHTS.edgeLabel}" ` +
+      `fill="var(--_text-muted)">${escapeXml(labelText)}</text>`
+    )
+    parts.push(
+      `<text x="${mid.x}" y="${mid.y + 8}" text-anchor="middle" dy="${TEXT_BASELINE_SHIFT}" ` +
+      `font-size="${C4_FONT.techSize}" font-weight="${C4_FONT.techWeight}" ` +
+      `font-style="italic" fill="var(--_text-faint)">${escapeXml(techText)}</text>`
+    )
+  } else {
+    parts.push(
+      `<text x="${mid.x}" y="${mid.y}" text-anchor="middle" dy="${TEXT_BASELINE_SHIFT}" ` +
+      `font-size="${FONT_SIZES.edgeLabel}" font-weight="${FONT_WEIGHTS.edgeLabel}" ` +
+      `fill="var(--_text-muted)">${escapeXml(labelText)}</text>`
+    )
+  }
+
+  return parts.join('\n')
+}
+
+// ============================================================================
+// Utilities
+// ============================================================================
+
+/** Compute the arc-length midpoint of a polyline path. */
+function midpoint(points: Array<{ x: number; y: number }>): { x: number; y: number } {
+  if (points.length === 0) return { x: 0, y: 0 }
+  if (points.length === 1) return points[0]!
+
+  let totalLen = 0
+  for (let i = 1; i < points.length; i++) {
+    const dx = points[i]!.x - points[i - 1]!.x
+    const dy = points[i]!.y - points[i - 1]!.y
+    totalLen += Math.sqrt(dx * dx + dy * dy)
+  }
+
+  if (totalLen === 0) return points[0]!
+
+  const halfLen = totalLen / 2
+  let walked = 0
+  for (let i = 1; i < points.length; i++) {
+    const dx = points[i]!.x - points[i - 1]!.x
+    const dy = points[i]!.y - points[i - 1]!.y
+    const segLen = Math.sqrt(dx * dx + dy * dy)
+    if (walked + segLen >= halfLen) {
+      const t = segLen > 0 ? (halfLen - walked) / segLen : 0
+      return {
+        x: points[i - 1]!.x + dx * t,
+        y: points[i - 1]!.y + dy * t,
+      }
+    }
+    walked += segLen
+  }
+
+  return points[points.length - 1]!
+}
+
+/** Flatten nested boundaries into a single array for rendering */
+function flattenBoundaries(boundaries: PositionedC4Boundary[]): PositionedC4Boundary[] {
+  const result: PositionedC4Boundary[] = []
+  for (const b of boundaries) {
+    result.push(b)
+    result.push(...flattenBoundaries(b.children))
+  }
+  return result
+}
+
+function escapeXml(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+}

--- a/src/c4/types.ts
+++ b/src/c4/types.ts
@@ -1,0 +1,113 @@
+// ============================================================================
+// C4 diagram types
+//
+// Models C4 model diagrams: System Context, Container, Component, Dynamic, Deployment.
+// Compatible with Mermaid.js C4 syntax.
+// ============================================================================
+
+/** C4 diagram type keywords */
+export type C4DiagramType = 'C4Context' | 'C4Container' | 'C4Component' | 'C4Dynamic' | 'C4Deployment'
+
+/** Parsed C4 diagram */
+export interface C4Diagram {
+  type: C4DiagramType
+  title?: string
+  elements: C4Element[]
+  relationships: C4Relationship[]
+  boundaries: C4Boundary[]
+}
+
+/** A C4 element: Person, System, Container, Component, or Deployment Node */
+export interface C4Element {
+  kind: C4ElementKind
+  alias: string
+  label: string
+  description?: string
+  technology?: string
+  /** Whether this is an external element (_Ext suffix) */
+  external: boolean
+  /** Parent boundary alias (if nested inside a boundary) */
+  parentBoundary?: string
+}
+
+export type C4ElementKind =
+  | 'Person'
+  | 'System'
+  | 'Container'
+  | 'ContainerDb'
+  | 'ContainerQueue'
+  | 'Component'
+  | 'ComponentDb'
+  | 'ComponentQueue'
+  | 'Deployment_Node'
+
+/** A boundary (grouping box) in the diagram */
+export interface C4Boundary {
+  alias: string
+  label: string
+  kind: C4BoundaryKind
+  elements: C4Element[]
+  childBoundaries: C4Boundary[]
+  parentBoundary?: string
+}
+
+export type C4BoundaryKind =
+  | 'Boundary'
+  | 'System_Boundary'
+  | 'Container_Boundary'
+  | 'Enterprise_Boundary'
+  | 'Deployment_Node'
+
+/** A relationship between elements */
+export interface C4Relationship {
+  from: string
+  to: string
+  label: string
+  technology?: string
+  direction?: 'D' | 'U' | 'L' | 'R' | 'Back'
+}
+
+// ============================================================================
+// Positioned C4 diagram — ready for SVG rendering
+// ============================================================================
+
+export interface PositionedC4Diagram {
+  width: number
+  height: number
+  title?: string
+  elements: PositionedC4Element[]
+  relationships: PositionedC4Relationship[]
+  boundaries: PositionedC4Boundary[]
+}
+
+export interface PositionedC4Element {
+  kind: C4ElementKind
+  alias: string
+  label: string
+  description?: string
+  technology?: string
+  external: boolean
+  x: number
+  y: number
+  width: number
+  height: number
+}
+
+export interface PositionedC4Relationship {
+  from: string
+  to: string
+  label: string
+  technology?: string
+  points: Array<{ x: number; y: number }>
+}
+
+export interface PositionedC4Boundary {
+  alias: string
+  label: string
+  kind: C4BoundaryKind
+  x: number
+  y: number
+  width: number
+  height: number
+  children: PositionedC4Boundary[]
+}


### PR DESCRIPTION
## Summary

This PR adds support for two new diagram types to beautiful-mermaid:

1. **C4 diagrams** — System Context, Container, Component, and Deployment diagrams for visualizing software architecture at different levels of abstraction
2. **ArchiMate diagrams** — Enterprise architecture diagrams spanning Business, Application, Technology, Strategy, Motivation, Physical, and Implementation layers

Both diagram types are now available in the sample gallery with multiple example diagrams demonstrating common use cases.

## Key Changes

- **C4 Support**: Added 5 sample C4 diagrams (System Context, Container, Component, Microservices, Deployment) with color-coded category in the UI
- **ArchiMate Support**: Added 5 sample ArchiMate diagrams (Simple Layered, Business Process, Full Stack, Strategy & Motivation, Implementation & Migration) with color-coded category
- **ArchiMate Parser** (`src/archimate/parser.ts`): Implements DSL parser for `archimate-layered` syntax supporting:
  - 7 layer types (business, application, technology, strategy, motivation, physical, implementation)
  - 40+ element types with layer-specific validation
  - 11 relationship types with typed connections
  - Flexible element declaration syntax (with/without labels and aliases)
- **ArchiMate Layout Engine** (`src/archimate/layout.ts`): Uses dagre for graph layout with:
  - Layer-aware positioning enforcing canonical top-to-bottom ordering
  - Invisible edges between layers to maintain vertical structure
  - Layer band computation with padding and labels
  - Orthogonal edge routing with endpoint clipping
- **ArchiMate Renderer** (`src/archimate/renderer.ts`): SVG rendering with:
  - Layer bands with color tints and labels
  - Element boxes with type indicators
  - 11 relationship marker styles (arrows, diamonds, circles, triangles)
  - Dashed/solid line styles per relationship type
  - Arc-length midpoint label positioning
- **Type Definitions** (`src/archimate/types.ts`): Complete TypeScript types for parsed and positioned diagrams
- **UI Integration** (`index.ts`): Added C4 and ArchiMate to category colors and labels
- **Lockfile**: Updated with `configVersion: 0`

## Implementation Details

- ArchiMate layout uses dagre's graph layout algorithm with custom layer enforcement via invisible high-weight edges
- Layer bands are computed from element bounding boxes with normalized widths for visual alignment
- Relationship rendering supports 11 distinct visual styles matching ArchiMate semantics (composition, aggregation, assignment, realization, serving, access, influence, triggering, flow, specialization, association)
- All colors use CSS custom properties for theme consistency
- Parser validates element types against layer-specific allowed types while accepting cross-layer types
- Orthogonal edge routing ensures clean, readable relationship paths in layered diagrams

https://claude.ai/code/session_01X9i2o51QrXYqyRS7M4eiCu