### PR TITLE
fix: group root nodes by downstream target and align fan-in children

### DIFF
--- a/src/ascii/grid.ts
+++ b/src/ascii/grid.ts
@@ -451,13 +451,26 @@ export function createMapping(graph: AsciiGraph): void {
     externalRootNodes = rootNodes
   }
 
-  // Place external root nodes
-  for (const node of externalRootNodes) {
-    const requested: GridCoord = dir === 'LR'
-      ? { x: 0, y: highestPositionPerLevel[0]! }
-      : { x: highestPositionPerLevel[0]!, y: 0 }
-    reserveSpotInGrid(graph, graph.nodes[node.index]!, requested)
-    highestPositionPerLevel[0] = highestPositionPerLevel[0]! + 4
+  // Place external root nodes, grouped by their immediate downstream target.
+  // Roots feeding into the same target are placed contiguously so that edge
+  // paths from different fan-in groups don't overlap.
+  const rootsByTarget = new Map<string, AsciiNode[]>()
+  for (const root of externalRootNodes) {
+    const children = getChildren(graph, root)
+    const targetName = children.length > 0 ? children[0]!.name : '__ungrouped__'
+    const group = rootsByTarget.get(targetName) ?? []
+    group.push(root)
+    rootsByTarget.set(targetName, group)
+  }
+
+  for (const [, roots] of rootsByTarget) {
+    for (const node of roots) {
+      const requested: GridCoord = dir === 'LR'
+        ? { x: 0, y: highestPositionPerLevel[0]! }
+        : { x: highestPositionPerLevel[0]!, y: 0 }
+      reserveSpotInGrid(graph, graph.nodes[node.index]!, requested)
+      highestPositionPerLevel[0] = highestPositionPerLevel[0]! + 4
+    }
   }
 
   // Place subgraph root nodes at level 4 (one level in from the edge)
@@ -470,6 +483,12 @@ export function createMapping(graph: AsciiGraph): void {
       reserveSpotInGrid(graph, graph.nodes[node.index]!, requested)
       highestPositionPerLevel[subgraphLevel] = highestPositionPerLevel[subgraphLevel]! + 4
     }
+  }
+
+  // Precompute in-degree for fan-in detection
+  const inDegree = new Map<string, number>()
+  for (const edge of graph.edges) {
+    inDegree.set(edge.to.name, (inDegree.get(edge.to.name) ?? 0) + 1)
   }
 
   // Place child nodes level by level
@@ -503,6 +522,11 @@ export function createMapping(graph: AsciiGraph): void {
           // Cross-direction: use parent's perpendicular coordinate
           // This keeps children aligned with parent when direction changes
           highestPosition = edgeDir === 'LR' ? gc.y : gc.x
+        } else if ((inDegree.get(child.name) ?? 0) > 1) {
+          // Fan-in target: align with parent's perpendicular position to keep
+          // the target near its root group and avoid long diagonal edges
+          const parentPerpendicular = graph.config.graphDirection === 'LR' ? gc.y : gc.x
+          highestPosition = Math.max(highestPositionPerLevel[childLevel]!, parentPerpendicular)
         } else {
           // Same direction: use level tracker
           highestPosition = highestPositionPerLevel[childLevel]!


### PR DESCRIPTION
## Summary

- Root nodes feeding into different targets were placed in a flat horizontal sequence, causing edge paths from different fan-in groups to overlap and become unreadable.
- Group roots by their immediate downstream target so roots for the same target are placed contiguously.
- When placing fan-in targets (in-degree > 1), align them with the parent's perpendicular position using `Math.max(levelTracker, parentPerpendicular)` to keep targets near their root group.

Fixes #68

## Before / After

For `A1, A2 --> A` and `B1, B2 --> B`:

**Before:** all roots in a flat row, edges cross between groups
```
A1   A2   B1   B2
 └────┼────┴────┘
      |    |
      A    B
```

**After:** roots grouped by target, targets aligned under their groups
```
A1   A2        B1   B2
 └────┘         └────┘
      |              |
      A              B
```

## Test plan

- [x] `bun test src/__tests__/` — all 711 tests pass, no regressions
- [x] Simple fan-in case (`A1,A2→A`, `B1,B2→B`) renders with separated groups
- [x] Dense fan-in case from #64 (4 edges to A, 3 edges to B) renders correctly
- [x] Single fan-in group: no change in behavior
- [x] LR and TD directions both work correctly