### PR TITLE
feat: support <br> multi-line labels, strip quoted labels, parse parallelograms

### DIFF
--- a/src/styles.ts
+++ b/src/styles.ts
@@ -7,6 +7,11 @@
 // contains font metrics, spacing constants, and stroke widths.
 // ============================================================================
 
+/** Split a label on `<br>` / `<br/>` / `<br />` tags (case-insensitive) */
+export function splitLabel(text: string): string[] {
+  return text.split(/<br\s*\/?>/i)
+}
+
 /** Average character width in px at the given font size and weight (proportional font) */
 export function estimateTextWidth(text: string, fontSize: number, fontWeight: number): number {
   // Inter average character widths as fraction of fontSize, per weight.
@@ -14,6 +19,9 @@ export function estimateTextWidth(text: string, fontSize: number, fontWeight: nu
   const widthRatio = fontWeight >= 600 ? 0.58 : fontWeight >= 500 ? 0.55 : 0.52
   return text.length * fontSize * widthRatio
 }
+
+/** Line height multiplier for multi-line text (1.3× the font size) */
+export const LINE_HEIGHT = 1.3
 
 /** Average character width in px for monospace fonts (uniform glyph width) */
 export function estimateMonoTextWidth(text: string, fontSize: number): number {


### PR DESCRIPTION
## Summary

- **Multi-line label support via `<br>` tags** — Node and edge labels containing `<br>`, `<br/>`, or `<br />` now render as vertically-centered multi-line text using SVG `<tspan>` elements. Layout sizing accounts for the extra height.
- **Strip surrounding double-quotes from labels** — Mermaid uses `"..."` as label delimiters (e.g. `["quoted text"]`, `-->|"label"|`). These quotes are now stripped instead of rendered as literal characters.
- **Parse parallelogram node shapes** — Added `[/text/]` and `[\text\]` patterns (mapped to trapezoid/trapezoid-alt), which are standard mermaid syntax that was previously unrecognized and fell through to plain rectangles.

## Files changed

| File | Change |
|------|--------|
| `src/styles.ts` | Added `splitLabel()` utility and `LINE_HEIGHT` constant |
| `src/layout.ts` | `estimateNodeSize` + edge label sizing use `splitLabel()` for multi-line height |
| `src/renderer.ts` | `renderNodeLabel` + `renderEdgeLabel` emit `<tspan>` for multi-line text |
| `src/parser.ts` | `stripQuotes()` for node/edge labels; parallelogram regex patterns |

## Test plan

- [x] Existing test suite passes (451 pass, 3 pre-existing failures unrelated to this PR)
- [x] Verified rendering of complex flowcharts with `<br>` tags, quoted labels, and `[/text/]` parallelogram nodes
- [x] Single-line labels are unchanged (early return, no `<tspan>` overhead)

🤖 Generated with [Claude Code](https://claude.com/claude-code)