### PR TITLE
Add linkStyle support for inline edge styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,6 +343,27 @@ erDiagram
   PRODUCT ||--o{ LINE_ITEM : "is in"
 ```
 
+### Inline Edge Styling
+
+Use `linkStyle` to override edge colors and stroke widths — just like [Mermaid's linkStyle](https://mermaid.js.org/syntax/flowchart.html#styling-links):
+
+```
+graph TD
+  A --> B --> C
+  linkStyle 0 stroke:#ff0000,stroke-width:2px
+  linkStyle default stroke:#888888
+```
+
+|             Syntax              |                 Effect                 |
+| ------------------------------- | -------------------------------------- |
+| `linkStyle 0 stroke:#f00`       | Style a single edge by index (0-based) |
+| `linkStyle 0,2 stroke:#f00`     | Style multiple edges at once           |
+| `linkStyle default stroke:#888` | Default style applied to all edges     |
+
+Index-specific styles override the default. Supported properties: `stroke`, `stroke-width`.
+
+Works in both flowcharts and state diagrams.
+
 ---
 
 ## ASCII Output

--- a/src/__tests__/linkstyle.test.ts
+++ b/src/__tests__/linkstyle.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'bun:test'
+import { parseMermaid } from '../parser.ts'
+import { renderMermaidSVG } from '../index.ts'
+
+describe('linkStyle – parser', () => {
+  it('parses linkStyle with single index', () => {
+    const g = parseMermaid('graph TD\n  A --> B\n  linkStyle 0 stroke:#ff0000,stroke-width:2px')
+    expect(g.linkStyles.get(0)).toEqual({ stroke: '#ff0000', 'stroke-width': '2px' })
+  })
+
+  it('parses linkStyle with comma-separated indices', () => {
+    const g = parseMermaid('graph TD\n  A --> B\n  B --> C\n  linkStyle 0,1 stroke:#00ff00')
+    expect(g.linkStyles.get(0)).toEqual({ stroke: '#00ff00' })
+    expect(g.linkStyles.get(1)).toEqual({ stroke: '#00ff00' })
+  })
+
+  it('parses linkStyle default', () => {
+    const g = parseMermaid('graph TD\n  A --> B\n  linkStyle default stroke:#888888,stroke-width:3px')
+    expect(g.linkStyles.get('default')).toEqual({ stroke: '#888888', 'stroke-width': '3px' })
+  })
+
+  it('later linkStyle overrides earlier for same index', () => {
+    const g = parseMermaid('graph TD\n  A --> B\n  linkStyle 0 stroke:#ff0000\n  linkStyle 0 stroke:#00ff00')
+    expect(g.linkStyles.get(0)).toEqual({ stroke: '#00ff00' })
+  })
+
+  it('ignores linkStyle lines silently (no crash) when index out of range', () => {
+    const g = parseMermaid('graph TD\n  A --> B\n  linkStyle 99 stroke:#ff0000')
+    expect(g.linkStyles.get(99)).toEqual({ stroke: '#ff0000' })
+    expect(g.edges).toHaveLength(1)
+  })
+
+  it('strips trailing semicolons from style values', () => {
+    const g = parseMermaid('graph TD\n  A --> B\n  linkStyle 0 stroke:#ff0000,stroke-width:4px;')
+    expect(g.linkStyles.get(0)).toEqual({ stroke: '#ff0000', 'stroke-width': '4px' })
+  })
+})
+
+describe('linkStyle – state diagram parser', () => {
+  it('parses linkStyle in state diagrams', () => {
+    const g = parseMermaid('stateDiagram-v2\n  A --> B\n  linkStyle 0 stroke:#ff0000')
+    expect(g.linkStyles.get(0)).toEqual({ stroke: '#ff0000' })
+  })
+
+  it('parses linkStyle default in state diagrams', () => {
+    const g = parseMermaid('stateDiagram-v2\n  A --> B\n  B --> C\n  linkStyle default stroke:#888')
+    expect(g.linkStyles.get('default')).toEqual({ stroke: '#888' })
+  })
+})
+
+describe('linkStyle – SVG integration', () => {
+  it('applies linkStyle stroke color to SVG edge', () => {
+    const svg = renderMermaidSVG('graph TD\n  A --> B\n  linkStyle 0 stroke:#ff0000')
+    expect(svg).toContain('stroke="#ff0000"')
+  })
+
+  it('applies linkStyle stroke-width to SVG edge', () => {
+    const svg = renderMermaidSVG('graph TD\n  A --> B\n  linkStyle 0 stroke-width:3px')
+    expect(svg).toContain('stroke-width="3px"')
+  })
+
+  it('applies linkStyle default to all edges', () => {
+    const svg = renderMermaidSVG('graph TD\n  A --> B\n  B --> C\n  linkStyle default stroke:#00ff00')
+    const matches = svg.match(/stroke="#00ff00"/g)
+    expect(matches).not.toBeNull()
+    expect(matches!.length).toBeGreaterThanOrEqual(2)
+  })
+
+  it('index-specific linkStyle overrides default', () => {
+    const svg = renderMermaidSVG(
+      'graph TD\n  A --> B\n  B --> C\n  linkStyle default stroke:#888\n  linkStyle 0 stroke:#ff0000'
+    )
+    expect(svg).toContain('stroke="#ff0000"')
+    expect(svg).toContain('stroke="#888"')
+  })
+
+  it('arrowhead color matches custom stroke color', () => {
+    const svg = renderMermaidSVG('graph TD\n  A --> B\n  linkStyle 0 stroke:#ff0000')
+    // Should have a color-specific marker def (# is hex-encoded to "23")
+    expect(svg).toContain('id="arrowhead-23ff0000"')
+    expect(svg).toContain('fill="#ff0000"')
+    // Edge should reference the colored marker
+    expect(svg).toContain('marker-end="url(#arrowhead-23ff0000)"')
+  })
+
+  it('escapes XSS injection in stroke value', () => {
+    const svg = renderMermaidSVG('graph TD\n  A --> B\n  linkStyle 0 stroke:red" onmouseover="alert(1)')
+    // Quotes must be escaped — no attribute breakout
+    expect(svg).not.toContain('stroke="red" onmouseover')
+    expect(svg).toContain('stroke="red&quot; onmouseover=&quot;alert(1)"')
+  })
+
+  it('trailing semicolons do not leak into SVG attributes', () => {
+    const svg = renderMermaidSVG('graph TD\n  A --> B\n  linkStyle 0 stroke:#ff0000,stroke-width:4px;')
+    expect(svg).toContain('stroke-width="4px"')
+    expect(svg).not.toContain('stroke-width="4px;"')
+  })
+})

--- a/src/layout-engine.ts
+++ b/src/layout-engine.ts
@@ -784,6 +784,7 @@ function extractEdgesRecursively(
       hasArrowEnd: originalEdge.hasArrowEnd,
       points: orthogonalPoints,
       labelPosition,
+      inlineStyle: resolveEdgeStyle(edgeIndex, graph),
     })
   }
 }
@@ -978,6 +979,29 @@ function resolveNodeStyle(
   const nodeStyle = graph.nodeStyles.get(nodeId)
   if (nodeStyle) {
     result = result ? { ...result, ...nodeStyle } : { ...nodeStyle }
+  }
+
+  return result
+}
+
+/**
+ * Resolve inline styles for an edge from linkStyles map.
+ * Default link style is applied first, then index-specific overrides.
+ */
+function resolveEdgeStyle(
+  edgeIndex: number,
+  graph: MermaidGraph
+): Record<string, string> | undefined {
+  let result: Record<string, string> | undefined
+
+  const defaultStyle = graph.linkStyles.get('default')
+  if (defaultStyle) {
+    result = { ...defaultStyle }
+  }
+
+  const indexStyle = graph.linkStyles.get(edgeIndex)
+  if (indexStyle) {
+    result = result ? { ...result, ...indexStyle } : { ...indexStyle }
   }
 
   return result

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,6 +12,8 @@ export interface MermaidGraph {
   classAssignments: Map<string, string>
   /** Maps node IDs to inline styles (from `style X fill:#f00,stroke:#333`) */
   nodeStyles: Map<string, Record<string, string>>
+  /** Maps edge indices (or 'default') to inline styles from `linkStyle` directives */
+  linkStyles: Map<number | 'default', Record<string, string>>
 }
 
 export type Direction = 'TD' | 'TB' | 'LR' | 'BT' | 'RL'
@@ -98,6 +100,8 @@ export interface PositionedEdge {
   points: Point[]
   /** Layout-computed label center position (avoids label-label collisions) */
   labelPosition?: Point
+  /** Inline styles resolved from `linkStyle` directives — override theme defaults */
+  inlineStyle?: Record<string, string>
 }
 
 export interface Point {


### PR DESCRIPTION
Goal is to support linkStyle that I'm using heavily in my mermaid files. Thank you for considering this patch to this great project.

- Add linkStyle directive parsing for flowcharts and state diagrams — supports single index (linkStyle 0), comma-separated indices (linkStyle 0,2), and default keyword
- Apply resolved styles (stroke, stroke-width) to SVG edge output, with index-specific overrides taking precedence over defaults
- Document the feature in the README with syntax table and examples

Example file

```ts
import { renderMermaidSVG } from '../src/index.ts'
import { writeFileSync } from 'fs'

const svg = renderMermaidSVG(
  `graph TD
  A[Start] --> B{Decision}
  B -->|Yes| C[Accept]
  B -->|No| D[Reject]
  C --> E[Done]
  D --> E
  linkStyle 0 stroke:#7aa2f7,stroke-width:3px
  linkStyle 1 stroke:#9ece6a,stroke-width:2px
  linkStyle 2 stroke:#f7768e,stroke-width:2px
  linkStyle default stroke:#565f89`,
  { bg: '#1a1b26', fg: '#a9b1d6', accent: '#7aa2f7' }
)

writeFileSync('linkstyle-example.svg', svg)
console.log(`wrote linkstyle-example.svg (${svg.length} bytes)`)
``` 

<img width="291" height="521" alt="image" src="https://github.com/user-attachments/assets/0bc8680e-723a-46cb-b550-6eb7490d3b18" />