### PR TITLE
fix: silently dropped notes before first message

### DIFF
--- a/src/__tests__/sequence-layout.test.ts
+++ b/src/__tests__/sequence-layout.test.ts
@@ -752,7 +752,7 @@ describe('sequence layout – note positioning', () => {
 // ============================================================================
 
 describe('sequence layout – pre-message notes', () => {
-  it('single pre-message note is positioned (not dropped)', () => {
+  it('single pre-message note is positioned above first message', () => {
     const result = layout(`sequenceDiagram
       participant A as Alice
       participant B as Bob
@@ -760,20 +760,10 @@ describe('sequence layout – pre-message notes', () => {
       A->>B: Hello`)
     expect(result.notes).toHaveLength(1)
     expect(result.notes[0]!.text).toBe('note 1')
+    expect(result.notes[0]!.y).toBeLessThan(result.messages[0]!.y)
   })
 
-  it('pre-message note is above the first message', () => {
-    const result = layout(`sequenceDiagram
-      participant A as Alice
-      participant B as Bob
-      Note over A: note 1
-      A->>B: Hello`)
-    const note = result.notes[0]!
-    const msg = result.messages[0]!
-    expect(note.y).toBeLessThan(msg.y)
-  })
-
-  it('multiple pre-message notes are stacked vertically', () => {
+  it('multiple pre-message notes stack above first message', () => {
     const result = layout(`sequenceDiagram
       participant A as Alice
       participant B as Bob
@@ -784,19 +774,7 @@ describe('sequence layout – pre-message notes', () => {
     const n0 = result.notes[0]!
     const n1 = result.notes[1]!
     expect(n1.y).toBeGreaterThanOrEqual(n0.y + n0.height)
-  })
-
-  it('all pre-message notes are above the first message', () => {
-    const result = layout(`sequenceDiagram
-      participant A as Alice
-      participant B as Bob
-      Note over A: note 1
-      Note over B: note 2
-      A->>B: Hello`)
-    const msg = result.messages[0]!
-    for (const note of result.notes.filter(n => n.y < msg.y)) {
-      expect(note.y + note.height).toBeLessThanOrEqual(msg.y)
-    }
+    expect(n1.y + n1.height).toBeLessThanOrEqual(result.messages[0]!.y)
   })
 
   it('notes-only diagram (0 messages) renders notes', () => {
@@ -808,7 +786,7 @@ describe('sequence layout – pre-message notes', () => {
     expect(result.messages).toHaveLength(0)
   })
 
-  it('pre-message notes push first message down vs diagram without notes', () => {
+  it('pre-message notes push first message down and increase diagram height', () => {
     const withNotes = layout(`sequenceDiagram
       participant A as Alice
       participant B as Bob
@@ -822,6 +800,7 @@ describe('sequence layout – pre-message notes', () => {
       A->>B: Hello`)
 
     expect(withNotes.messages[0]!.y).toBeGreaterThan(withoutNotes.messages[0]!.y)
+    expect(withNotes.height).toBeGreaterThan(withoutNotes.height)
   })
 
   it('pre-message note right of actor is within diagram bounds', () => {
@@ -835,37 +814,5 @@ describe('sequence layout – pre-message notes', () => {
       expect(note.x).toBeGreaterThanOrEqual(0)
       expect(note.x + note.width).toBeLessThanOrEqual(result.width)
     }
-  })
-
-  it('pre-message note over two actors is centered between them', () => {
-    const result = layout(`sequenceDiagram
-      participant A as Alice
-      participant B as Bob
-      Note over A,B: shared note
-      A->>B: Hello`)
-    expect(result.notes).toHaveLength(1)
-    const note = result.notes[0]!
-    const a = result.actors[0]!
-    const b = result.actors[1]!
-    const mid = (a.x + b.x) / 2
-    // Note center should be near the midpoint between actor centers
-    const noteCenter = note.x + note.width / 2
-    expect(Math.abs(noteCenter - mid)).toBeLessThan(20) // within 20px
-  })
-
-  it('diagram height accommodates pre-message notes', () => {
-    const withNotes = layout(`sequenceDiagram
-      participant A as Alice
-      participant B as Bob
-      Note over A: note 1
-      Note over B: note 2
-      A->>B: Hello`)
-
-    const withoutNotes = layout(`sequenceDiagram
-      participant A as Alice
-      participant B as Bob
-      A->>B: Hello`)
-
-    expect(withNotes.height).toBeGreaterThan(withoutNotes.height)
   })
 })

--- a/src/__tests__/sequence-layout.test.ts
+++ b/src/__tests__/sequence-layout.test.ts
@@ -745,3 +745,127 @@ describe('sequence layout – note positioning', () => {
     }
   })
 })
+
+// ============================================================================
+// Pre-message notes — verify fix for issue #53 (notes before first message
+// were silently dropped because afterIndex === -1 was never looked up)
+// ============================================================================
+
+describe('sequence layout – pre-message notes', () => {
+  it('single pre-message note is positioned (not dropped)', () => {
+    const result = layout(`sequenceDiagram
+      participant A as Alice
+      participant B as Bob
+      Note over A: note 1
+      A->>B: Hello`)
+    expect(result.notes).toHaveLength(1)
+    expect(result.notes[0]!.text).toBe('note 1')
+  })
+
+  it('pre-message note is above the first message', () => {
+    const result = layout(`sequenceDiagram
+      participant A as Alice
+      participant B as Bob
+      Note over A: note 1
+      A->>B: Hello`)
+    const note = result.notes[0]!
+    const msg = result.messages[0]!
+    expect(note.y).toBeLessThan(msg.y)
+  })
+
+  it('multiple pre-message notes are stacked vertically', () => {
+    const result = layout(`sequenceDiagram
+      participant A as Alice
+      participant B as Bob
+      Note over A: note 1
+      Note over B: note 2
+      A->>B: Hello`)
+    expect(result.notes).toHaveLength(2)
+    const n0 = result.notes[0]!
+    const n1 = result.notes[1]!
+    expect(n1.y).toBeGreaterThanOrEqual(n0.y + n0.height)
+  })
+
+  it('all pre-message notes are above the first message', () => {
+    const result = layout(`sequenceDiagram
+      participant A as Alice
+      participant B as Bob
+      Note over A: note 1
+      Note over B: note 2
+      A->>B: Hello`)
+    const msg = result.messages[0]!
+    for (const note of result.notes.filter(n => n.y < msg.y)) {
+      expect(note.y + note.height).toBeLessThanOrEqual(msg.y)
+    }
+  })
+
+  it('notes-only diagram (0 messages) renders notes', () => {
+    const result = layout(`sequenceDiagram
+      participant A
+      Note over A: lonely note`)
+    expect(result.notes).toHaveLength(1)
+    expect(result.notes[0]!.text).toBe('lonely note')
+    expect(result.messages).toHaveLength(0)
+  })
+
+  it('pre-message notes push first message down vs diagram without notes', () => {
+    const withNotes = layout(`sequenceDiagram
+      participant A as Alice
+      participant B as Bob
+      Note over A: note 1
+      Note over B: note 2
+      A->>B: Hello`)
+
+    const withoutNotes = layout(`sequenceDiagram
+      participant A as Alice
+      participant B as Bob
+      A->>B: Hello`)
+
+    expect(withNotes.messages[0]!.y).toBeGreaterThan(withoutNotes.messages[0]!.y)
+  })
+
+  it('pre-message note right of actor is within diagram bounds', () => {
+    const result = layout(`sequenceDiagram
+      participant A as Alice
+      participant B as Bob
+      Note right of B: side note
+      A->>B: Hello`)
+    expect(result.notes).toHaveLength(1)
+    for (const note of result.notes) {
+      expect(note.x).toBeGreaterThanOrEqual(0)
+      expect(note.x + note.width).toBeLessThanOrEqual(result.width)
+    }
+  })
+
+  it('pre-message note over two actors is centered between them', () => {
+    const result = layout(`sequenceDiagram
+      participant A as Alice
+      participant B as Bob
+      Note over A,B: shared note
+      A->>B: Hello`)
+    expect(result.notes).toHaveLength(1)
+    const note = result.notes[0]!
+    const a = result.actors[0]!
+    const b = result.actors[1]!
+    const mid = (a.x + b.x) / 2
+    // Note center should be near the midpoint between actor centers
+    const noteCenter = note.x + note.width / 2
+    expect(Math.abs(noteCenter - mid)).toBeLessThan(20) // within 20px
+  })
+
+  it('diagram height accommodates pre-message notes', () => {
+    const withNotes = layout(`sequenceDiagram
+      participant A as Alice
+      participant B as Bob
+      Note over A: note 1
+      Note over B: note 2
+      A->>B: Hello`)
+
+    const withoutNotes = layout(`sequenceDiagram
+      participant A as Alice
+      participant B as Bob
+      A->>B: Hello`)
+
+    expect(withNotes.height).toBeGreaterThan(withoutNotes.height)
+  })
+})

--- a/src/__tests__/sequence-layout.test.ts
+++ b/src/__tests__/sequence-layout.test.ts
@@ -769,12 +769,19 @@ describe('sequence layout – pre-message notes', () => {
       participant B as Bob
       Note over A: note 1
       Note over B: note 2
+      Note over A,B: spanning note
       A->>B: Hello`)
-    expect(result.notes).toHaveLength(2)
+    expect(result.notes).toHaveLength(3)
     const n0 = result.notes[0]!
     const n1 = result.notes[1]!
     expect(n1.y).toBeGreaterThanOrEqual(n0.y + n0.height)
     expect(n1.y + n1.height).toBeLessThanOrEqual(result.messages[0]!.y)
+    // spanning note is centered between actors
+    const spanning = result.notes.find(n => n.text === 'spanning note')!
+    const aActor = result.actors.find(a => a.id === 'A')!
+    const bActor = result.actors.find(a => a.id === 'B')!
+    const mid = (aActor.x + bActor.x) / 2
+    expect(Math.abs(spanning.x + spanning.width / 2 - mid)).toBeLessThan(20)
   })
 
   it('notes-only diagram (0 messages) renders notes', () => {

--- a/src/__tests__/sequence-parser.test.ts
+++ b/src/__tests__/sequence-parser.test.ts
@@ -231,3 +231,42 @@ describe('parseSequenceDiagram – full diagram', () => {
     expect(d.blocks[0]!.dividers).toHaveLength(1)
   })
 })
+
+// ============================================================================
+// Pre-message notes
+// ============================================================================
+
+describe('parseSequenceDiagram – pre-message notes', () => {
+  it('note before first message gets afterIndex -1', () => {
+    const d = parse(`sequenceDiagram
+      participant A as Alice
+      participant B as Bob
+      Note over A: note 1
+      A->>B: Hello`)
+    expect(d.notes).toHaveLength(1)
+    expect(d.notes[0]!.afterIndex).toBe(-1)
+    expect(d.notes[0]!.text).toBe('note 1')
+    expect(d.notes[0]!.position).toBe('over')
+  })
+
+  it('multiple notes before first message all get afterIndex -1', () => {
+    const d = parse(`sequenceDiagram
+      participant A as Alice
+      participant B as Bob
+      Note over A: note 1
+      Note over B: note 2
+      A->>B: Hello`)
+    expect(d.notes).toHaveLength(2)
+    expect(d.notes[0]!.afterIndex).toBe(-1)
+    expect(d.notes[1]!.afterIndex).toBe(-1)
+  })
+
+  it('note in notes-only diagram (0 messages) gets afterIndex -1', () => {
+    const d = parse(`sequenceDiagram
+      participant A
+      Note over A: lonely`)
+    expect(d.notes).toHaveLength(1)
+    expect(d.notes[0]!.afterIndex).toBe(-1)
+    expect(d.messages).toHaveLength(0)
+  })
+})

--- a/src/ascii/sequence.ts
+++ b/src/ascii/sequence.ts
@@ -102,6 +102,35 @@ export function renderSequenceAscii(text: string, config: AsciiConfig, colorMode
 
   let curY = actorBoxH // start right below header boxes
 
+  // Pre-message notes: afterIndex === -1 — position before message loop
+  for (const note of diagram.notes) {
+    if (note.afterIndex !== -1) continue
+    curY += 1 // gap before note
+    const nLines = splitLines(note.text)
+    const nWidth = Math.max(...nLines.map(l => l.length)) + 4
+    const nHeight = nLines.length + 2
+
+    const aIdx = actorIdx.get(note.actorIds[0]!) ?? 0
+    let nx: number
+    if (note.position === 'left') {
+      nx = llX[aIdx]! - nWidth - 1
+    } else if (note.position === 'right') {
+      nx = llX[aIdx]! + 2
+    } else {
+      // 'over'
+      if (note.actorIds.length >= 2) {
+        const aIdx2 = actorIdx.get(note.actorIds[1]!) ?? aIdx
+        nx = Math.floor((llX[aIdx]! + llX[aIdx2]!) / 2) - Math.floor(nWidth / 2)
+      } else {
+        nx = llX[aIdx]! - Math.floor(nWidth / 2)
+      }
+    }
+    nx = Math.max(0, nx)
+
+    notePositions.push({ x: nx, y: curY, width: nWidth, height: nHeight, lines: nLines })
+    curY += nHeight
+  }
+
   for (let m = 0; m < diagram.messages.length; m++) {
     // Block openings at this message
     for (let b = 0; b < diagram.blocks.length; b++) {

--- a/src/sequence/layout.ts
+++ b/src/sequence/layout.ts
@@ -132,6 +132,50 @@ export function layoutSequenceDiagram(
   const activations: Activation[] = []
   const nestingOffset = 4 // Horizontal offset per nesting level
 
+  // Handle notes that appear before the first message (afterIndex === -1)
+  const notesBeforeFirstMsg = notesByAfterIndex.get(-1)
+  if (notesBeforeFirstMsg && notesBeforeFirstMsg.length > 0) {
+    let noteY = messageY
+    for (const note of notesBeforeFirstMsg) {
+      const noteW = Math.max(
+        SEQ.noteWidth,
+        estimateTextWidth(note.text, FONT_SIZES.edgeLabel, FONT_WEIGHTS.edgeLabel) + SEQ.notePadX * 2
+      )
+      const noteH = FONT_SIZES.edgeLabel + SEQ.notePadY * 2
+
+      // X positioning based on actor position and note type
+      const firstActorIdx = actorIndex.get(note.actorIds[0] ?? '') ?? 0
+      let noteX: number
+      if (note.position === 'left') {
+        noteX = actorCenterX[firstActorIdx]! - actorWidths[firstActorIdx]! / 2 - noteW - SEQ.noteGap
+      } else if (note.position === 'right') {
+        noteX = actorCenterX[firstActorIdx]! + actorWidths[firstActorIdx]! / 2 + SEQ.noteGap
+      } else {
+        // over — center between first and last actor
+        if (note.actorIds.length > 1) {
+          const lastActorIdx = actorIndex.get(note.actorIds[note.actorIds.length - 1] ?? '') ?? firstActorIdx
+          noteX = (actorCenterX[firstActorIdx]! + actorCenterX[lastActorIdx]!) / 2 - noteW / 2
+        } else {
+          noteX = actorCenterX[firstActorIdx]! - noteW / 2
+        }
+      }
+
+      positionedNotes.push({
+        text: note.text,
+        x: noteX,
+        y: noteY,
+        width: noteW,
+        height: noteH,
+        position: note.position,
+        actors: note.actorIds,
+      })
+
+      noteY += noteH + 4
+    }
+
+    messageY = Math.max(messageY, noteY + SEQ.messageRowHeight / 2)
+  }
+
   for (let msgIdx = 0; msgIdx < diagram.messages.length; msgIdx++) {
     const msg = diagram.messages[msgIdx]!
     const fromIdx = actorIndex.get(msg.from) ?? 0


### PR DESCRIPTION
fixes #53

notes before the first message had `afterIndex === -1`, which was never looked up in either the SVG layout or ASCII renderer's message loop. added a pre-loop block in both to handle the `-1` case.

Includes regression tests.

Disclaimer: contains LLM generated code. I manually checked them. but I may have missed something.