### PR TITLE
fix: support both edge label syntaxes in flowchart rendering

### DIFF
--- a/src/__tests__/parser.test.ts
+++ b/src/__tests__/parser.test.ts
@@ -294,6 +294,85 @@ describe('parseMermaid – no-arrow edges', () => {
 })
 
 // ============================================================================
+// Text-embedded label arrows: -- label --> syntax (Issue #32)
+// ============================================================================
+
+describe('parseMermaid – text-embedded label arrows', () => {
+  it('parses solid arrow with text label: -- Yes -->', () => {
+    const g = parseMermaid('graph TD\n  B -- Yes --> C')
+    expect(g.edges).toHaveLength(1)
+    expect(g.edges[0]!.source).toBe('B')
+    expect(g.edges[0]!.target).toBe('C')
+    expect(g.edges[0]!.label).toBe('Yes')
+    expect(g.edges[0]!.style).toBe('solid')
+    expect(g.edges[0]!.hasArrowEnd).toBe(true)
+    expect(g.edges[0]!.hasArrowStart).toBe(false)
+  })
+
+  it('parses solid line with text label (no arrow): -- Yes ---', () => {
+    const g = parseMermaid('graph TD\n  A -- connects --- B')
+    expect(g.edges[0]!.label).toBe('connects')
+    expect(g.edges[0]!.style).toBe('solid')
+    expect(g.edges[0]!.hasArrowEnd).toBe(false)
+  })
+
+  it('parses dotted arrow with text label: -. Maybe .->', () => {
+    const g = parseMermaid('graph TD\n  A -. Maybe .-> B')
+    expect(g.edges[0]!.label).toBe('Maybe')
+    expect(g.edges[0]!.style).toBe('dotted')
+    expect(g.edges[0]!.hasArrowEnd).toBe(true)
+  })
+
+  it('parses thick arrow with text label: == Sure ==>', () => {
+    const g = parseMermaid('graph TD\n  A == Sure ==> B')
+    expect(g.edges[0]!.label).toBe('Sure')
+    expect(g.edges[0]!.style).toBe('thick')
+    expect(g.edges[0]!.hasArrowEnd).toBe(true)
+  })
+
+  it('parses multi-word text label: -- Long Label Text -->', () => {
+    const g = parseMermaid('graph TD\n  A -- Long Label Text --> B')
+    expect(g.edges[0]!.label).toBe('Long Label Text')
+  })
+
+  it('works with shaped nodes: B{Decision} -- Yes --> C[Result]', () => {
+    const g = parseMermaid('graph TD\n  B{Decision} -- Yes --> C[Result]')
+    expect(g.edges[0]!.source).toBe('B')
+    expect(g.edges[0]!.target).toBe('C')
+    expect(g.edges[0]!.label).toBe('Yes')
+    expect(g.nodes.get('B')!.shape).toBe('diamond')
+    expect(g.nodes.get('C')!.shape).toBe('rectangle')
+  })
+
+  it('handles the exact Issue #32 scenario', () => {
+    const g = parseMermaid(`flowchart TD
+      A(Start) --> B{Is it sunny?}
+      B -- Yes --> C[Go to the park]
+      B -- No --> D[Stay indoors]
+      C --> E[Finish]
+      D --> E`)
+    expect(g.edges).toHaveLength(5)
+    // Check the two text-embedded label edges
+    const yesEdge = g.edges.find(e => e.label === 'Yes')
+    expect(yesEdge).toBeDefined()
+    expect(yesEdge!.source).toBe('B')
+    expect(yesEdge!.target).toBe('C')
+    const noEdge = g.edges.find(e => e.label === 'No')
+    expect(noEdge).toBeDefined()
+    expect(noEdge!.source).toBe('B')
+    expect(noEdge!.target).toBe('D')
+  })
+
+  it('both label syntaxes produce equivalent edges', () => {
+    const g1 = parseMermaid('graph TD\n  A -->|Yes| B')
+    const g2 = parseMermaid('graph TD\n  A -- Yes --> B')
+    expect(g1.edges[0]!.label).toBe(g2.edges[0]!.label)
+    expect(g1.edges[0]!.style).toBe(g2.edges[0]!.style)
+    expect(g1.edges[0]!.hasArrowEnd).toBe(g2.edges[0]!.hasArrowEnd)
+  })
+})
+
+// ============================================================================
 // Bidirectional arrows (Batch 2.4)
 // ============================================================================
 


### PR DESCRIPTION
## Problem

Fixes #32 — Flowchart edges using the text-embedded label syntax (`B -- Yes --> C`) fail to render, while the pipe-delimited syntax (`B -->|Yes| C`) works correctly. Both are valid Mermaid flowchart syntaxes per the [official spec](https://mermaid.js.org/syntax/flowchart.html#a-link-with-arrow-head-and-text).

**Does not render:**
```mermaid
flowchart TD
  B -- Yes --> C
```

**Renders correctly:**
```mermaid
flowchart TD
  B -->|Yes| C
```

## Root Cause

The `ARROW_REGEX` in `src/parser.ts` only matches the pipe-delimited label format (`-->|label|`):

```js
const ARROW_REGEX = /^(<)?(-->|-.->|==>|---|-\.-|===)(?:\|([^|]*)\|)?/
```

The text-embedded label syntax (`-- label -->`, `-. label .->`, `== label ==>`) was completely unhandled by the parser, causing these edges to be silently dropped during parsing.

## Fix

Added a new `TEXT_ARROW_REGEX` that matches the text-embedded label arrow syntax:

```js
const TEXT_ARROW_REGEX = /^(<)?(--|-\.|==)\s+(.+?)\s+(-->|---|\.->|\.−|==>|===)/
```

Updated `parseEdgeLine()` to try `TEXT_ARROW_REGEX` as a fallback when `ARROW_REGEX` does not match.

Added `textArrowStyleFromOps()` helper to map the opening/closing operators to the correct edge style (solid/dotted/thick).

### Supported text-embedded patterns:
| Syntax | Style | Arrow |
|--------|-------|-------|
| `-- Yes -->` | solid | yes |
| `-- Yes ---` | solid | no |
| `-. Maybe .->` | dotted | yes |
| `== Sure ==>` | thick | yes |

## Tests

Added 8 new test cases covering:
- Solid/dotted/thick arrows with text-embedded labels
- No-arrow variant (`---`)
- Multi-word labels
- Shaped nodes with text-embedded labels
- The exact Issue #32 scenario (full diagram)
- Equivalence between both label syntaxes

All 90 parser tests pass (82 existing + 8 new). No regressions.