### PR TITLE
feat: add CLI for rendering diagrams from the command line

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,9 @@
     "theming"
   ],
   "author": "Craft Docs",
+  "bin": {
+    "beautiful-mermaid": "dist/cli.js"
+  },
   "files": ["src/", "dist/", "LICENSE", "README.md"],
   "scripts": {
     "test": "bun test src/__tests__/",

--- a/src/__tests__/cli-diagrams.test.ts
+++ b/src/__tests__/cli-diagrams.test.ts
@@ -1,12 +1,3 @@
-/**
- * Smoke tests: all 6 supported diagram types through the CLI render pipeline.
- *
- * For each diagram type, verifies:
- * - ASCII output is non-empty
- * - SVG file contains proper <svg> wrapper
- *
- * Uses runRender directly (no subprocess) for speed and reliability.
- */
 import { describe, it, expect, beforeEach, afterEach } from 'bun:test'
 import { mkdtemp, writeFile, readFile, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'

--- a/src/__tests__/cli-diagrams.test.ts
+++ b/src/__tests__/cli-diagrams.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Smoke tests: all 6 supported diagram types through the CLI render pipeline.
+ *
+ * For each diagram type, verifies:
+ * - ASCII output is non-empty
+ * - SVG file contains proper <svg> wrapper
+ *
+ * Uses runRender directly (no subprocess) for speed and reliability.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test'
+import { mkdtemp, writeFile, readFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { runRender } from '../cli/render.ts'
+import type { RenderArgs } from '../cli/parse-args.ts'
+
+// ============================================================================
+// Diagram sources — one per supported type
+// ============================================================================
+
+const diagrams: Record<string, string> = {
+  flowchart: `graph TD
+  A[Start] --> B{Decision}
+  B -->|Yes| C[Action]
+  B -->|No| D[End]
+  C --> D`,
+
+  sequence: `sequenceDiagram
+  Alice->>Bob: Hello Bob!
+  Bob-->>Alice: Hi Alice!
+  Alice->>Bob: How are you?`,
+
+  state: `stateDiagram-v2
+  [*] --> Idle
+  Idle --> Processing: start
+  Processing --> Complete: done
+  Complete --> [*]`,
+
+  class: `classDiagram
+  Animal <|-- Duck
+  Animal <|-- Fish
+  Animal: +int age
+  Animal: +isMammal() bool
+  Duck: +String beakColor
+  Duck: +swim()`,
+
+  er: `erDiagram
+  CUSTOMER ||--o{ ORDER : places
+  ORDER ||--|{ LINE_ITEM : contains
+  CUSTOMER {
+    string name
+    int id
+  }`,
+
+  xychart: `xychart-beta
+  title "Sales Revenue"
+  x-axis [jan, feb, mar, apr]
+  y-axis "Revenue (k)" 0 --> 120
+  bar [50, 60, 75, 90]`,
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/** Collect all write() calls into a single string. */
+function createMockStdout(): { write: (s: string) => void; output: () => string } {
+  const chunks: string[] = []
+  return {
+    write: (s: string) => chunks.push(s),
+    output: () => chunks.join(''),
+  }
+}
+
+/** Build a RenderArgs with sensible defaults. */
+function renderArgs(overrides: Partial<RenderArgs> = {}): RenderArgs {
+  return {
+    command: 'render',
+    input: undefined,
+    ascii: false,
+    svg: false,
+    output: undefined,
+    theme: undefined,
+    ...overrides,
+  }
+}
+
+// ============================================================================
+// Temp directory lifecycle
+// ============================================================================
+
+let tmpDir: string
+
+beforeEach(async () => {
+  tmpDir = await mkdtemp(join(tmpdir(), 'cli-diagrams-test-'))
+})
+
+afterEach(async () => {
+  await rm(tmpDir, { recursive: true, force: true })
+})
+
+// ============================================================================
+// Smoke tests — one per diagram type
+// ============================================================================
+
+describe('CLI diagram smoke tests', () => {
+  for (const [name, source] of Object.entries(diagrams)) {
+    it(`renders ${name} diagram as ASCII + SVG`, async () => {
+      // 1. Write source to a temp .mmd file
+      const inputPath = join(tmpDir, `${name}.mmd`)
+      const outputPath = join(tmpDir, `${name}.svg`)
+      await writeFile(inputPath, source)
+
+      // 2. Call runRender with both ascii and svg enabled
+      const mockStdout = createMockStdout()
+      await runRender(
+        renderArgs({ input: inputPath, ascii: true, svg: true, output: outputPath }),
+        mockStdout,
+      )
+
+      // 3. Assert ASCII output is non-empty
+      const asciiOutput = mockStdout.output()
+      expect(asciiOutput.length).toBeGreaterThan(0)
+
+      // 4. Assert SVG file is valid
+      const svgContent = await readFile(outputPath, 'utf-8')
+      expect(svgContent).toContain('<svg')
+      expect(svgContent).toContain('</svg>')
+    })
+  }
+})

--- a/src/__tests__/cli-diagrams.test.ts
+++ b/src/__tests__/cli-diagrams.test.ts
@@ -12,7 +12,7 @@ import { mkdtemp, writeFile, readFile, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { runRender } from '../cli/render.ts'
-import type { RenderArgs } from '../cli/parse-args.ts'
+import { createMockStdout, renderArgs } from './cli-test-helpers.ts'
 
 // ============================================================================
 // Diagram sources — one per supported type
@@ -57,32 +57,6 @@ const diagrams: Record<string, string> = {
   x-axis [jan, feb, mar, apr]
   y-axis "Revenue (k)" 0 --> 120
   bar [50, 60, 75, 90]`,
-}
-
-// ============================================================================
-// Helpers
-// ============================================================================
-
-/** Collect all write() calls into a single string. */
-function createMockStdout(): { write: (s: string) => void; output: () => string } {
-  const chunks: string[] = []
-  return {
-    write: (s: string) => chunks.push(s),
-    output: () => chunks.join(''),
-  }
-}
-
-/** Build a RenderArgs with sensible defaults. */
-function renderArgs(overrides: Partial<RenderArgs> = {}): RenderArgs {
-  return {
-    command: 'render',
-    input: undefined,
-    ascii: false,
-    svg: false,
-    output: undefined,
-    theme: undefined,
-    ...overrides,
-  }
 }
 
 // ============================================================================

--- a/src/__tests__/cli-e2e.test.ts
+++ b/src/__tests__/cli-e2e.test.ts
@@ -1,0 +1,204 @@
+/**
+ * End-to-end integration tests for the built CLI (dist/cli.js).
+ *
+ * These tests spawn the actual CLI binary as a subprocess and verify the full
+ * pipeline: argument parsing -> input reading -> rendering -> output.
+ *
+ * Prerequisites: `bun run build` must have been run before these tests.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test'
+import { mkdtemp, writeFile, readFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+const CLI = join(import.meta.dir, '../../dist/cli.js')
+
+const SIMPLE_FLOWCHART = `graph LR
+  A[Start] --> B[Middle] --> C[End]`
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+interface CliResult {
+  stdout: string
+  stderr: string
+  exitCode: number
+}
+
+/**
+ * Run the CLI as a subprocess and collect stdout, stderr, and exit code.
+ */
+async function runCli(args: string[], stdin?: string): Promise<CliResult> {
+  const proc = Bun.spawn(['node', CLI, ...args], {
+    stdin: stdin !== undefined ? new Blob([stdin]) : undefined,
+    stdout: 'pipe',
+    stderr: 'pipe',
+  })
+
+  const [stdout, stderr] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+  ])
+
+  const exitCode = await proc.exited
+
+  return { stdout, stderr, exitCode }
+}
+
+// ============================================================================
+// Temp directory lifecycle
+// ============================================================================
+
+let tmpDir: string
+
+beforeEach(async () => {
+  tmpDir = await mkdtemp(join(tmpdir(), 'cli-e2e-test-'))
+})
+
+afterEach(async () => {
+  await rm(tmpDir, { recursive: true, force: true })
+})
+
+// ============================================================================
+// --help prints usage
+// ============================================================================
+
+describe('CLI e2e – --help', () => {
+  it('prints usage containing "beautiful-mermaid" and "render"', async () => {
+    const { stdout, exitCode } = await runCli(['--help'])
+
+    expect(exitCode).toBe(0)
+    expect(stdout).toContain('beautiful-mermaid')
+    expect(stdout).toContain('render')
+  })
+})
+
+// ============================================================================
+// themes lists available themes
+// ============================================================================
+
+describe('CLI e2e – themes command', () => {
+  it('lists available themes including tokyo-night and dracula', async () => {
+    const { stdout, exitCode } = await runCli(['themes'])
+
+    expect(exitCode).toBe(0)
+    expect(stdout).toContain('tokyo-night')
+    expect(stdout).toContain('dracula')
+  })
+})
+
+// ============================================================================
+// render --ascii prints diagram to stdout
+// ============================================================================
+
+describe('CLI e2e – render --ascii from file', () => {
+  it('renders ASCII diagram to stdout containing node labels', async () => {
+    const inputPath = join(tmpDir, 'diagram.mmd')
+    await writeFile(inputPath, SIMPLE_FLOWCHART)
+
+    const { stdout, exitCode } = await runCli(['render', inputPath, '--ascii'])
+
+    expect(exitCode).toBe(0)
+    expect(stdout).toContain('Start')
+    expect(stdout).toContain('Middle')
+    expect(stdout).toContain('End')
+  })
+})
+
+// ============================================================================
+// render --ascii from stdin
+// ============================================================================
+
+describe('CLI e2e – render --ascii from stdin', () => {
+  it('renders ASCII diagram piped via stdin', async () => {
+    const { stdout, exitCode } = await runCli(
+      ['render', '--ascii'],
+      SIMPLE_FLOWCHART,
+    )
+
+    expect(exitCode).toBe(0)
+    expect(stdout).toContain('Start')
+    expect(stdout).toContain('End')
+  })
+})
+
+// ============================================================================
+// render --svg -o writes SVG file
+// ============================================================================
+
+describe('CLI e2e – render --svg -o writes SVG file', () => {
+  it('renders SVG and writes output file containing <svg', async () => {
+    const inputPath = join(tmpDir, 'diagram.mmd')
+    const outputPath = join(tmpDir, 'output.svg')
+    await writeFile(inputPath, SIMPLE_FLOWCHART)
+
+    const { exitCode } = await runCli([
+      'render', inputPath, '--svg', '-o', outputPath,
+    ])
+
+    expect(exitCode).toBe(0)
+
+    const svg = await readFile(outputPath, 'utf-8')
+    expect(svg).toContain('<svg')
+    expect(svg).toContain('</svg>')
+  })
+})
+
+// ============================================================================
+// render --ascii --svg -o produces both
+// ============================================================================
+
+describe('CLI e2e – render --ascii --svg -o produces both', () => {
+  it('prints ASCII to stdout AND writes SVG to file', async () => {
+    const inputPath = join(tmpDir, 'diagram.mmd')
+    const outputPath = join(tmpDir, 'both.svg')
+    await writeFile(inputPath, SIMPLE_FLOWCHART)
+
+    const { stdout, exitCode } = await runCli([
+      'render', inputPath, '--ascii', '--svg', '-o', outputPath,
+    ])
+
+    // ASCII in stdout
+    expect(exitCode).toBe(0)
+    expect(stdout).toContain('Start')
+    expect(stdout).toContain('End')
+
+    // SVG in file
+    const svg = await readFile(outputPath, 'utf-8')
+    expect(svg).toContain('<svg')
+    expect(svg).toContain('</svg>')
+  })
+})
+
+// ============================================================================
+// exits 1 on unknown command
+// ============================================================================
+
+describe('CLI e2e – unknown command', () => {
+  it('exits 1 and prints "Error" to stderr', async () => {
+    const { exitCode, stderr } = await runCli(['badcommand'])
+
+    expect(exitCode).toBe(1)
+    expect(stderr).toContain('Error')
+  })
+})
+
+// ============================================================================
+// exits 1 on invalid mermaid input
+// ============================================================================
+
+describe('CLI e2e – invalid mermaid input', () => {
+  it('exits 1 when given a file with invalid mermaid syntax', async () => {
+    const inputPath = join(tmpDir, 'bad.mmd')
+    await writeFile(inputPath, 'this is not valid mermaid syntax at all')
+
+    const { exitCode } = await runCli(['render', inputPath, '--ascii'])
+
+    expect(exitCode).toBe(1)
+  })
+})

--- a/src/__tests__/cli-e2e.test.ts
+++ b/src/__tests__/cli-e2e.test.ts
@@ -1,11 +1,3 @@
-/**
- * End-to-end integration tests for the built CLI (dist/cli.js).
- *
- * These tests spawn the actual CLI binary as a subprocess and verify the full
- * pipeline: argument parsing -> input reading -> rendering -> output.
- *
- * Prerequisites: `bun run build` must have been run before these tests.
- */
 import { describe, it, expect, beforeEach, afterEach } from 'bun:test'
 import { mkdtemp, writeFile, readFile, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
@@ -75,6 +67,13 @@ describe('CLI e2e – help and metadata', () => {
     expect(exitCode).toBe(0)
     expect(stdout).toContain('beautiful-mermaid')
     expect(stdout).toContain('render')
+  })
+
+  it('--version prints version string and exits 0', async () => {
+    const { stdout, exitCode } = await runCli(['--version'])
+
+    expect(exitCode).toBe(0)
+    expect(stdout).toMatch(/beautiful-mermaid \d+\.\d+\.\d+/)
   })
 
   it('themes command lists available themes including tokyo-night and dracula', async () => {

--- a/src/__tests__/cli-e2e.test.ts
+++ b/src/__tests__/cli-e2e.test.ts
@@ -65,25 +65,19 @@ afterEach(async () => {
 })
 
 // ============================================================================
-// --help prints usage
+// help and metadata
 // ============================================================================
 
-describe('CLI e2e – --help', () => {
-  it('prints usage containing "beautiful-mermaid" and "render"', async () => {
+describe('CLI e2e – help and metadata', () => {
+  it('--help prints usage containing "beautiful-mermaid" and "render"', async () => {
     const { stdout, exitCode } = await runCli(['--help'])
 
     expect(exitCode).toBe(0)
     expect(stdout).toContain('beautiful-mermaid')
     expect(stdout).toContain('render')
   })
-})
 
-// ============================================================================
-// themes lists available themes
-// ============================================================================
-
-describe('CLI e2e – themes command', () => {
-  it('lists available themes including tokyo-night and dracula', async () => {
+  it('themes command lists available themes including tokyo-night and dracula', async () => {
     const { stdout, exitCode } = await runCli(['themes'])
 
     expect(exitCode).toBe(0)
@@ -93,11 +87,11 @@ describe('CLI e2e – themes command', () => {
 })
 
 // ============================================================================
-// render --ascii prints diagram to stdout
+// render
 // ============================================================================
 
-describe('CLI e2e – render --ascii from file', () => {
-  it('renders ASCII diagram to stdout containing node labels', async () => {
+describe('CLI e2e – render', () => {
+  it('renders ASCII diagram from file to stdout containing node labels', async () => {
     const inputPath = join(tmpDir, 'diagram.mmd')
     await writeFile(inputPath, SIMPLE_FLOWCHART)
 
@@ -108,13 +102,7 @@ describe('CLI e2e – render --ascii from file', () => {
     expect(stdout).toContain('Middle')
     expect(stdout).toContain('End')
   })
-})
 
-// ============================================================================
-// render --ascii from stdin
-// ============================================================================
-
-describe('CLI e2e – render --ascii from stdin', () => {
   it('renders ASCII diagram piped via stdin', async () => {
     const { stdout, exitCode } = await runCli(
       ['render', '--ascii'],
@@ -125,13 +113,7 @@ describe('CLI e2e – render --ascii from stdin', () => {
     expect(stdout).toContain('Start')
     expect(stdout).toContain('End')
   })
-})
 
-// ============================================================================
-// render --svg -o writes SVG file
-// ============================================================================
-
-describe('CLI e2e – render --svg -o writes SVG file', () => {
   it('renders SVG and writes output file containing <svg', async () => {
     const inputPath = join(tmpDir, 'diagram.mmd')
     const outputPath = join(tmpDir, 'output.svg')
@@ -147,13 +129,7 @@ describe('CLI e2e – render --svg -o writes SVG file', () => {
     expect(svg).toContain('<svg')
     expect(svg).toContain('</svg>')
   })
-})
 
-// ============================================================================
-// render --ascii --svg -o produces both
-// ============================================================================
-
-describe('CLI e2e – render --ascii --svg -o produces both', () => {
   it('prints ASCII to stdout AND writes SVG to file', async () => {
     const inputPath = join(tmpDir, 'diagram.mmd')
     const outputPath = join(tmpDir, 'both.svg')
@@ -176,23 +152,17 @@ describe('CLI e2e – render --ascii --svg -o produces both', () => {
 })
 
 // ============================================================================
-// exits 1 on unknown command
+// error handling
 // ============================================================================
 
-describe('CLI e2e – unknown command', () => {
-  it('exits 1 and prints "Error" to stderr', async () => {
+describe('CLI e2e – error handling', () => {
+  it('exits 1 and prints "Error" to stderr on unknown command', async () => {
     const { exitCode, stderr } = await runCli(['badcommand'])
 
     expect(exitCode).toBe(1)
     expect(stderr).toContain('Error')
   })
-})
 
-// ============================================================================
-// exits 1 on invalid mermaid input
-// ============================================================================
-
-describe('CLI e2e – invalid mermaid input', () => {
   it('exits 1 when given a file with invalid mermaid syntax', async () => {
     const inputPath = join(tmpDir, 'bad.mmd')
     await writeFile(inputPath, 'this is not valid mermaid syntax at all')

--- a/src/__tests__/cli-render.test.ts
+++ b/src/__tests__/cli-render.test.ts
@@ -1,0 +1,209 @@
+/**
+ * Tests for the CLI render command (runRender).
+ *
+ * Covers:
+ * - ASCII output from file input
+ * - SVG output to file
+ * - Both ASCII + SVG simultaneously
+ * - Theme application to SVG
+ * - stdin input via stdinContent
+ * - Invalid mermaid syntax
+ * - Unknown theme error
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test'
+import { mkdtemp, writeFile, readFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { runRender } from '../cli/render.ts'
+import type { RenderArgs } from '../cli/parse-args.ts'
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+const SIMPLE_FLOWCHART = `graph LR
+  A --> B --> C`
+
+/** Collect all write() calls into a single string. */
+function createMockStdout(): { write: (s: string) => void; output: () => string } {
+  const chunks: string[] = []
+  return {
+    write: (s: string) => chunks.push(s),
+    output: () => chunks.join(''),
+  }
+}
+
+/** Build a RenderArgs for common test scenarios. */
+function renderArgs(overrides: Partial<RenderArgs> = {}): RenderArgs {
+  return {
+    command: 'render',
+    input: undefined,
+    ascii: false,
+    svg: false,
+    output: undefined,
+    theme: undefined,
+    ...overrides,
+  }
+}
+
+// ============================================================================
+// Temp directory lifecycle
+// ============================================================================
+
+let tmpDir: string
+
+beforeEach(async () => {
+  tmpDir = await mkdtemp(join(tmpdir(), 'cli-render-test-'))
+})
+
+afterEach(async () => {
+  await rm(tmpDir, { recursive: true, force: true })
+})
+
+// ============================================================================
+// ASCII output
+// ============================================================================
+
+describe('runRender – ASCII from file', () => {
+  it('renders ASCII to stdout from a file and output contains node labels', async () => {
+    const inputPath = join(tmpDir, 'diagram.mmd')
+    await writeFile(inputPath, SIMPLE_FLOWCHART)
+
+    const mockStdout = createMockStdout()
+    await runRender(renderArgs({ input: inputPath, ascii: true }), mockStdout)
+
+    const output = mockStdout.output()
+    expect(output).toContain('A')
+    expect(output).toContain('B')
+    expect(output).toContain('C')
+  })
+})
+
+describe('runRender – ASCII from stdin', () => {
+  it('reads from stdinContent and renders ASCII output', async () => {
+    const mockStdout = createMockStdout()
+    await runRender(
+      renderArgs({ ascii: true }),
+      mockStdout,
+      SIMPLE_FLOWCHART,
+    )
+
+    const output = mockStdout.output()
+    expect(output).toContain('A')
+    expect(output).toContain('B')
+    expect(output).toContain('C')
+  })
+})
+
+// ============================================================================
+// SVG output
+// ============================================================================
+
+describe('runRender – SVG to file', () => {
+  it('renders SVG and writes to the output file', async () => {
+    const inputPath = join(tmpDir, 'diagram.mmd')
+    const outputPath = join(tmpDir, 'out.svg')
+    await writeFile(inputPath, SIMPLE_FLOWCHART)
+
+    await runRender(renderArgs({ input: inputPath, svg: true, output: outputPath }))
+
+    const svg = await readFile(outputPath, 'utf-8')
+    expect(svg).toContain('<svg')
+    expect(svg).toContain('</svg>')
+  })
+})
+
+// ============================================================================
+// Both ASCII + SVG
+// ============================================================================
+
+describe('runRender – both ASCII and SVG', () => {
+  it('renders both ASCII to stdout and SVG to file', async () => {
+    const inputPath = join(tmpDir, 'diagram.mmd')
+    const outputPath = join(tmpDir, 'out.svg')
+    await writeFile(inputPath, SIMPLE_FLOWCHART)
+
+    const mockStdout = createMockStdout()
+    await runRender(
+      renderArgs({ input: inputPath, ascii: true, svg: true, output: outputPath }),
+      mockStdout,
+    )
+
+    // ASCII went to stdout
+    const asciiOutput = mockStdout.output()
+    expect(asciiOutput).toContain('A')
+    expect(asciiOutput).toContain('B')
+
+    // SVG went to file
+    const svg = await readFile(outputPath, 'utf-8')
+    expect(svg).toContain('<svg')
+    expect(svg).toContain('</svg>')
+  })
+})
+
+// ============================================================================
+// Theme application
+// ============================================================================
+
+describe('runRender – theme application', () => {
+  it('applies tokyo-night theme and SVG contains --bg:#1a1b26', async () => {
+    const inputPath = join(tmpDir, 'diagram.mmd')
+    const outputPath = join(tmpDir, 'themed.svg')
+    await writeFile(inputPath, SIMPLE_FLOWCHART)
+
+    await runRender(
+      renderArgs({ input: inputPath, svg: true, output: outputPath, theme: 'tokyo-night' }),
+    )
+
+    const svg = await readFile(outputPath, 'utf-8')
+    expect(svg).toContain('--bg:#1a1b26')
+  })
+})
+
+// ============================================================================
+// Error cases
+// ============================================================================
+
+describe('runRender – errors', () => {
+  it('throws on empty input', async () => {
+    const mockStdout = createMockStdout()
+    await expect(
+      runRender(renderArgs({ ascii: true }), mockStdout, '   '),
+    ).rejects.toThrow()
+  })
+
+  it('throws on unknown theme with descriptive message', async () => {
+    const inputPath = join(tmpDir, 'diagram.mmd')
+    await writeFile(inputPath, SIMPLE_FLOWCHART)
+
+    await expect(
+      runRender(renderArgs({ input: inputPath, svg: true, output: join(tmpDir, 'out.svg'), theme: 'nonexistent-theme' })),
+    ).rejects.toThrow('Unknown theme')
+  })
+
+  it('unknown theme error lists available themes', async () => {
+    const inputPath = join(tmpDir, 'diagram.mmd')
+    await writeFile(inputPath, SIMPLE_FLOWCHART)
+
+    try {
+      await runRender(
+        renderArgs({ input: inputPath, svg: true, output: join(tmpDir, 'out.svg'), theme: 'nope' }),
+      )
+      // Should not reach here
+      expect(true).toBe(false)
+    } catch (err) {
+      const msg = (err as Error).message
+      expect(msg).toContain('Unknown theme')
+      expect(msg).toContain('"nope"')
+      expect(msg).toContain('Available themes:')
+      expect(msg).toContain('tokyo-night')
+    }
+  })
+
+  it('throws on invalid mermaid syntax', async () => {
+    const mockStdout = createMockStdout()
+    await expect(
+      runRender(renderArgs({ ascii: true }), mockStdout, 'this is not valid mermaid'),
+    ).rejects.toThrow()
+  })
+})

--- a/src/__tests__/cli-render.test.ts
+++ b/src/__tests__/cli-render.test.ts
@@ -169,35 +169,16 @@ describe('runRender – errors', () => {
     const mockStdout = createMockStdout()
     await expect(
       runRender(renderArgs({ ascii: true }), mockStdout, '   '),
-    ).rejects.toThrow()
+    ).rejects.toThrow('Empty input')
   })
 
-  it('throws on unknown theme with descriptive message', async () => {
+  it('throws on unknown theme with name, "Available themes", and known theme listed', async () => {
     const inputPath = join(tmpDir, 'diagram.mmd')
     await writeFile(inputPath, SIMPLE_FLOWCHART)
 
     await expect(
-      runRender(renderArgs({ input: inputPath, svg: true, output: join(tmpDir, 'out.svg'), theme: 'nonexistent-theme' })),
-    ).rejects.toThrow('Unknown theme')
-  })
-
-  it('unknown theme error lists available themes', async () => {
-    const inputPath = join(tmpDir, 'diagram.mmd')
-    await writeFile(inputPath, SIMPLE_FLOWCHART)
-
-    try {
-      await runRender(
-        renderArgs({ input: inputPath, svg: true, output: join(tmpDir, 'out.svg'), theme: 'nope' }),
-      )
-      // Should not reach here
-      expect(true).toBe(false)
-    } catch (err) {
-      const msg = (err as Error).message
-      expect(msg).toContain('Unknown theme')
-      expect(msg).toContain('"nope"')
-      expect(msg).toContain('Available themes:')
-      expect(msg).toContain('tokyo-night')
-    }
+      runRender(renderArgs({ input: inputPath, svg: true, output: join(tmpDir, 'out.svg'), theme: 'nope' })),
+    ).rejects.toThrow(/Unknown theme.*"nope".*Available themes:.*tokyo-night/)
   })
 
   it('throws on invalid mermaid syntax', async () => {

--- a/src/__tests__/cli-render.test.ts
+++ b/src/__tests__/cli-render.test.ts
@@ -15,36 +15,14 @@ import { mkdtemp, writeFile, readFile, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { runRender } from '../cli/render.ts'
-import type { RenderArgs } from '../cli/parse-args.ts'
+import { createMockStdout, renderArgs } from './cli-test-helpers.ts'
 
 // ============================================================================
-// Helpers
+// Constants
 // ============================================================================
 
 const SIMPLE_FLOWCHART = `graph LR
   A --> B --> C`
-
-/** Collect all write() calls into a single string. */
-function createMockStdout(): { write: (s: string) => void; output: () => string } {
-  const chunks: string[] = []
-  return {
-    write: (s: string) => chunks.push(s),
-    output: () => chunks.join(''),
-  }
-}
-
-/** Build a RenderArgs for common test scenarios. */
-function renderArgs(overrides: Partial<RenderArgs> = {}): RenderArgs {
-  return {
-    command: 'render',
-    input: undefined,
-    ascii: false,
-    svg: false,
-    output: undefined,
-    theme: undefined,
-    ...overrides,
-  }
-}
 
 // ============================================================================
 // Temp directory lifecycle

--- a/src/__tests__/cli-render.test.ts
+++ b/src/__tests__/cli-render.test.ts
@@ -1,15 +1,3 @@
-/**
- * Tests for the CLI render command (runRender).
- *
- * Covers:
- * - ASCII output from file input
- * - SVG output to file
- * - Both ASCII + SVG simultaneously
- * - Theme application to SVG
- * - stdin input via stdinContent
- * - Invalid mermaid syntax
- * - Unknown theme error
- */
 import { describe, it, expect, beforeEach, afterEach } from 'bun:test'
 import { mkdtemp, writeFile, readFile, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'

--- a/src/__tests__/cli-test-helpers.ts
+++ b/src/__tests__/cli-test-helpers.ts
@@ -1,8 +1,3 @@
-/**
- * Shared test helpers for CLI render tests.
- *
- * Used by cli-render.test.ts and cli-diagrams.test.ts.
- */
 import type { RenderArgs } from '../cli/parse-args.ts'
 
 /** Collect all write() calls into a single string. */

--- a/src/__tests__/cli-test-helpers.ts
+++ b/src/__tests__/cli-test-helpers.ts
@@ -1,0 +1,28 @@
+/**
+ * Shared test helpers for CLI render tests.
+ *
+ * Used by cli-render.test.ts and cli-diagrams.test.ts.
+ */
+import type { RenderArgs } from '../cli/parse-args.ts'
+
+/** Collect all write() calls into a single string. */
+export function createMockStdout(): { write: (s: string) => void; output: () => string } {
+  const chunks: string[] = []
+  return {
+    write: (s: string) => chunks.push(s),
+    output: () => chunks.join(''),
+  }
+}
+
+/** Build a RenderArgs for common test scenarios. */
+export function renderArgs(overrides: Partial<RenderArgs> = {}): RenderArgs {
+  return {
+    command: 'render',
+    input: undefined,
+    ascii: false,
+    svg: false,
+    output: undefined,
+    theme: undefined,
+    ...overrides,
+  }
+}

--- a/src/__tests__/cli.test.ts
+++ b/src/__tests__/cli.test.ts
@@ -1,12 +1,3 @@
-/**
- * Tests for CLI argument parsing.
- *
- * Covers:
- * - render command: file input, stdin, --ascii, --svg, -o, --theme
- * - themes command
- * - help / version flags
- * - validation errors (missing flags, missing -o, unknown command)
- */
 import { describe, it, expect } from 'bun:test'
 import { parseArgs } from '../cli/parse-args.ts'
 import type { RenderArgs, SimpleCommand } from '../cli/parse-args.ts'

--- a/src/__tests__/cli.test.ts
+++ b/src/__tests__/cli.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Tests for CLI argument parsing.
+ *
+ * Covers:
+ * - render command: file input, stdin, --ascii, --svg, -o, --theme
+ * - themes command
+ * - help / version flags
+ * - validation errors (missing flags, missing -o, unknown command)
+ */
+import { describe, it, expect } from 'bun:test'
+import { parseArgs } from '../cli/parse-args.ts'
+import type { RenderArgs, SimpleCommand, CliArgs } from '../cli/parse-args.ts'
+
+// ============================================================================
+// render command — happy paths
+// ============================================================================
+
+describe('parseArgs – render with --ascii', () => {
+  it('parses render <file> --ascii', () => {
+    const result = parseArgs(['render', 'diagram.mmd', '--ascii'])
+    expect(result).toEqual({
+      command: 'render',
+      input: 'diagram.mmd',
+      ascii: true,
+      svg: false,
+      output: undefined,
+      theme: undefined,
+    } satisfies RenderArgs)
+  })
+})
+
+describe('parseArgs – render with --svg and -o', () => {
+  it('parses render <file> --svg -o <path>', () => {
+    const result = parseArgs(['render', 'diagram.mmd', '--svg', '-o', 'out.svg'])
+    expect(result).toEqual({
+      command: 'render',
+      input: 'diagram.mmd',
+      ascii: false,
+      svg: true,
+      output: 'out.svg',
+      theme: undefined,
+    } satisfies RenderArgs)
+  })
+})
+
+describe('parseArgs – render with both --ascii and --svg', () => {
+  it('parses render <file> --ascii --svg -o <path>', () => {
+    const result = parseArgs(['render', 'diagram.mmd', '--ascii', '--svg', '-o', 'out.svg'])
+    expect(result).toEqual({
+      command: 'render',
+      input: 'diagram.mmd',
+      ascii: true,
+      svg: true,
+      output: 'out.svg',
+      theme: undefined,
+    } satisfies RenderArgs)
+  })
+})
+
+describe('parseArgs – render with --theme', () => {
+  it('parses render <file> --svg -o out.svg --theme tokyo-night', () => {
+    const result = parseArgs(['render', 'diagram.mmd', '--svg', '-o', 'out.svg', '--theme', 'tokyo-night'])
+    expect(result).toEqual({
+      command: 'render',
+      input: 'diagram.mmd',
+      ascii: false,
+      svg: true,
+      output: 'out.svg',
+      theme: 'tokyo-night',
+    } satisfies RenderArgs)
+  })
+})
+
+describe('parseArgs – render from stdin (no file argument)', () => {
+  it('parses render --ascii with no file', () => {
+    const result = parseArgs(['render', '--ascii'])
+    expect(result).toEqual({
+      command: 'render',
+      input: undefined,
+      ascii: true,
+      svg: false,
+      output: undefined,
+      theme: undefined,
+    } satisfies RenderArgs)
+  })
+
+  it('parses render --svg -o out.svg with no file', () => {
+    const result = parseArgs(['render', '--svg', '-o', 'out.svg'])
+    expect(result).toEqual({
+      command: 'render',
+      input: undefined,
+      ascii: false,
+      svg: true,
+      output: 'out.svg',
+      theme: undefined,
+    } satisfies RenderArgs)
+  })
+})
+
+// ============================================================================
+// simple commands
+// ============================================================================
+
+describe('parseArgs – themes command', () => {
+  it('parses "themes"', () => {
+    const result = parseArgs(['themes'])
+    expect(result).toEqual({ command: 'themes' } satisfies SimpleCommand)
+  })
+})
+
+describe('parseArgs – help', () => {
+  it('returns help for --help', () => {
+    const result = parseArgs(['--help'])
+    expect(result).toEqual({ command: 'help' } satisfies SimpleCommand)
+  })
+
+  it('returns help for -h', () => {
+    const result = parseArgs(['-h'])
+    expect(result).toEqual({ command: 'help' } satisfies SimpleCommand)
+  })
+
+  it('returns help for empty args', () => {
+    const result = parseArgs([])
+    expect(result).toEqual({ command: 'help' } satisfies SimpleCommand)
+  })
+})
+
+describe('parseArgs – version', () => {
+  it('returns version for --version', () => {
+    const result = parseArgs(['--version'])
+    expect(result).toEqual({ command: 'version' } satisfies SimpleCommand)
+  })
+
+  it('returns version for -v', () => {
+    const result = parseArgs(['-v'])
+    expect(result).toEqual({ command: 'version' } satisfies SimpleCommand)
+  })
+})
+
+// ============================================================================
+// validation errors
+// ============================================================================
+
+describe('parseArgs – errors', () => {
+  it('throws when render has --svg but no -o', () => {
+    expect(() => parseArgs(['render', 'diagram.mmd', '--svg'])).toThrow('--svg requires -o <path>')
+  })
+
+  it('throws when render has no output flags', () => {
+    expect(() => parseArgs(['render', 'diagram.mmd'])).toThrow('Specify --ascii and/or --svg -o <path>')
+  })
+
+  it('throws on unknown command', () => {
+    expect(() => parseArgs(['foobar'])).toThrow('Unknown command: foobar')
+  })
+})

--- a/src/__tests__/cli.test.ts
+++ b/src/__tests__/cli.test.ts
@@ -15,7 +15,7 @@ import type { RenderArgs, SimpleCommand } from '../cli/parse-args.ts'
 // render command — happy paths
 // ============================================================================
 
-describe('parseArgs – render with --ascii', () => {
+describe('parseArgs – render happy paths', () => {
   it('parses render <file> --ascii', () => {
     const result = parseArgs(['render', 'diagram.mmd', '--ascii'])
     expect(result).toEqual({
@@ -27,9 +27,7 @@ describe('parseArgs – render with --ascii', () => {
       theme: undefined,
     } satisfies RenderArgs)
   })
-})
 
-describe('parseArgs – render with --svg and -o', () => {
   it('parses render <file> --svg -o <path>', () => {
     const result = parseArgs(['render', 'diagram.mmd', '--svg', '-o', 'out.svg'])
     expect(result).toEqual({
@@ -41,9 +39,7 @@ describe('parseArgs – render with --svg and -o', () => {
       theme: undefined,
     } satisfies RenderArgs)
   })
-})
 
-describe('parseArgs – render with both --ascii and --svg', () => {
   it('parses render <file> --ascii --svg -o <path>', () => {
     const result = parseArgs(['render', 'diagram.mmd', '--ascii', '--svg', '-o', 'out.svg'])
     expect(result).toEqual({
@@ -55,9 +51,7 @@ describe('parseArgs – render with both --ascii and --svg', () => {
       theme: undefined,
     } satisfies RenderArgs)
   })
-})
 
-describe('parseArgs – render with --theme', () => {
   it('parses render <file> --svg -o out.svg --theme tokyo-night', () => {
     const result = parseArgs(['render', 'diagram.mmd', '--svg', '-o', 'out.svg', '--theme', 'tokyo-night'])
     expect(result).toEqual({
@@ -69,10 +63,8 @@ describe('parseArgs – render with --theme', () => {
       theme: 'tokyo-night',
     } satisfies RenderArgs)
   })
-})
 
-describe('parseArgs – render from stdin (no file argument)', () => {
-  it('parses render --ascii with no file', () => {
+  it('parses render --ascii with no file (stdin)', () => {
     const result = parseArgs(['render', '--ascii'])
     expect(result).toEqual({
       command: 'render',
@@ -84,7 +76,7 @@ describe('parseArgs – render from stdin (no file argument)', () => {
     } satisfies RenderArgs)
   })
 
-  it('parses render --svg -o out.svg with no file', () => {
+  it('parses render --svg -o out.svg with no file (stdin)', () => {
     const result = parseArgs(['render', '--svg', '-o', 'out.svg'])
     expect(result).toEqual({
       command: 'render',
@@ -95,49 +87,7 @@ describe('parseArgs – render from stdin (no file argument)', () => {
       theme: undefined,
     } satisfies RenderArgs)
   })
-})
 
-// ============================================================================
-// simple commands
-// ============================================================================
-
-describe('parseArgs – themes command', () => {
-  it('parses "themes"', () => {
-    const result = parseArgs(['themes'])
-    expect(result).toEqual({ command: 'themes' } satisfies SimpleCommand)
-  })
-})
-
-describe('parseArgs – help', () => {
-  it('returns help for --help', () => {
-    const result = parseArgs(['--help'])
-    expect(result).toEqual({ command: 'help' } satisfies SimpleCommand)
-  })
-
-  it('returns help for -h', () => {
-    const result = parseArgs(['-h'])
-    expect(result).toEqual({ command: 'help' } satisfies SimpleCommand)
-  })
-
-  it('returns help for empty args', () => {
-    const result = parseArgs([])
-    expect(result).toEqual({ command: 'help' } satisfies SimpleCommand)
-  })
-})
-
-describe('parseArgs – version', () => {
-  it('returns version for --version', () => {
-    const result = parseArgs(['--version'])
-    expect(result).toEqual({ command: 'version' } satisfies SimpleCommand)
-  })
-
-  it('returns version for -v', () => {
-    const result = parseArgs(['-v'])
-    expect(result).toEqual({ command: 'version' } satisfies SimpleCommand)
-  })
-})
-
-describe('parseArgs – render with --output long form', () => {
   it('parses --output the same as -o', () => {
     const result = parseArgs(['render', 'diagram.mmd', '--svg', '--output', 'out.svg'])
     expect(result).toEqual({
@@ -152,10 +102,46 @@ describe('parseArgs – render with --output long form', () => {
 })
 
 // ============================================================================
+// simple commands
+// ============================================================================
+
+describe('parseArgs – simple commands', () => {
+  it('parses "themes"', () => {
+    const result = parseArgs(['themes'])
+    expect(result).toEqual({ command: 'themes' } satisfies SimpleCommand)
+  })
+
+  it('returns help for --help', () => {
+    const result = parseArgs(['--help'])
+    expect(result).toEqual({ command: 'help' } satisfies SimpleCommand)
+  })
+
+  it('returns help for -h', () => {
+    const result = parseArgs(['-h'])
+    expect(result).toEqual({ command: 'help' } satisfies SimpleCommand)
+  })
+
+  it('returns help for empty args', () => {
+    const result = parseArgs([])
+    expect(result).toEqual({ command: 'help' } satisfies SimpleCommand)
+  })
+
+  it('returns version for --version', () => {
+    const result = parseArgs(['--version'])
+    expect(result).toEqual({ command: 'version' } satisfies SimpleCommand)
+  })
+
+  it('returns version for -v', () => {
+    const result = parseArgs(['-v'])
+    expect(result).toEqual({ command: 'version' } satisfies SimpleCommand)
+  })
+})
+
+// ============================================================================
 // validation errors
 // ============================================================================
 
-describe('parseArgs – errors', () => {
+describe('parseArgs – validation errors', () => {
   it('throws when render has --svg but no -o', () => {
     expect(() => parseArgs(['render', 'diagram.mmd', '--svg'])).toThrow('--svg requires -o <path>')
   })

--- a/src/__tests__/cli.test.ts
+++ b/src/__tests__/cli.test.ts
@@ -9,7 +9,7 @@
  */
 import { describe, it, expect } from 'bun:test'
 import { parseArgs } from '../cli/parse-args.ts'
-import type { RenderArgs, SimpleCommand, CliArgs } from '../cli/parse-args.ts'
+import type { RenderArgs, SimpleCommand } from '../cli/parse-args.ts'
 
 // ============================================================================
 // render command — happy paths
@@ -137,6 +137,20 @@ describe('parseArgs – version', () => {
   })
 })
 
+describe('parseArgs – render with --output long form', () => {
+  it('parses --output the same as -o', () => {
+    const result = parseArgs(['render', 'diagram.mmd', '--svg', '--output', 'out.svg'])
+    expect(result).toEqual({
+      command: 'render',
+      input: 'diagram.mmd',
+      ascii: false,
+      svg: true,
+      output: 'out.svg',
+      theme: undefined,
+    } satisfies RenderArgs)
+  })
+})
+
 // ============================================================================
 // validation errors
 // ============================================================================
@@ -152,5 +166,25 @@ describe('parseArgs – errors', () => {
 
   it('throws on unknown command', () => {
     expect(() => parseArgs(['foobar'])).toThrow('Unknown command: foobar')
+  })
+
+  it('throws when -o is last argument with no value', () => {
+    expect(() => parseArgs(['render', 'diagram.mmd', '--svg', '-o'])).toThrow('-o requires a file path')
+  })
+
+  it('throws when --theme is last argument with no value', () => {
+    expect(() => parseArgs(['render', 'diagram.mmd', '--ascii', '--theme'])).toThrow(
+      '--theme requires a theme name',
+    )
+  })
+
+  it('throws on unknown flag in render sub-parser', () => {
+    expect(() => parseArgs(['render', 'diagram.mmd', '--ascii', '--bogus'])).toThrow('Unknown flag: --bogus')
+  })
+
+  it('throws on duplicate positional argument', () => {
+    expect(() => parseArgs(['render', 'diagram1.mmd', '--ascii', 'diagram2.mmd'])).toThrow(
+      'Unexpected argument: diagram2.mmd (input file already set to "diagram1.mmd")',
+    )
   })
 })

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,5 +1,6 @@
 import { createRequire } from 'node:module'
 import { parseArgs } from './cli/parse-args.ts'
+import type { CliArgs } from './cli/parse-args.ts'
 import { runRender } from './cli/render.ts'
 import { THEMES } from './theme.ts'
 
@@ -9,7 +10,7 @@ const pkg = require('../package.json') as { version: string }
 async function main() {
   const argv = process.argv.slice(2)
 
-  let args
+  let args: CliArgs
   try {
     args = parseArgs(argv)
   } catch (err) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,8 +1,10 @@
+import { createRequire } from 'node:module'
 import { parseArgs } from './cli/parse-args.ts'
 import { runRender } from './cli/render.ts'
 import { THEMES } from './theme.ts'
 
-const VERSION = process.env.npm_package_version ?? 'dev'
+const require = createRequire(import.meta.url)
+const pkg = require('../package.json') as { version: string }
 
 async function main() {
   const argv = process.argv.slice(2)
@@ -21,7 +23,7 @@ async function main() {
       break
 
     case 'version':
-      console.log(`beautiful-mermaid ${VERSION}`)
+      console.log(`beautiful-mermaid ${pkg.version}`)
       break
 
     case 'themes':

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,68 @@
+import { parseArgs } from './cli/parse-args.ts'
+import { runRender } from './cli/render.ts'
+import { THEMES } from './theme.ts'
+
+const VERSION = process.env.npm_package_version ?? 'dev'
+
+async function main() {
+  const argv = process.argv.slice(2)
+
+  let args
+  try {
+    args = parseArgs(argv)
+  } catch (err) {
+    console.error(`Error: ${(err as Error).message}`)
+    process.exit(1)
+  }
+
+  switch (args.command) {
+    case 'help':
+      printHelp()
+      break
+
+    case 'version':
+      console.log(`beautiful-mermaid ${VERSION}`)
+      break
+
+    case 'themes':
+      console.log('Available themes:\n')
+      for (const name of Object.keys(THEMES)) {
+        console.log(`  ${name}`)
+      }
+      break
+
+    case 'render':
+      try {
+        await runRender(args)
+      } catch (err) {
+        console.error(`Error: ${(err as Error).message}`)
+        process.exit(1)
+      }
+      break
+  }
+}
+
+function printHelp() {
+  console.log(`
+beautiful-mermaid — render Mermaid diagrams from the command line
+
+Usage:
+  beautiful-mermaid render <file> --ascii              Render to ASCII in terminal
+  beautiful-mermaid render <file> --svg -o <out.svg>   Render to SVG file
+  beautiful-mermaid render <file> --ascii --svg -o <out.svg>   Both
+  cat file.mmd | beautiful-mermaid render --ascii      Read from stdin
+  beautiful-mermaid themes                             List available themes
+  beautiful-mermaid --help                             Show this help
+  beautiful-mermaid --version                          Show version
+
+Options:
+  --ascii          Print ASCII/Unicode diagram to terminal
+  --svg            Render SVG (requires -o)
+  -o, --output     Output file path for SVG
+  --theme <name>   Apply a built-in theme (see 'themes' command)
+  -h, --help       Show help
+  -v, --version    Show version
+`.trim())
+}
+
+main()

--- a/src/cli/parse-args.ts
+++ b/src/cli/parse-args.ts
@@ -1,18 +1,4 @@
 // ============================================================================
-// CLI argument parser — zero-dependency, hand-rolled from process.argv.
-//
-// Usage:  parseArgs(process.argv.slice(2))
-//
-// Commands:
-//   render <file> --ascii              ASCII to stdout
-//   render <file> --svg -o <out.svg>   SVG to file
-//   render --ascii                     stdin → ASCII
-//   themes                             list available themes
-//   --help / -h                        show help
-//   --version / -v                     show version
-// ============================================================================
-
-// ============================================================================
 // Types
 // ============================================================================
 

--- a/src/cli/parse-args.ts
+++ b/src/cli/parse-args.ts
@@ -85,19 +85,23 @@ function parseRender(args: string[]): RenderArgs {
     } else if (arg === '--svg') {
       svg = true
       i++
-    } else if (arg === '-o') {
+    } else if (arg === '-o' || arg === '--output') {
+      if (i + 1 >= args.length) throw new Error('-o requires a file path')
       output = args[i + 1]
       i += 2
     } else if (arg === '--theme') {
+      if (i + 1 >= args.length) throw new Error('--theme requires a theme name')
       theme = args[i + 1]
       i += 2
     } else if (!arg.startsWith('-')) {
       // Positional argument = input file
+      if (input !== undefined) {
+        throw new Error(`Unexpected argument: ${arg} (input file already set to "${input}")`)
+      }
       input = arg
       i++
     } else {
-      // Unknown flag — skip
-      i++
+      throw new Error(`Unknown flag: ${arg}`)
     }
   }
 

--- a/src/cli/parse-args.ts
+++ b/src/cli/parse-args.ts
@@ -1,0 +1,114 @@
+// ============================================================================
+// CLI argument parser — zero-dependency, hand-rolled from process.argv.
+//
+// Usage:  parseArgs(process.argv.slice(2))
+//
+// Commands:
+//   render <file> --ascii              ASCII to stdout
+//   render <file> --svg -o <out.svg>   SVG to file
+//   render --ascii                     stdin → ASCII
+//   themes                             list available themes
+//   --help / -h                        show help
+//   --version / -v                     show version
+// ============================================================================
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface RenderArgs {
+  command: 'render'
+  input: string | undefined
+  ascii: boolean
+  svg: boolean
+  output: string | undefined
+  theme: string | undefined
+}
+
+export interface SimpleCommand {
+  command: 'themes' | 'help' | 'version'
+}
+
+export type CliArgs = RenderArgs | SimpleCommand
+
+// ============================================================================
+// Parser
+// ============================================================================
+
+export function parseArgs(argv: string[]): CliArgs {
+  // Empty args → help
+  if (argv.length === 0) {
+    return { command: 'help' }
+  }
+
+  const first = argv[0]!
+
+  // Top-level flags (before any command)
+  if (first === '--help' || first === '-h') {
+    return { command: 'help' }
+  }
+  if (first === '--version' || first === '-v') {
+    return { command: 'version' }
+  }
+
+  // Simple commands
+  if (first === 'themes') {
+    return { command: 'themes' }
+  }
+
+  // Render command
+  if (first === 'render') {
+    return parseRender(argv.slice(1))
+  }
+
+  throw new Error(`Unknown command: ${first}`)
+}
+
+// ============================================================================
+// render sub-parser
+// ============================================================================
+
+function parseRender(args: string[]): RenderArgs {
+  let input: string | undefined
+  let ascii = false
+  let svg = false
+  let output: string | undefined
+  let theme: string | undefined
+
+  let i = 0
+  while (i < args.length) {
+    const arg = args[i]!
+
+    if (arg === '--ascii') {
+      ascii = true
+      i++
+    } else if (arg === '--svg') {
+      svg = true
+      i++
+    } else if (arg === '-o') {
+      output = args[i + 1]
+      i += 2
+    } else if (arg === '--theme') {
+      theme = args[i + 1]
+      i += 2
+    } else if (!arg.startsWith('-')) {
+      // Positional argument = input file
+      input = arg
+      i++
+    } else {
+      // Unknown flag — skip
+      i++
+    }
+  }
+
+  // Validation
+  if (!ascii && !svg) {
+    throw new Error('Specify --ascii and/or --svg -o <path>')
+  }
+
+  if (svg && output === undefined) {
+    throw new Error('--svg requires -o <path>')
+  }
+
+  return { command: 'render', input, ascii, svg, output, theme }
+}

--- a/src/cli/render.ts
+++ b/src/cli/render.ts
@@ -1,20 +1,10 @@
-// ============================================================================
-// CLI render command — reads Mermaid input, renders ASCII and/or SVG.
-//
-// Orchestrates:
-//   1. Input reading (file, stdin, or test string)
-//   2. Theme resolution (lookup in THEMES, error on unknown)
-//   3. ASCII rendering → stdout
-//   4. SVG rendering → output file
-// ============================================================================
-
 import { readFile, writeFile } from 'node:fs/promises'
 import { renderMermaidASCII, diagramColorsToAsciiTheme } from '../ascii/index.ts'
 import type { AsciiRenderOptions } from '../ascii/index.ts'
 import { renderMermaidSVG } from '../index.ts'
 import { THEMES } from '../theme.ts'
-import type { RenderArgs } from './parse-args.ts'
 import type { DiagramColors } from '../theme.ts'
+import type { RenderArgs } from './parse-args.ts'
 
 // ============================================================================
 // Types
@@ -43,9 +33,6 @@ export async function runRender(
 ): Promise<void> {
   const out = stdout ?? process.stdout
 
-  // --------------------------------------------------------------------------
-  // 1. Read input
-  // --------------------------------------------------------------------------
   let text: string
 
   if (args.input !== undefined) {
@@ -59,17 +46,11 @@ export async function runRender(
     text = await readStdin()
   }
 
-  // --------------------------------------------------------------------------
-  // 2. Validate — reject empty input
-  // --------------------------------------------------------------------------
   text = text.trim()
   if (text.length === 0) {
     throw new Error('Empty input — provide a Mermaid diagram via file or stdin')
   }
 
-  // --------------------------------------------------------------------------
-  // 3. Resolve theme
-  // --------------------------------------------------------------------------
   let themeColors: DiagramColors | undefined
 
   if (args.theme !== undefined) {
@@ -82,9 +63,6 @@ export async function runRender(
     }
   }
 
-  // --------------------------------------------------------------------------
-  // 4. Render ASCII → stdout
-  // --------------------------------------------------------------------------
   if (args.ascii) {
     // Use plain text by default (respects terminal colors on any background).
     // Only apply ANSI colors when the user explicitly passes --theme.
@@ -95,9 +73,6 @@ export async function runRender(
     out.write(ascii + '\n')
   }
 
-  // --------------------------------------------------------------------------
-  // 5. Render SVG → output file
-  // --------------------------------------------------------------------------
   if (args.svg && args.output) {
     const svg = renderMermaidSVG(text, themeColors ?? {})
     await writeFile(args.output, svg, 'utf-8')
@@ -108,10 +83,6 @@ export async function runRender(
 // Helpers
 // ============================================================================
 
-/**
- * Read all of stdin as a UTF-8 string.
- * Collects chunks until the stream ends.
- */
 async function readStdin(): Promise<string> {
   const chunks: string[] = []
   const stdin = process.stdin

--- a/src/cli/render.ts
+++ b/src/cli/render.ts
@@ -86,10 +86,11 @@ export async function runRender(
   // 4. Render ASCII → stdout
   // --------------------------------------------------------------------------
   if (args.ascii) {
-    const asciiOpts: AsciiRenderOptions = { colorMode: 'auto' }
-    if (themeColors) {
-      asciiOpts.theme = diagramColorsToAsciiTheme(themeColors)
-    }
+    // Use plain text by default (respects terminal colors on any background).
+    // Only apply ANSI colors when the user explicitly passes --theme.
+    const asciiOpts: AsciiRenderOptions = themeColors
+      ? { colorMode: 'auto', theme: diagramColorsToAsciiTheme(themeColors) }
+      : { colorMode: 'none' }
     const ascii = renderMermaidASCII(text, asciiOpts)
     out.write(ascii + '\n')
   }

--- a/src/cli/render.ts
+++ b/src/cli/render.ts
@@ -9,7 +9,8 @@
 // ============================================================================
 
 import { readFile, writeFile } from 'node:fs/promises'
-import { renderMermaidASCII } from '../ascii/index.ts'
+import { renderMermaidASCII, diagramColorsToAsciiTheme } from '../ascii/index.ts'
+import type { AsciiRenderOptions } from '../ascii/index.ts'
 import { renderMermaidSVG } from '../index.ts'
 import { THEMES } from '../theme.ts'
 import type { RenderArgs } from './parse-args.ts'
@@ -52,6 +53,9 @@ export async function runRender(
   } else if (stdinContent !== undefined) {
     text = stdinContent
   } else {
+    if (process.stdin.isTTY) {
+      throw new Error('No input file specified and stdin is a terminal. Pipe a diagram or pass a file path.')
+    }
     text = await readStdin()
   }
 
@@ -82,7 +86,11 @@ export async function runRender(
   // 4. Render ASCII → stdout
   // --------------------------------------------------------------------------
   if (args.ascii) {
-    const ascii = renderMermaidASCII(text, { colorMode: 'none' })
+    const asciiOpts: AsciiRenderOptions = { colorMode: 'auto' }
+    if (themeColors) {
+      asciiOpts.theme = diagramColorsToAsciiTheme(themeColors)
+    }
+    const ascii = renderMermaidASCII(text, asciiOpts)
     out.write(ascii)
   }
 

--- a/src/cli/render.ts
+++ b/src/cli/render.ts
@@ -91,7 +91,7 @@ export async function runRender(
       asciiOpts.theme = diagramColorsToAsciiTheme(themeColors)
     }
     const ascii = renderMermaidASCII(text, asciiOpts)
-    out.write(ascii)
+    out.write(ascii + '\n')
   }
 
   // --------------------------------------------------------------------------

--- a/src/cli/render.ts
+++ b/src/cli/render.ts
@@ -1,0 +1,116 @@
+// ============================================================================
+// CLI render command — reads Mermaid input, renders ASCII and/or SVG.
+//
+// Orchestrates:
+//   1. Input reading (file, stdin, or test string)
+//   2. Theme resolution (lookup in THEMES, error on unknown)
+//   3. ASCII rendering → stdout
+//   4. SVG rendering → output file
+// ============================================================================
+
+import { readFile, writeFile } from 'node:fs/promises'
+import { renderMermaidASCII } from '../ascii/index.ts'
+import { renderMermaidSVG } from '../index.ts'
+import { THEMES } from '../theme.ts'
+import type { RenderArgs } from './parse-args.ts'
+import type { DiagramColors } from '../theme.ts'
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface Writable {
+  write: (s: string) => void
+}
+
+// ============================================================================
+// Main entry point
+// ============================================================================
+
+/**
+ * Execute the `render` command.
+ *
+ * @param args - Parsed CLI arguments (command === 'render')
+ * @param stdout - Writable stream for ASCII output (defaults to process.stdout)
+ * @param stdinContent - Pre-read stdin content for testing; if undefined and
+ *   no file input, reads from process.stdin at runtime
+ */
+export async function runRender(
+  args: RenderArgs,
+  stdout?: Writable,
+  stdinContent?: string,
+): Promise<void> {
+  const out = stdout ?? process.stdout
+
+  // --------------------------------------------------------------------------
+  // 1. Read input
+  // --------------------------------------------------------------------------
+  let text: string
+
+  if (args.input !== undefined) {
+    text = await readFile(args.input, 'utf-8')
+  } else if (stdinContent !== undefined) {
+    text = stdinContent
+  } else {
+    text = await readStdin()
+  }
+
+  // --------------------------------------------------------------------------
+  // 2. Validate — reject empty input
+  // --------------------------------------------------------------------------
+  text = text.trim()
+  if (text.length === 0) {
+    throw new Error('Empty input — provide a Mermaid diagram via file or stdin')
+  }
+
+  // --------------------------------------------------------------------------
+  // 3. Resolve theme
+  // --------------------------------------------------------------------------
+  let themeColors: DiagramColors | undefined
+
+  if (args.theme !== undefined) {
+    themeColors = THEMES[args.theme]
+    if (themeColors === undefined) {
+      const available = Object.keys(THEMES).join(', ')
+      throw new Error(
+        `Unknown theme: "${args.theme}". Available themes: ${available}`,
+      )
+    }
+  }
+
+  // --------------------------------------------------------------------------
+  // 4. Render ASCII → stdout
+  // --------------------------------------------------------------------------
+  if (args.ascii) {
+    const ascii = renderMermaidASCII(text, { colorMode: 'none' })
+    out.write(ascii)
+  }
+
+  // --------------------------------------------------------------------------
+  // 5. Render SVG → output file
+  // --------------------------------------------------------------------------
+  if (args.svg && args.output) {
+    const svg = renderMermaidSVG(text, themeColors ?? {})
+    await writeFile(args.output, svg, 'utf-8')
+  }
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/**
+ * Read all of stdin as a UTF-8 string.
+ * Collects chunks until the stream ends.
+ */
+async function readStdin(): Promise<string> {
+  const chunks: string[] = []
+  const stdin = process.stdin
+  stdin.setEncoding('utf-8')
+
+  return new Promise((resolve, reject) => {
+    stdin.on('data', (chunk: string) => chunks.push(chunk))
+    stdin.on('end', () => resolve(chunks.join('')))
+    stdin.on('error', reject)
+  })
+}

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,13 +1,29 @@
 import { defineConfig } from 'tsup'
 
-export default defineConfig({
-  entry: ['src/index.ts'],
-  format: ['esm'],
-  dts: true,
-  splitting: false,
-  sourcemap: true,
-  clean: true,
-  target: 'es2022',
-  outDir: 'dist',
-  external: ['elkjs', 'entities'],
-})
+export default defineConfig([
+  // Library build
+  {
+    entry: ['src/index.ts'],
+    format: ['esm'],
+    dts: true,
+    splitting: false,
+    sourcemap: true,
+    clean: true,
+    target: 'es2022',
+    outDir: 'dist',
+    external: ['elkjs', 'entities'],
+  },
+  // CLI build
+  {
+    entry: ['src/cli.ts'],
+    format: ['esm'],
+    dts: false,
+    splitting: false,
+    sourcemap: false,
+    clean: false,
+    target: 'es2022',
+    outDir: 'dist',
+    external: ['elkjs', 'entities'],
+    banner: { js: '#!/usr/bin/env node' },
+  },
+])


### PR DESCRIPTION
## Summary

- Adds a CLI that exposes the library's rendering as a command-line tool (`beautiful-mermaid render`)
- Supports ASCII output to terminal and SVG output to file, with built-in theme support
- All 6 diagram types work (flowchart, sequence, state, class, ER, XY chart)
- One motivation for this CLI is to enable AI-assisted diagramming tools (e.g. Claude Code skills) that call it programmatically — but the CLI is useful standalone for shell scripts, CI pipelines, and quick terminal previews

### Usage

```bash
# Render to ASCII in terminal
beautiful-mermaid render diagram.mmd --ascii

# Render to SVG file
beautiful-mermaid render diagram.mmd --svg -o out.svg

# Both at once, with a theme
beautiful-mermaid render diagram.mmd --ascii --svg -o out.svg --theme tokyo-night

# Pipe from stdin
cat diagram.mmd | beautiful-mermaid render --ascii

# List available themes
beautiful-mermaid themes
```

### What's included

| File | Purpose |
|------|---------|
| `src/cli.ts` | Entry point — dispatches to commands |
| `src/cli/parse-args.ts` | Argument parser (zero deps, hand-rolled) |
| `src/cli/render.ts` | Render command — file/stdin input, ASCII+SVG output |
| `tsup.config.ts` | Dual build config (library + CLI with shebang) |
| `package.json` | Added `bin` field |

### Design decisions

- **No external dependencies** for arg parsing — keeps it minimal and consistent with the library's philosophy
- **Plain text ASCII by default** — no ANSI colors unless `--theme` is explicitly passed, so output is readable on both light and dark terminals
- **TTY detection** — errors helpfully instead of hanging when stdin is a terminal
- **Errors to stderr, exit code 1** — CLI-friendly for scripting and tool integration

### Test coverage (42 new tests, 753 total)

- Unit tests for arg parsing (20 tests)
- Integration tests for the render command (8 tests)
- E2E subprocess tests against the built binary (8 tests)
- Smoke tests for all 6 diagram types (6 tests)

## Test plan

- [x] All 753 tests pass (`bun test src/__tests__/`)
- [x] `beautiful-mermaid render <file> --ascii` renders to terminal
- [x] `beautiful-mermaid render <file> --svg -o <out>` writes valid SVG
- [x] `beautiful-mermaid themes` lists all 15 themes
- [x] `beautiful-mermaid --help` and `--version` work
- [x] Stdin piping works (`cat file.mmd | beautiful-mermaid render --ascii`)
- [x] Errors exit 1 with helpful messages (unknown command, bad syntax, missing flags)
- [x] No regressions in existing 711 library tests