### PR TITLE
fix: correct CJK/wide character width in ASCII renderer

### DIFF
--- a/src/ascii/canvas.ts
+++ b/src/ascii/canvas.ts
@@ -8,6 +8,7 @@
 
 import type { Canvas, DrawingCoord, RoleCanvas, CharRole, AsciiTheme, ColorMode } from './types.ts'
 import { colorizeLine, DEFAULT_ASCII_THEME } from './ansi.ts'
+import { displayWidth, drawCJKText, CJK_PAD } from './cjk.ts'
 
 /**
  * Create a blank canvas filled with spaces.
@@ -294,6 +295,7 @@ export function canvasToString(canvas: Canvas, options?: CanvasToStringOptions):
       // Plain text output — no colors
       let line = ''
       for (let x = 0; x <= maxX; x++) {
+        if (canvas[x]![y]! === CJK_PAD) continue
         line += canvas[x]![y]!
       }
       lines.push(line)
@@ -302,6 +304,7 @@ export function canvasToString(canvas: Canvas, options?: CanvasToStringOptions):
       const chars: string[] = []
       const roles: (CharRole | null)[] = []
       for (let x = 0; x <= maxX; x++) {
+        if (canvas[x]![y]! === CJK_PAD) continue
         chars.push(canvas[x]![y]!)
         roles.push(roleCanvas[x]?.[y] ?? null)
       }
@@ -387,15 +390,8 @@ export function drawText(
   text: string,
   forceOverwrite = false
 ): void {
-  increaseSize(canvas, start.x + text.length, start.y)
-  for (let i = 0; i < text.length; i++) {
-    const x = start.x + i
-    const current = canvas[x]![start.y]!
-    // Only write if target is empty or we're forcing overwrite
-    if (forceOverwrite || current === ' ') {
-      canvas[x]![start.y] = text[i]!
-    }
-  }
+  increaseSize(canvas, start.x + displayWidth(text), start.y)
+  drawCJKText(canvas, start.x, start.y, text, forceOverwrite)
 }
 
 /**

--- a/src/ascii/cjk.ts
+++ b/src/ascii/cjk.ts
@@ -1,0 +1,34 @@
+// CJK 宽度修复模块 (patch-cjk-v2.mjs 生成)
+export const CJK_PAD = '\u200B'
+
+export function isCJK(ch: string): boolean {
+  const c = ch.codePointAt(0)!
+  return (c >= 0x2E80 && c <= 0x9FFF) || (c >= 0xAC00 && c <= 0xD7AF) ||
+         (c >= 0xF900 && c <= 0xFAFF) || (c >= 0xFE30 && c <= 0xFE4F) ||
+         (c >= 0xFF00 && c <= 0xFF60) || (c >= 0xFFE0 && c <= 0xFFE6) ||
+         (c >= 0x20000 && c <= 0x2FA1F)
+}
+
+export function displayWidth(str: string): number {
+  let w = 0
+  for (const ch of str) w += isCJK(ch) ? 2 : 1
+  return w
+}
+
+export function drawCJKText(
+  canvas: string[][], x: number, y: number, text: string, forceOverwrite = false
+): void {
+  let offset = 0
+  for (const ch of text) {
+    const cx = x + offset
+    if (cx >= 0 && cx < canvas.length && y >= 0 && y < (canvas[0]?.length ?? 0)) {
+      if (forceOverwrite || canvas[cx]![y] === ' ') canvas[cx]![y] = ch
+    }
+    offset++
+    if (isCJK(ch)) {
+      const px = x + offset
+      if (px >= 0 && px < canvas.length && y >= 0 && y < (canvas[0]?.length ?? 0)) canvas[px]![y] = CJK_PAD
+      offset++
+    }
+  }
+}

--- a/src/ascii/cjk.ts
+++ b/src/ascii/cjk.ts
@@ -8,7 +8,7 @@
 // Unicode ranges from src/text-metrics.ts isFullwidth() — kept in sync.
 // ============================================================================
 
-import type { Canvas } from './types.ts'
+import type { Canvas, RoleCanvas, CharRole } from './types.ts'
 
 /**
  * Sentinel character placed in the "right half" of a fullwidth character's
@@ -71,6 +71,8 @@ export function displayWidth(str: string): number {
  * @param y - Row index
  * @param text - Text to draw
  * @param forceOverwrite - If true, overwrite existing non-space characters
+ * @param roleCanvas - Optional role canvas for colored output
+ * @param role - Character role to assign (requires roleCanvas)
  */
 export function drawCJKText(
   canvas: Canvas,
@@ -78,21 +80,30 @@ export function drawCJKText(
   y: number,
   text: string,
   forceOverwrite = false,
+  roleCanvas?: RoleCanvas,
+  role?: CharRole,
 ): void {
   let offset = 0
   for (const ch of text) {
     const cx = x + offset
+    let written = false
     if (cx >= 0 && cx < canvas.length && y >= 0 && y < (canvas[0]?.length ?? 0)) {
       if (forceOverwrite || canvas[cx]![y] === ' ') {
         canvas[cx]![y] = ch
+        if (roleCanvas && role !== undefined && cx < roleCanvas.length && y < (roleCanvas[0]?.length ?? 0)) {
+          roleCanvas[cx]![y] = role
+        }
+        written = true
       }
     }
     offset++
     const code = ch.codePointAt(0)
     if (code !== undefined && isFullwidthChar(code)) {
-      const px = x + offset
-      if (px >= 0 && px < canvas.length && y >= 0 && y < (canvas[0]?.length ?? 0)) {
-        canvas[px]![y] = CJK_PAD
+      if (written) {
+        const px = x + offset
+        if (px >= 0 && px < canvas.length && y >= 0 && y < (canvas[0]?.length ?? 0)) {
+          canvas[px]![y] = CJK_PAD
+        }
       }
       offset++
     }

--- a/src/ascii/cjk.ts
+++ b/src/ascii/cjk.ts
@@ -1,33 +1,99 @@
-// CJK 宽度修复模块 (patch-cjk-v2.mjs 生成)
+// ============================================================================
+// ASCII renderer — fullwidth character support
+//
+// CJK (Chinese/Japanese/Korean) and other fullwidth characters occupy 2
+// terminal columns, but JavaScript's `.length` counts them as 1. This module
+// provides display-width calculation and CJK-aware canvas text rendering.
+//
+// Unicode ranges from src/text-metrics.ts isFullwidth() — kept in sync.
+// ============================================================================
+
+import type { Canvas } from './types.ts'
+
+/**
+ * Sentinel character placed in the "right half" of a fullwidth character's
+ * canvas cell. Stripped by `canvasToString()` before output.
+ *
+ * Uses zero-width space (U+200B) — invisible in terminal output even if
+ * stripping is accidentally skipped.
+ */
 export const CJK_PAD = '\u200B'
 
-export function isCJK(ch: string): boolean {
-  const c = ch.codePointAt(0)!
-  return (c >= 0x2E80 && c <= 0x9FFF) || (c >= 0xAC00 && c <= 0xD7AF) ||
-         (c >= 0xF900 && c <= 0xFAFF) || (c >= 0xFE30 && c <= 0xFE4F) ||
-         (c >= 0xFF00 && c <= 0xFF60) || (c >= 0xFFE0 && c <= 0xFFE6) ||
-         (c >= 0x20000 && c <= 0x2FA1F)
+/**
+ * Check if a character occupies two columns in a monospace terminal.
+ *
+ * Covers CJK Unified Ideographs, Hangul, fullwidth forms, and extended
+ * CJK blocks. Ranges mirror `isFullwidth()` in `src/text-metrics.ts`.
+ */
+export function isFullwidthChar(code: number): boolean {
+  return (
+    (code >= 0x1100 && code <= 0x115f) || // Hangul Jamo
+    (code >= 0x2e80 && code <= 0x2eff) || // CJK Radicals Supplement
+    (code >= 0x2f00 && code <= 0x2fdf) || // Kangxi Radicals
+    (code >= 0x3000 && code <= 0x303f) || // CJK Symbols and Punctuation
+    (code >= 0x3040 && code <= 0x309f) || // Hiragana
+    (code >= 0x30a0 && code <= 0x30ff) || // Katakana
+    (code >= 0x3100 && code <= 0x312f) || // Bopomofo
+    (code >= 0x3130 && code <= 0x318f) || // Hangul Compatibility Jamo
+    (code >= 0x3190 && code <= 0x31ff) || // Kanbun + extensions
+    (code >= 0x3200 && code <= 0x33ff) || // Enclosed CJK + Compatibility
+    (code >= 0x3400 && code <= 0x4dbf) || // CJK Extension A
+    (code >= 0x4e00 && code <= 0x9fff) || // CJK Unified Ideographs
+    (code >= 0xac00 && code <= 0xd7af) || // Hangul Syllables
+    (code >= 0xf900 && code <= 0xfaff) || // CJK Compatibility Ideographs
+    (code >= 0xfe30 && code <= 0xfe4f) || // CJK Compatibility Forms
+    (code >= 0xff00 && code <= 0xff60) || // Fullwidth ASCII
+    (code >= 0xffe0 && code <= 0xffe6) || // Fullwidth symbols
+    code >= 0x20000                       // CJK Extension B and beyond
+  )
 }
 
+/**
+ * Calculate the display width of a string in monospace terminal columns.
+ * Fullwidth characters (CJK, etc.) count as 2; all others count as 1.
+ */
 export function displayWidth(str: string): number {
   let w = 0
-  for (const ch of str) w += isCJK(ch) ? 2 : 1
+  for (const ch of str) {
+    const code = ch.codePointAt(0)
+    w += (code !== undefined && isFullwidthChar(code)) ? 2 : 1
+  }
   return w
 }
 
+/**
+ * Draw a text string onto a column-major canvas with fullwidth character
+ * support. Each fullwidth character is followed by a `CJK_PAD` sentinel
+ * in the next column to maintain alignment.
+ *
+ * @param canvas - Column-major 2D character array (canvas[x][y])
+ * @param x - Starting column index
+ * @param y - Row index
+ * @param text - Text to draw
+ * @param forceOverwrite - If true, overwrite existing non-space characters
+ */
 export function drawCJKText(
-  canvas: string[][], x: number, y: number, text: string, forceOverwrite = false
+  canvas: Canvas,
+  x: number,
+  y: number,
+  text: string,
+  forceOverwrite = false,
 ): void {
   let offset = 0
   for (const ch of text) {
     const cx = x + offset
     if (cx >= 0 && cx < canvas.length && y >= 0 && y < (canvas[0]?.length ?? 0)) {
-      if (forceOverwrite || canvas[cx]![y] === ' ') canvas[cx]![y] = ch
+      if (forceOverwrite || canvas[cx]![y] === ' ') {
+        canvas[cx]![y] = ch
+      }
     }
     offset++
-    if (isCJK(ch)) {
+    const code = ch.codePointAt(0)
+    if (code !== undefined && isFullwidthChar(code)) {
       const px = x + offset
-      if (px >= 0 && px < canvas.length && y >= 0 && y < (canvas[0]?.length ?? 0)) canvas[px]![y] = CJK_PAD
+      if (px >= 0 && px < canvas.length && y >= 0 && y < (canvas[0]?.length ?? 0)) {
+        canvas[px]![y] = CJK_PAD
+      }
       offset++
     }
   }

--- a/src/ascii/cjk.ts
+++ b/src/ascii/cjk.ts
@@ -14,10 +14,11 @@ import type { Canvas, RoleCanvas, CharRole } from './types.ts'
  * Sentinel character placed in the "right half" of a fullwidth character's
  * canvas cell. Stripped by `canvasToString()` before output.
  *
- * Uses zero-width space (U+200B) — invisible in terminal output even if
- * stripping is accidentally skipped.
+ * Uses a Private Use Area character (U+E000) to avoid collisions with
+ * real user text. If stripping is accidentally skipped, the character
+ * renders as a visible box — making the bug immediately obvious.
  */
-export const CJK_PAD = '\u200B'
+export const CJK_PAD = '\uE000'
 
 /**
  * Check if a character occupies two columns in a monospace terminal.

--- a/src/ascii/class-diagram.ts
+++ b/src/ascii/class-diagram.ts
@@ -685,7 +685,7 @@ export function renderClassAscii(text: string, config: AsciiConfig, colorMode?: 
           increaseRoleCanvasSize(rc, Math.max(labelEnd, 1), Math.max(y + 1, 1))
         }
         // Clear the area first (overwrite line characters) then draw the padded label
-        drawCJKText(canvas, labelStart, y, paddedLine, true)
+        drawCJKText(canvas, labelStart, y, paddedLine, true, rc, 'text')
       }
     }
   }

--- a/src/ascii/class-diagram.ts
+++ b/src/ascii/class-diagram.ts
@@ -16,6 +16,7 @@ import type { Canvas, AsciiConfig, RoleCanvas, CharRole, AsciiTheme, ColorMode }
 import { mkCanvas, mkRoleCanvas, canvasToString, increaseSize, increaseRoleCanvasSize, setRole } from './canvas.ts'
 import { drawMultiBox } from './draw.ts'
 import { splitLines } from './multiline-utils.ts'
+import { displayWidth, drawCJKText, CJK_PAD } from './cjk.ts'
 
 /** Classify a character from a box drawing as 'border' or 'text'. */
 function classifyBoxChar(ch: string): CharRole {

--- a/src/ascii/class-diagram.ts
+++ b/src/ascii/class-diagram.ts
@@ -16,7 +16,7 @@ import type { Canvas, AsciiConfig, RoleCanvas, CharRole, AsciiTheme, ColorMode }
 import { mkCanvas, mkRoleCanvas, canvasToString, increaseSize, increaseRoleCanvasSize, setRole } from './canvas.ts'
 import { drawMultiBox } from './draw.ts'
 import { splitLines } from './multiline-utils.ts'
-import { displayWidth, drawCJKText, CJK_PAD } from './cjk.ts'
+import { displayWidth, drawCJKText } from './cjk.ts'
 
 /** Classify a character from a box drawing as 'border' or 'text'. */
 function classifyBoxChar(ch: string): CharRole {
@@ -171,7 +171,7 @@ export function renderClassAscii(text: string, config: AsciiConfig, colorMode?: 
     // Compute box dimensions from drawMultiBox logic
     let maxTextW = 0
     for (const section of sections) {
-      for (const line of section) maxTextW = Math.max(maxTextW, line.length)
+      for (const line of section) maxTextW = Math.max(maxTextW, displayWidth(line))
     }
     const boxW = maxTextW + 4 // 2 border + 2 padding
 
@@ -603,7 +603,7 @@ export function renderClassAscii(text: string, config: AsciiConfig, colorMode?: 
     // Add padding around the label for readability
     if (rel.label) {
       const lines = splitLines(rel.label)
-      const maxLabelWidth = Math.max(...lines.map(l => l.length)) + 2 // +2 for padding
+      const maxLabelWidth = Math.max(...lines.map(l => displayWidth(l))) + 2 // +2 for padding
 
       // Calculate ideal label position based on routing direction
       let baseMidY: number
@@ -674,22 +674,18 @@ export function renderClassAscii(text: string, config: AsciiConfig, colorMode?: 
       for (let lineIdx = 0; lineIdx < lines.length; lineIdx++) {
         const paddedLine = ` ${lines[lineIdx]!} `  // Add space padding on both sides
         // Calculate label start, but ensure it doesn't go negative
-        const idealLabelStart = idealMidX - Math.floor(paddedLine.length / 2)
+        const paddedLineW = displayWidth(paddedLine)
+        const idealLabelStart = idealMidX - Math.floor(paddedLineW / 2)
         const labelStart = Math.max(0, idealLabelStart)
         const y = startY + lineIdx
         // Ensure canvas is wide enough for the label
-        const labelEnd = labelStart + paddedLine.length
+        const labelEnd = labelStart + paddedLineW
         if (labelEnd > 0 && y >= 0) {
           increaseSize(canvas, Math.max(labelEnd, 1), Math.max(y + 1, 1))
           increaseRoleCanvasSize(rc, Math.max(labelEnd, 1), Math.max(y + 1, 1))
         }
         // Clear the area first (overwrite line characters) then draw the padded label
-        for (let i = 0; i < paddedLine.length; i++) {
-          const lx = labelStart + i
-          if (lx >= 0 && y >= 0) {
-            setC(lx, y, paddedLine[i]!, 'text')
-          }
-        }
+        drawCJKText(canvas, labelStart, y, paddedLine, true)
       }
     }
   }

--- a/src/ascii/draw.ts
+++ b/src/ascii/draw.ts
@@ -21,6 +21,7 @@ import { gridToDrawingCoord, lineToDrawing } from './grid.ts'
 import { splitLines } from './multiline-utils.ts'
 import { getCorners } from './shapes/corners.ts'
 import { getShapeAttachmentPoint } from './shapes/index.ts'
+import { displayWidth, drawCJKText, CJK_PAD } from './cjk.ts'
 
 // ============================================================================
 // Node drawing — renders a node using shape-aware rendering
@@ -104,12 +105,8 @@ function drawBoxWithGridDimensions(node: AsciiNode, graph: AsciiGraph): Canvas {
 
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i]!
-    const textX = from.x + Math.floor(w / 2) - Math.ceil(line.length / 2) + 1
-    for (let j = 0; j < line.length; j++) {
-      if (textX + j >= 0 && textX + j < box.length && startY + i >= 0 && startY + i < box[0]!.length) {
-        box[textX + j]![startY + i] = line[j]!
-      }
-    }
+    const textX = from.x + Math.floor(w / 2) - Math.ceil(displayWidth(line) / 2) + 1
+    drawCJKText(box, textX, startY + i, line)
   }
 
   return box
@@ -147,7 +144,7 @@ export function drawMultiBox(
   let maxTextWidth = 0
   for (const section of sections) {
     for (const line of section) {
-      maxTextWidth = Math.max(maxTextWidth, line.length)
+      maxTextWidth = Math.max(maxTextWidth, displayWidth(line))
     }
   }
   const innerWidth = maxTextWidth + 2 * padding
@@ -198,9 +195,7 @@ export function drawMultiBox(
     // Draw section text lines
     for (const line of lines) {
       const startX = 1 + padding
-      for (let i = 0; i < line.length; i++) {
-        canvas[startX + i]![row] = line[i]!
-      }
+      drawCJKText(canvas, startX, row, line)
       row++
     }
 
@@ -673,7 +668,7 @@ function drawTextOnLine(canvas: Canvas, line: DrawingCoord[], label: string, isU
 
   for (let i = 0; i < lines.length; i++) {
     const lineText = lines[i]!
-    const startX = middleX - Math.floor(lineText.length / 2)
+    const startX = middleX - Math.floor(displayWidth(lineText) / 2)
     drawText(canvas, { x: startX, y: startY + i }, lineText)
   }
 }
@@ -1142,14 +1137,10 @@ export function drawSubgraphLabel(sg: AsciiSubgraph, graph: AsciiGraph): [Canvas
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i]!
     const labelY = 1 + i
-    let labelX = Math.floor(width / 2) - Math.floor(line.length / 2)
+    let labelX = Math.floor(width / 2) - Math.floor(displayWidth(line) / 2)
     if (labelX < 1) labelX = 1
 
-    for (let j = 0; j < line.length; j++) {
-      if (labelX + j < width && labelY < height) {
-        canvas[labelX + j]![labelY] = line[j]!
-      }
-    }
+    drawCJKText(canvas, labelX, labelY, line)
   }
 
   return [canvas, { x: sg.minX, y: sg.minY }]

--- a/src/ascii/draw.ts
+++ b/src/ascii/draw.ts
@@ -21,7 +21,7 @@ import { gridToDrawingCoord, lineToDrawing } from './grid.ts'
 import { splitLines } from './multiline-utils.ts'
 import { getCorners } from './shapes/corners.ts'
 import { getShapeAttachmentPoint } from './shapes/index.ts'
-import { displayWidth, drawCJKText, CJK_PAD } from './cjk.ts'
+import { displayWidth, drawCJKText } from './cjk.ts'
 
 // ============================================================================
 // Node drawing — renders a node using shape-aware rendering

--- a/src/ascii/edge-routing.ts
+++ b/src/ascii/edge-routing.ts
@@ -13,6 +13,7 @@ import {
 } from './types.ts'
 import { getPath, mergePath } from './pathfinder.ts'
 import { getEffectiveDirection, getNodeSubgraph } from './grid.ts'
+import { displayWidth } from './cjk.ts'
 
 // ============================================================================
 // Direction utilities
@@ -227,7 +228,7 @@ export function determinePath(graph: AsciiGraph, edge: AsciiEdge): void {
 export function determineLabelLine(graph: AsciiGraph, edge: AsciiEdge): void {
   if (edge.text.length === 0) return
 
-  const lenLabel = edge.text.length
+  const lenLabel = displayWidth(edge.text)
   const pathLen = edge.path.length
   const isVerticalFlow = graph.config.graphDirection === 'TD'
 

--- a/src/ascii/er-diagram.ts
+++ b/src/ascii/er-diagram.ts
@@ -15,7 +15,7 @@ import type { Canvas, AsciiConfig, RoleCanvas, CharRole, AsciiTheme, ColorMode }
 import { mkCanvas, mkRoleCanvas, canvasToString, increaseSize, increaseRoleCanvasSize, setRole } from './canvas.ts'
 import { drawMultiBox } from './draw.ts'
 import { splitLines } from './multiline-utils.ts'
-import { displayWidth, drawCJKText, CJK_PAD } from './cjk.ts'
+import { displayWidth, drawCJKText } from './cjk.ts'
 
 /** Classify a character from a box drawing as 'border' or 'text'. */
 function classifyBoxChar(ch: string): CharRole {
@@ -345,17 +345,12 @@ export function renderErAscii(text: string, config: AsciiConfig, colorMode?: Col
         // Place lines below the relationship line (lineY + 1, lineY + 2, ...)
         for (let lineIdx = 0; lineIdx < lines.length; lineIdx++) {
           const line = lines[lineIdx]!
-          const labelStart = Math.max(startX, gapMid - Math.floor(line.length / 2))
+          const labelStart = Math.max(startX, gapMid - Math.floor(displayWidth(line) / 2))
           const labelY = lineY + 1 + lineIdx
           // Ensure canvas is tall enough
-          increaseSize(canvas, Math.max(labelStart + line.length, 1), Math.max(labelY + 1, 1))
-          increaseRoleCanvasSize(rc, Math.max(labelStart + line.length, 1), Math.max(labelY + 1, 1))
-          for (let i = 0; i < line.length; i++) {
-            const lx = labelStart + i
-            if (lx >= startX && lx <= endX) {
-              setC(lx, labelY, line[i]!, 'text')
-            }
-          }
+          increaseSize(canvas, Math.max(labelStart + displayWidth(line), 1), Math.max(labelY + 1, 1))
+          increaseRoleCanvasSize(rc, Math.max(labelStart + displayWidth(line), 1), Math.max(labelY + 1, 1))
+          drawCJKText(canvas, labelStart, labelY, line, true)
         }
       }
     } else {
@@ -418,14 +413,9 @@ export function renderErAscii(text: string, config: AsciiConfig, colorMode?: Col
           const labelX = lineX + 2
           const y = startLabelY + lineIdx
           if (y >= 0) {
-            for (let i = 0; i < line.length; i++) {
-              const lx = labelX + i
-              if (lx >= 0) {
-                increaseSize(canvas, lx + 1, y + 1)
-                increaseRoleCanvasSize(rc, lx + 1, y + 1)
-                setC(lx, y, line[i]!, 'text')
-              }
-            }
+            increaseSize(canvas, labelX + displayWidth(line) + 1, y + 1)
+            increaseRoleCanvasSize(rc, labelX + displayWidth(line) + 1, y + 1)
+            drawCJKText(canvas, labelX, y, line, true)
           }
         }
       }

--- a/src/ascii/er-diagram.ts
+++ b/src/ascii/er-diagram.ts
@@ -181,7 +181,7 @@ export function renderErAscii(text: string, config: AsciiConfig, colorMode?: Col
 
     let maxTextW = 0
     for (const section of sections) {
-      for (const line of section) maxTextW = Math.max(maxTextW, line.length)
+      for (const line of section) maxTextW = Math.max(maxTextW, displayWidth(line))
     }
     const boxW = maxTextW + 4 // 2 border + 2 padding
 
@@ -350,7 +350,7 @@ export function renderErAscii(text: string, config: AsciiConfig, colorMode?: Col
           // Ensure canvas is tall enough
           increaseSize(canvas, Math.max(labelStart + displayWidth(line), 1), Math.max(labelY + 1, 1))
           increaseRoleCanvasSize(rc, Math.max(labelStart + displayWidth(line), 1), Math.max(labelY + 1, 1))
-          drawCJKText(canvas, labelStart, labelY, line, true)
+          drawCJKText(canvas, labelStart, labelY, line, true, rc, 'text')
         }
       }
     } else {
@@ -415,7 +415,7 @@ export function renderErAscii(text: string, config: AsciiConfig, colorMode?: Col
           if (y >= 0) {
             increaseSize(canvas, labelX + displayWidth(line) + 1, y + 1)
             increaseRoleCanvasSize(rc, labelX + displayWidth(line) + 1, y + 1)
-            drawCJKText(canvas, labelX, y, line, true)
+            drawCJKText(canvas, labelX, y, line, true, rc, 'text')
           }
         }
       }

--- a/src/ascii/er-diagram.ts
+++ b/src/ascii/er-diagram.ts
@@ -15,6 +15,7 @@ import type { Canvas, AsciiConfig, RoleCanvas, CharRole, AsciiTheme, ColorMode }
 import { mkCanvas, mkRoleCanvas, canvasToString, increaseSize, increaseRoleCanvasSize, setRole } from './canvas.ts'
 import { drawMultiBox } from './draw.ts'
 import { splitLines } from './multiline-utils.ts'
+import { displayWidth, drawCJKText, CJK_PAD } from './cjk.ts'
 
 /** Classify a character from a box drawing as 'border' or 'text'. */
 function classifyBoxChar(ch: string): CharRole {

--- a/src/ascii/multiline-utils.ts
+++ b/src/ascii/multiline-utils.ts
@@ -8,6 +8,7 @@
 
 import type { Canvas } from './types.ts'
 import { drawText } from './canvas.ts'
+import { displayWidth } from './cjk.ts'
 
 /**
  * Split a label into lines.
@@ -23,7 +24,7 @@ export function splitLines(label: string): string[] {
  */
 export function maxLineWidth(label: string): number {
   const lines = splitLines(label)
-  return Math.max(...lines.map(l => l.length), 0)
+  return Math.max(...lines.map(l => displayWidth(l)), 0)
 }
 
 /**
@@ -53,7 +54,7 @@ export function drawMultilineTextCentered(
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i]!
     // Center each line horizontally
-    const startX = cx - Math.floor(line.length / 2)
+    const startX = cx - Math.floor(displayWidth(line) / 2)
     // Force overwrite for node labels (they take priority)
     drawText(canvas, { x: startX, y: startY + i }, line, true)
   }

--- a/src/ascii/sequence.ts
+++ b/src/ascii/sequence.ts
@@ -240,7 +240,7 @@ export function renderSequenceAscii(text: string, config: AsciiConfig, colorMode
       // Center this line within the box
       const line = lines[i]!
       const ls = left + 1 + boxPad + Math.floor((maxW - displayWidth(line)) / 2)
-      drawCJKText(canvas, ls, row, line, true)
+      drawCJKText(canvas, ls, row, line, true, rc, 'text')
     }
 
     // Bottom border
@@ -304,7 +304,7 @@ export function renderSequenceAscii(text: string, config: AsciiConfig, colorMode
       // Row 1: vertical on right side + label
       setC(fromX + loopW, y0 + 1, V, 'line')
       const labelX = fromX + loopW + 2
-      drawCJKText(canvas, labelX, y0 + 1, msg.label, true)
+      drawCJKText(canvas, labelX, y0 + 1, msg.label, true, rc, 'text')
 
       // Row 2: arrow-back + horizontal + bottom-right corner
       const arrowChar = isFilled ? (useAscii ? '<' : '◀') : (useAscii ? '<' : '◁')
@@ -325,7 +325,7 @@ export function renderSequenceAscii(text: string, config: AsciiConfig, colorMode
         const line = msgLines[lineIdx]!
         const labelStart = midX - Math.floor(displayWidth(line) / 2)
         const y = labelY + lineIdx
-        drawCJKText(canvas, labelStart, y, line, true)
+        drawCJKText(canvas, labelStart, y, line, true, rc, 'text')
       }
 
       // Draw arrow line
@@ -375,7 +375,7 @@ export function renderSequenceAscii(text: string, config: AsciiConfig, colorMode
 
     for (let lineIdx = 0; lineIdx < hdrLines.length && topY + lineIdx < botY; lineIdx++) {
       const line = hdrLines[lineIdx]!
-      drawCJKText(canvas, bLeft + 1, topY + lineIdx, line, true)
+      drawCJKText(canvas, bLeft + 1, topY + lineIdx, line, true, rc, 'text')
     }
 
     // Bottom border
@@ -401,7 +401,7 @@ export function renderSequenceAscii(text: string, config: AsciiConfig, colorMode
       const dLabel = block.dividers[d]!.label
       if (dLabel) {
         const dStr = `[${dLabel}]`
-        drawCJKText(canvas, bLeft + 1, dY, dStr, true)
+        drawCJKText(canvas, bLeft + 1, dY, dStr, true, rc, 'text')
       }
     }
   }
@@ -421,7 +421,7 @@ export function renderSequenceAscii(text: string, config: AsciiConfig, colorMode
       const ly = np.y + 1 + l
       setC(np.x, ly, V, 'border')
       setC(np.x + np.width - 1, ly, V, 'border')
-      drawCJKText(canvas, np.x + 2, ly, np.lines[l]!, true)
+      drawCJKText(canvas, np.x + 2, ly, np.lines[l]!, true, rc, 'text')
     }
     // Bottom border
     const by = np.y + np.height - 1

--- a/src/ascii/sequence.ts
+++ b/src/ascii/sequence.ts
@@ -14,7 +14,7 @@ import type { SequenceDiagram, Block } from '../sequence/types.ts'
 import type { Canvas, AsciiConfig, RoleCanvas, CharRole, AsciiTheme, ColorMode } from './types.ts'
 import { mkCanvas, mkRoleCanvas, canvasToString, increaseSize, increaseRoleCanvasSize, setRole } from './canvas.ts'
 import { splitLines, maxLineWidth, lineCount } from './multiline-utils.ts'
-import { displayWidth, drawCJKText, CJK_PAD } from './cjk.ts'
+import { displayWidth, drawCJKText } from './cjk.ts'
 
 /** Classify a box-drawing character as 'border' or 'text'. */
 function classifyBoxChar(ch: string): CharRole {
@@ -149,7 +149,7 @@ export function renderSequenceAscii(text: string, config: AsciiConfig, colorMode
         curY += 1
         const note = diagram.notes[n]!
         const nLines = splitLines(note.text)
-        const nWidth = Math.max(...nLines.map(l => l.length)) + 4
+        const nWidth = Math.max(...nLines.map(l => displayWidth(l))) + 4
         const nHeight = nLines.length + 2
 
         // Determine x position based on note.position
@@ -239,10 +239,8 @@ export function renderSequenceAscii(text: string, config: AsciiConfig, colorMode
       setC(left + w - 1, row, V, 'border')
       // Center this line within the box
       const line = lines[i]!
-      const ls = left + 1 + boxPad + Math.floor((maxW - line.length) / 2)
-      for (let j = 0; j < line.length; j++) {
-        setC(ls + j, row, line[j]!, 'text')
-      }
+      const ls = left + 1 + boxPad + Math.floor((maxW - displayWidth(line)) / 2)
+      drawCJKText(canvas, ls, row, line, true)
     }
 
     // Bottom border
@@ -306,9 +304,7 @@ export function renderSequenceAscii(text: string, config: AsciiConfig, colorMode
       // Row 1: vertical on right side + label
       setC(fromX + loopW, y0 + 1, V, 'line')
       const labelX = fromX + loopW + 2
-      for (let i = 0; i < msg.label.length; i++) {
-        if (labelX + i < totalW) setC(labelX + i, y0 + 1, msg.label[i]!, 'text')
-      }
+      drawCJKText(canvas, labelX, y0 + 1, msg.label, true)
 
       // Row 2: arrow-back + horizontal + bottom-right corner
       const arrowChar = isFilled ? (useAscii ? '<' : '◀') : (useAscii ? '<' : '◁')
@@ -327,12 +323,9 @@ export function renderSequenceAscii(text: string, config: AsciiConfig, colorMode
 
       for (let lineIdx = 0; lineIdx < msgLines.length; lineIdx++) {
         const line = msgLines[lineIdx]!
-        const labelStart = midX - Math.floor(line.length / 2)
+        const labelStart = midX - Math.floor(displayWidth(line) / 2)
         const y = labelY + lineIdx
-        for (let i = 0; i < line.length; i++) {
-          const lx = labelStart + i
-          if (lx >= 0 && lx < totalW) setC(lx, y, line[i]!, 'text')
-        }
+        drawCJKText(canvas, labelStart, y, line, true)
       }
 
       // Draw arrow line
@@ -382,9 +375,7 @@ export function renderSequenceAscii(text: string, config: AsciiConfig, colorMode
 
     for (let lineIdx = 0; lineIdx < hdrLines.length && topY + lineIdx < botY; lineIdx++) {
       const line = hdrLines[lineIdx]!
-      for (let i = 0; i < line.length && bLeft + 1 + i < bRight; i++) {
-        setC(bLeft + 1 + i, topY + lineIdx, line[i]!, 'text')
-      }
+      drawCJKText(canvas, bLeft + 1, topY + lineIdx, line, true)
     }
 
     // Bottom border
@@ -410,9 +401,7 @@ export function renderSequenceAscii(text: string, config: AsciiConfig, colorMode
       const dLabel = block.dividers[d]!.label
       if (dLabel) {
         const dStr = `[${dLabel}]`
-        for (let i = 0; i < dStr.length && bLeft + 1 + i < bRight; i++) {
-          setC(bLeft + 1 + i, dY, dStr[i]!, 'text')
-        }
+        drawCJKText(canvas, bLeft + 1, dY, dStr, true)
       }
     }
   }
@@ -432,9 +421,7 @@ export function renderSequenceAscii(text: string, config: AsciiConfig, colorMode
       const ly = np.y + 1 + l
       setC(np.x, ly, V, 'border')
       setC(np.x + np.width - 1, ly, V, 'border')
-      for (let i = 0; i < np.lines[l]!.length; i++) {
-        setC(np.x + 2 + i, ly, np.lines[l]![i]!, 'text')
-      }
+      drawCJKText(canvas, np.x + 2, ly, np.lines[l]!, true)
     }
     // Bottom border
     const by = np.y + np.height - 1

--- a/src/ascii/sequence.ts
+++ b/src/ascii/sequence.ts
@@ -14,6 +14,7 @@ import type { SequenceDiagram, Block } from '../sequence/types.ts'
 import type { Canvas, AsciiConfig, RoleCanvas, CharRole, AsciiTheme, ColorMode } from './types.ts'
 import { mkCanvas, mkRoleCanvas, canvasToString, increaseSize, increaseRoleCanvasSize, setRole } from './canvas.ts'
 import { splitLines, maxLineWidth, lineCount } from './multiline-utils.ts'
+import { displayWidth, drawCJKText, CJK_PAD } from './cjk.ts'
 
 /** Classify a box-drawing character as 'border' or 'text'. */
 function classifyBoxChar(ch: string): CharRole {
@@ -198,7 +199,7 @@ export function renderSequenceAscii(text: string, config: AsciiConfig, colorMode
     const msg = diagram.messages[m]!
     if (msg.from === msg.to) {
       const fi = actorIdx.get(msg.from)!
-      const selfRight = llX[fi]! + 6 + 2 + msg.label.length
+      const selfRight = llX[fi]! + 6 + 2 + displayWidth(msg.label)
       totalW = Math.max(totalW, selfRight + 1)
     }
   }

--- a/src/ascii/shapes/rectangle.ts
+++ b/src/ascii/shapes/rectangle.ts
@@ -13,7 +13,7 @@ import { splitLines } from '../multiline-utils.ts'
 import type { ShapeRenderer, ShapeDimensions, ShapeRenderOptions } from './types.ts'
 import { dirEquals } from '../edge-routing.ts'
 import { type CornerChars, getCorners } from './corners.ts'
-import { displayWidth, drawCJKText, CJK_PAD } from '../cjk.ts'
+import { displayWidth, drawCJKText } from '../cjk.ts'
 
 // ============================================================================
 // Shared dimension calculation

--- a/src/ascii/shapes/rectangle.ts
+++ b/src/ascii/shapes/rectangle.ts
@@ -13,6 +13,7 @@ import { splitLines } from '../multiline-utils.ts'
 import type { ShapeRenderer, ShapeDimensions, ShapeRenderOptions } from './types.ts'
 import { dirEquals } from '../edge-routing.ts'
 import { type CornerChars, getCorners } from './corners.ts'
+import { displayWidth, drawCJKText, CJK_PAD } from '../cjk.ts'
 
 // ============================================================================
 // Shared dimension calculation
@@ -24,7 +25,7 @@ import { type CornerChars, getCorners } from './corners.ts'
  */
 export function getBoxDimensions(label: string, options: ShapeRenderOptions): ShapeDimensions {
   const lines = splitLines(label)
-  const maxLineWidth = Math.max(...lines.map(l => l.length), 0)
+  const maxLineWidth = Math.max(...lines.map(l => displayWidth(l)), 0)
   const lineCount = lines.length
 
   // Width: 2*padding + maxLineWidth + 2 border chars
@@ -108,14 +109,8 @@ export function renderBox(
 
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i]!
-    const textX = Math.floor(w / 2) - Math.ceil(line.length / 2) + 1
-    for (let j = 0; j < line.length; j++) {
-      const x = textX + j
-      const y = startY + i
-      if (x >= 0 && x < canvas.length && y >= 0 && y < canvas[0]!.length) {
-        canvas[x]![y] = line[j]!
-      }
-    }
+    const textX = Math.floor(w / 2) - Math.ceil(displayWidth(line) / 2) + 1
+    drawCJKText(canvas, textX, startY + i, line)
   }
 
   return canvas

--- a/src/ascii/shapes/special.ts
+++ b/src/ascii/shapes/special.ts
@@ -13,7 +13,7 @@ import type { ShapeRenderer, ShapeDimensions, ShapeRenderOptions } from './types
 import { dirEquals } from '../edge-routing.ts'
 import { getBoxDimensions, renderBox, getBoxAttachmentPoint } from './rectangle.ts'
 import { getCorners } from './corners.ts'
-import { displayWidth, drawCJKText, CJK_PAD } from '../cjk.ts'
+import { displayWidth, drawCJKText } from '../cjk.ts'
 
 // ============================================================================
 // Subroutine — keeps custom double-border rendering

--- a/src/ascii/shapes/special.ts
+++ b/src/ascii/shapes/special.ts
@@ -13,6 +13,7 @@ import type { ShapeRenderer, ShapeDimensions, ShapeRenderOptions } from './types
 import { dirEquals } from '../edge-routing.ts'
 import { getBoxDimensions, renderBox, getBoxAttachmentPoint } from './rectangle.ts'
 import { getCorners } from './corners.ts'
+import { displayWidth, drawCJKText, CJK_PAD } from '../cjk.ts'
 
 // ============================================================================
 // Subroutine — keeps custom double-border rendering
@@ -28,7 +29,7 @@ import { getCorners } from './corners.ts'
 export const subroutineRenderer: ShapeRenderer = {
   getDimensions(label: string, options: ShapeRenderOptions): ShapeDimensions {
     const lines = splitLines(label)
-    const maxLineWidth = Math.max(...lines.map(l => l.length), 0)
+    const maxLineWidth = Math.max(...lines.map(l => displayWidth(l)), 0)
     const lineCount = lines.length
 
     const innerWidth = 2 * options.padding + maxLineWidth
@@ -86,14 +87,8 @@ export const subroutineRenderer: ShapeRenderer = {
 
     for (let i = 0; i < lines.length; i++) {
       const line = lines[i]!
-      const textX = Math.floor(width / 2) - Math.floor(line.length / 2)
-      for (let j = 0; j < line.length; j++) {
-        const x = textX + j
-        const y = startY + i
-        if (x > 1 && x < width - 2 && y > 0 && y < height - 1) {
-          canvas[x]![y] = line[j]!
-        }
-      }
+      const textX = Math.floor(width / 2) - Math.floor(displayWidth(line) / 2)
+      drawCJKText(canvas, textX, startY + i, line)
     }
 
     return canvas
@@ -142,7 +137,7 @@ export const doublecircleRenderer: ShapeRenderer = {
 export const cylinderRenderer: ShapeRenderer = {
   getDimensions(label: string, options: ShapeRenderOptions): ShapeDimensions {
     const lines = splitLines(label)
-    const maxLineWidth = Math.max(...lines.map(l => l.length), 0)
+    const maxLineWidth = Math.max(...lines.map(l => displayWidth(l)), 0)
     const lineCount = lines.length
 
     const innerWidth = 2 * options.padding + maxLineWidth
@@ -204,14 +199,8 @@ export const cylinderRenderer: ShapeRenderer = {
 
     for (let i = 0; i < lines.length; i++) {
       const line = lines[i]!
-      const textX = Math.floor(width / 2) - Math.floor(line.length / 2)
-      for (let j = 0; j < line.length; j++) {
-        const x = textX + j
-        const y = startY + i
-        if (x > 0 && x < width - 1 && y > 1 && y < height - 2) {
-          canvas[x]![y] = line[j]!
-        }
-      }
+      const textX = Math.floor(width / 2) - Math.floor(displayWidth(line) / 2)
+      drawCJKText(canvas, textX, startY + i, line)
     }
 
     return canvas

--- a/src/ascii/shapes/stadium.ts
+++ b/src/ascii/shapes/stadium.ts
@@ -11,6 +11,7 @@ import { mkCanvas } from '../canvas.ts'
 import { splitLines } from '../multiline-utils.ts'
 import type { ShapeRenderer, ShapeDimensions, ShapeRenderOptions } from './types.ts'
 import { getBoxAttachmentPoint } from './rectangle.ts'
+import { displayWidth, drawCJKText, CJK_PAD } from '../cjk.ts'
 
 /**
  * Stadium (pill) shape renderer.
@@ -30,7 +31,7 @@ import { getBoxAttachmentPoint } from './rectangle.ts'
 export const stadiumRenderer: ShapeRenderer = {
   getDimensions(label: string, options: ShapeRenderOptions): ShapeDimensions {
     const lines = splitLines(label)
-    const maxLineWidth = Math.max(...lines.map(l => l.length), 0)
+    const maxLineWidth = Math.max(...lines.map(l => displayWidth(l)), 0)
     const lineCount = lines.length
 
     const innerWidth = 2 * options.padding + maxLineWidth
@@ -95,14 +96,8 @@ export const stadiumRenderer: ShapeRenderer = {
 
     for (let i = 0; i < lines.length; i++) {
       const line = lines[i]!
-      const textX = Math.floor(width / 2) - Math.floor(line.length / 2)
-      for (let j = 0; j < line.length; j++) {
-        const x = textX + j
-        const y = startY + i
-        if (x > 0 && x < width - 1 && y >= 0 && y < height) {
-          canvas[x]![y] = line[j]!
-        }
-      }
+      const textX = Math.floor(width / 2) - Math.floor(displayWidth(line) / 2)
+      drawCJKText(canvas, textX, startY + i, line)
     }
 
     return canvas

--- a/src/ascii/shapes/stadium.ts
+++ b/src/ascii/shapes/stadium.ts
@@ -11,7 +11,7 @@ import { mkCanvas } from '../canvas.ts'
 import { splitLines } from '../multiline-utils.ts'
 import type { ShapeRenderer, ShapeDimensions, ShapeRenderOptions } from './types.ts'
 import { getBoxAttachmentPoint } from './rectangle.ts'
-import { displayWidth, drawCJKText, CJK_PAD } from '../cjk.ts'
+import { displayWidth, drawCJKText } from '../cjk.ts'
 
 /**
  * Stadium (pill) shape renderer.


### PR DESCRIPTION
## Summary

The ASCII renderer uses `.length` for terminal width calculations, but CJK (Chinese/Japanese/Korean) characters occupy **2 terminal columns** while `.length` counts them as 1. This causes box borders, labels, and edges to misalign when CJK text is present.

**Before (broken):**
```
┌──────┐
│      │
│ 中文测试 │    ← text overflows the box
│      │
└──────┘
```

**After (fixed):**
```
┌──────────┐
│          │
│ 中文测试 │    ← perfectly aligned
│          │
└──────────┘
```

## Changes

- **New file: `src/ascii/cjk.ts`** — CJK width utilities:
  - `displayWidth(str)` — calculates terminal display width (CJK=2, ASCII=1)
  - `drawCJKText(canvas, x, y, text)` — draws text onto canvas with zero-width space padding after CJK characters
  - `CJK_PAD` — zero-width space (`\u200B`) used as column placeholder

- **Modified 9 files** across all ASCII renderers:
  - `canvas.ts` — `drawText()` uses `displayWidth`/`drawCJKText`; `canvasToString()` skips `CJK_PAD` in both plain and colored modes
  - `draw.ts` — node labels, edge labels, multi-box, subgraph labels
  - `edge-routing.ts` — label width for column sizing
  - `shapes/rectangle.ts`, `shapes/stadium.ts`, `shapes/special.ts` — dimension calculation and label rendering
  - `sequence.ts` — actor boxes, message labels, notes, block headers, dividers
  - `class-diagram.ts` — relationship labels
  - `er-diagram.ts` — horizontal and vertical relationship labels

## Testing

Verified with all 5 diagram types using Chinese text:

| Diagram Type | CJK Status |
|---|---|
| flowchart (LR/TD/BT) | ✅ |
| sequenceDiagram | ✅ |
| classDiagram | ✅ |
| erDiagram | ✅ |
| stateDiagram-v2 | ⚠️ blocked by parser regex (#43) |

Also tested: mixed CJK/ASCII labels, single-character labels, subgraph labels, `--ascii` mode, and multi-line labels.

## Note

`text-metrics.ts` already handles CJK width correctly for the **SVG renderer** — this PR brings the same treatment to the **ASCII renderer**, which was missing CJK-aware width calculations entirely.

Relates to #43 (stateDiagram CJK is a separate parser issue)