### PR TITLE
chore: add Biome linter/formatter with auto-fixed codebase

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,49 @@
+{
+  "assist": {
+    "enabled": true,
+    "actions": {
+      "source": {
+        "organizeImports": "on"
+      }
+    }
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineWidth": 120
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "single",
+      "semicolons": "asNeeded",
+      "trailingCommas": "all",
+      "arrowParentheses": "asNeeded"
+    }
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true,
+      "complexity": {
+        "noForEach": "off"
+      },
+      "style": {
+        "noNonNullAssertion": "off",
+        "useConst": "error",
+        "noParameterAssign": "off"
+      },
+      "suspicious": {
+        "noExplicitAny": "warn",
+        "noAssignInExpressions": "off"
+      },
+      "correctness": {
+        "noUnusedVariables": "warn",
+        "noUnusedImports": "warn"
+      }
+    }
+  },
+  "files": {
+    "includes": ["src/**", "index.ts", "dev.ts", "bench.ts", "samples-data.ts"]
+  }
+}

--- a/bun.lock
+++ b/bun.lock
@@ -9,6 +9,7 @@
         "entities": "^7.0.1",
       },
       "devDependencies": {
+        "@biomejs/biome": "^2.4.8",
         "@types/bun": "^1.3.9",
         "shiki": "^3.19.0",
         "tsup": "^8.5.1",
@@ -17,6 +18,24 @@
     },
   },
   "packages": {
+    "@biomejs/biome": ["@biomejs/biome@2.4.8", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.4.8", "@biomejs/cli-darwin-x64": "2.4.8", "@biomejs/cli-linux-arm64": "2.4.8", "@biomejs/cli-linux-arm64-musl": "2.4.8", "@biomejs/cli-linux-x64": "2.4.8", "@biomejs/cli-linux-x64-musl": "2.4.8", "@biomejs/cli-win32-arm64": "2.4.8", "@biomejs/cli-win32-x64": "2.4.8" }, "bin": { "biome": "bin/biome" } }, "sha512-ponn0oKOky1oRXBV+rlSaUlixUxf1aZvWC19Z41zBfUOUesthrQqL3OtiAlSB1EjFjyWpn98Q64DHelhA6jNlA=="],
+
+    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.4.8", "", { "os": "darwin", "cpu": "arm64" }, "sha512-ARx0tECE8I7S2C2yjnWYLNbBdDoPdq3oyNLhMglmuctThwUsuzFWRKrHmIGwIRWKz0Mat9DuzLEDp52hGnrxGQ=="],
+
+    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.4.8", "", { "os": "darwin", "cpu": "x64" }, "sha512-Jg9/PsB9vDCJlANE8uhG7qDhb5w0Ix69D7XIIc8IfZPUoiPrbLm33k2Ig3NOJ/7nb3UbesFz3D1aDKm9DvzjhQ=="],
+
+    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.4.8", "", { "os": "linux", "cpu": "arm64" }, "sha512-5CdrsJct76XG2hpKFwXnEtlT1p+4g4yV+XvvwBpzKsTNLO9c6iLlAxwcae2BJ7ekPGWjNGw9j09T5KGPKKxQig=="],
+
+    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.4.8", "", { "os": "linux", "cpu": "arm64" }, "sha512-Zo9OhBQDJ3IBGPlqHiTISloo5H0+FBIpemqIJdW/0edJ+gEcLR+MZeZozcUyz3o1nXkVA7++DdRKQT0599j9jA=="],
+
+    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.4.8", "", { "os": "linux", "cpu": "x64" }, "sha512-PdKXspVEaMCQLjtZCn6vfSck/li4KX9KGwSDbZdgIqlrizJ2MnMcE3TvHa2tVfXNmbjMikzcfJpuPWH695yJrw=="],
+
+    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.4.8", "", { "os": "linux", "cpu": "x64" }, "sha512-Gi8quv8MEuDdKaPFtS2XjEnMqODPsRg6POT6KhoP+VrkNb+T2ywunVB+TvOU0LX1jAZzfBr+3V1mIbBhzAMKvw=="],
+
+    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.4.8", "", { "os": "win32", "cpu": "arm64" }, "sha512-LoFatS0tnHv6KkCVpIy3qZCih+MxUMvdYiPWLHRri7mhi2vyOOs8OrbZBcLTUEWCS+ktO72nZMy4F96oMhkOHQ=="],
+
+    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.8", "", { "os": "win32", "cpu": "x64" }, "sha512-vAn7iXDoUbqFXqVocuq1sMYAd33p8+mmurqJkWl6CtIhobd/O6moe4rY5AJvzbunn/qZCdiDVcveqtkFh1e7Hg=="],
+
     "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.3", "", { "os": "aix", "cpu": "ppc64" }, "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg=="],
 
     "@esbuild/android-arm": ["@esbuild/android-arm@0.27.3", "", { "os": "android", "cpu": "arm" }, "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA=="],

--- a/package.json
+++ b/package.json
@@ -38,6 +38,9 @@
   "author": "Craft Docs",
   "files": ["src/", "dist/", "LICENSE", "README.md"],
   "scripts": {
+    "lint": "biome check src/",
+    "lint:fix": "biome check --write src/",
+    "format": "biome format --write src/",
     "test": "bun test src/__tests__/",
     "samples": "bun run index.ts",
     "dev": "bun run dev.ts",
@@ -53,6 +56,7 @@
     "entities": "^7.0.1"
   },
   "devDependencies": {
+    "@biomejs/biome": "^2.4.8",
     "@types/bun": "^1.3.9",
     "shiki": "^3.19.0",
     "tsup": "^8.5.1",

--- a/src/__tests__/ascii-edge-styles.test.ts
+++ b/src/__tests__/ascii-edge-styles.test.ts
@@ -2,7 +2,7 @@
 // ASCII edge style tests — dotted and thick line rendering
 // ============================================================================
 
-import { describe, it, expect } from 'bun:test'
+import { describe, expect, it } from 'bun:test'
 import { renderMermaidAscii } from '../ascii/index.ts'
 
 describe('ASCII edge styles', () => {
@@ -18,10 +18,13 @@ describe('ASCII edge styles', () => {
     })
 
     it('renders solid edges with - in ascii mode', () => {
-      const result = renderMermaidAscii(`
+      const result = renderMermaidAscii(
+        `
         graph LR
           A --> B
-      `, { useAscii: true })
+      `,
+        { useAscii: true },
+      )
       expect(result).toContain('-')
     })
   })
@@ -37,10 +40,13 @@ describe('ASCII edge styles', () => {
     })
 
     it('renders dotted edges with . in ascii mode', () => {
-      const result = renderMermaidAscii(`
+      const result = renderMermaidAscii(
+        `
         graph LR
           A -.-> B
-      `, { useAscii: true })
+      `,
+        { useAscii: true },
+      )
       // Should contain dots for dotted lines
       expect(result).toContain('.')
     })
@@ -55,10 +61,13 @@ describe('ASCII edge styles', () => {
     })
 
     it('renders dotted vertical edges with : in ascii mode', () => {
-      const result = renderMermaidAscii(`
+      const result = renderMermaidAscii(
+        `
         graph TD
           A -.-> B
-      `, { useAscii: true })
+      `,
+        { useAscii: true },
+      )
       // Should contain colons for dotted vertical lines
       expect(result).toContain(':')
     })
@@ -84,10 +93,13 @@ describe('ASCII edge styles', () => {
     })
 
     it('renders thick edges with = in ascii mode', () => {
-      const result = renderMermaidAscii(`
+      const result = renderMermaidAscii(
+        `
         graph LR
           A ==> B
-      `, { useAscii: true })
+      `,
+        { useAscii: true },
+      )
       // Should contain equals for thick lines
       expect(result).toContain('=')
     })
@@ -111,18 +123,21 @@ describe('ASCII edge styles', () => {
           C ==> D
       `)
       // Should have all three line types
-      expect(result).toContain('─')  // solid
-      expect(result).toContain('┄')  // dotted
-      expect(result).toContain('━')  // thick
+      expect(result).toContain('─') // solid
+      expect(result).toContain('┄') // dotted
+      expect(result).toContain('━') // thick
     })
 
     it('renders mixed styles in ascii mode', () => {
-      const result = renderMermaidAscii(`
+      const result = renderMermaidAscii(
+        `
         graph LR
           A --> B
           B -.-> C
           C ==> D
-      `, { useAscii: true })
+      `,
+        { useAscii: true },
+      )
       // Note: ASCII mode uses - for solid, . for dotted, = for thick
       // We just check that the diagram renders without error
       expect(result).toContain('A')

--- a/src/__tests__/ascii-multiline.test.ts
+++ b/src/__tests__/ascii-multiline.test.ts
@@ -1,10 +1,12 @@
-import { describe, it, expect } from 'bun:test'
+import { describe, expect, it } from 'bun:test'
 import { renderMermaidAscii } from '../ascii/index.ts'
 
 describe('ASCII multi-line labels', () => {
   describe('flowchart nodes', () => {
     it('renders multi-line node labels', () => {
-      const ascii = renderMermaidAscii('graph TD\n  A[Line1<br>Line2]', { useAscii: false })
+      const ascii = renderMermaidAscii('graph TD\n  A[Line1<br>Line2]', {
+        useAscii: false,
+      })
       expect(ascii).toContain('Line1')
       expect(ascii).toContain('Line2')
       // Lines should be on different rows
@@ -15,7 +17,9 @@ describe('ASCII multi-line labels', () => {
     })
 
     it('handles 3+ line labels', () => {
-      const ascii = renderMermaidAscii('graph TD\n  A[A<br>B<br>C]', { useAscii: false })
+      const ascii = renderMermaidAscii('graph TD\n  A[A<br>B<br>C]', {
+        useAscii: false,
+      })
       expect(ascii).toContain('A')
       expect(ascii).toContain('B')
       expect(ascii).toContain('C')
@@ -29,7 +33,9 @@ describe('ASCII multi-line labels', () => {
     })
 
     it('renders in ASCII mode (not Unicode)', () => {
-      const ascii = renderMermaidAscii('graph TD\n  A[Line1<br>Line2]', { useAscii: true })
+      const ascii = renderMermaidAscii('graph TD\n  A[Line1<br>Line2]', {
+        useAscii: true,
+      })
       expect(ascii).toContain('Line1')
       expect(ascii).toContain('Line2')
       // Should use ASCII box characters
@@ -48,11 +54,14 @@ describe('ASCII multi-line labels', () => {
 
   describe('flowchart subgraph labels', () => {
     it('renders multi-line subgraph labels', () => {
-      const ascii = renderMermaidAscii(`graph TD
+      const ascii = renderMermaidAscii(
+        `graph TD
         subgraph sg [Group<br>Header]
           A[Node]
         end
-      `, { useAscii: false })
+      `,
+        { useAscii: false },
+      )
       expect(ascii).toContain('Group')
       expect(ascii).toContain('Header')
     })
@@ -60,30 +69,39 @@ describe('ASCII multi-line labels', () => {
 
   describe('sequence diagram', () => {
     it('renders multi-line actor labels', () => {
-      const ascii = renderMermaidAscii(`sequenceDiagram
+      const ascii = renderMermaidAscii(
+        `sequenceDiagram
         participant A as Actor<br>One
         A->>A: msg
-      `, { useAscii: false })
+      `,
+        { useAscii: false },
+      )
       expect(ascii).toContain('Actor')
       expect(ascii).toContain('One')
     })
 
     it('renders multi-line message labels', () => {
-      const ascii = renderMermaidAscii(`sequenceDiagram
+      const ascii = renderMermaidAscii(
+        `sequenceDiagram
         participant A
         participant B
         A->>B: Line1<br>Line2
-      `, { useAscii: false })
+      `,
+        { useAscii: false },
+      )
       expect(ascii).toContain('Line1')
       expect(ascii).toContain('Line2')
     })
 
     it('preserves existing note multi-line support', () => {
-      const ascii = renderMermaidAscii(`sequenceDiagram
+      const ascii = renderMermaidAscii(
+        `sequenceDiagram
         participant A
         A->>A: self
         Note over A: Note line 1<br>Note line 2
-      `, { useAscii: false })
+      `,
+        { useAscii: false },
+      )
       expect(ascii).toContain('Note line 1')
       expect(ascii).toContain('Note line 2')
     })
@@ -91,17 +109,23 @@ describe('ASCII multi-line labels', () => {
 
   describe('class diagram', () => {
     it('renders multi-line class names', () => {
-      const ascii = renderMermaidAscii(`classDiagram
+      const ascii = renderMermaidAscii(
+        `classDiagram
         class MyClass["Long<br>Name"]
-      `, { useAscii: false })
+      `,
+        { useAscii: false },
+      )
       expect(ascii).toContain('Long')
       expect(ascii).toContain('Name')
     })
 
     it('renders multi-line relationship labels', () => {
-      const ascii = renderMermaidAscii(`classDiagram
+      const ascii = renderMermaidAscii(
+        `classDiagram
         A --> B : uses<br>implements
-      `, { useAscii: false })
+      `,
+        { useAscii: false },
+      )
       expect(ascii).toContain('uses')
       expect(ascii).toContain('implements')
     })
@@ -109,19 +133,25 @@ describe('ASCII multi-line labels', () => {
 
   describe('ER diagram', () => {
     it('renders multi-line entity names', () => {
-      const ascii = renderMermaidAscii(`erDiagram
+      const ascii = renderMermaidAscii(
+        `erDiagram
         "Entity<br>Name" {
           string id
         }
-      `, { useAscii: false })
+      `,
+        { useAscii: false },
+      )
       expect(ascii).toContain('Entity')
       expect(ascii).toContain('Name')
     })
 
     it('renders multi-line relationship labels', () => {
-      const ascii = renderMermaidAscii(`erDiagram
+      const ascii = renderMermaidAscii(
+        `erDiagram
         A ||--o{ B : "has<br>many"
-      `, { useAscii: false })
+      `,
+        { useAscii: false },
+      )
       expect(ascii).toContain('has')
       expect(ascii).toContain('many')
     })
@@ -129,19 +159,25 @@ describe('ASCII multi-line labels', () => {
 
   describe('edge cases', () => {
     it('handles empty lines from consecutive <br>', () => {
-      const ascii = renderMermaidAscii('graph TD\n  A[Line1<br><br>Line3]', { useAscii: false })
+      const ascii = renderMermaidAscii('graph TD\n  A[Line1<br><br>Line3]', {
+        useAscii: false,
+      })
       expect(ascii).toContain('Line1')
       expect(ascii).toContain('Line3')
     })
 
     it('handles single-line labels (no <br>)', () => {
-      const ascii = renderMermaidAscii('graph TD\n  A[SingleLine]', { useAscii: false })
+      const ascii = renderMermaidAscii('graph TD\n  A[SingleLine]', {
+        useAscii: false,
+      })
       expect(ascii).toContain('SingleLine')
     })
 
     it('handles very long lines', () => {
       const long = 'A'.repeat(30)
-      const ascii = renderMermaidAscii(`graph TD\n  A[${long}<br>Short]`, { useAscii: false })
+      const ascii = renderMermaidAscii(`graph TD\n  A[${long}<br>Short]`, {
+        useAscii: false,
+      })
       expect(ascii).toContain(long)
       expect(ascii).toContain('Short')
     })
@@ -157,7 +193,9 @@ describe('ASCII multi-line labels', () => {
   describe('multiline-utils functions', () => {
     it('splitLines splits on newlines', () => {
       // Test through the rendering pipeline
-      const ascii = renderMermaidAscii('graph TD\n  A[One<br>Two<br>Three]', { useAscii: false })
+      const ascii = renderMermaidAscii('graph TD\n  A[One<br>Two<br>Three]', {
+        useAscii: false,
+      })
       const lines = ascii.split('\n')
       // All three words should appear on separate lines
       expect(lines.some(l => l.includes('One'))).toBe(true)
@@ -167,7 +205,9 @@ describe('ASCII multi-line labels', () => {
 
     it('maxLineWidth uses longest line for box sizing', () => {
       // Box should be wide enough for the longest line
-      const ascii = renderMermaidAscii('graph TD\n  A[X<br>LongLine<br>Y]', { useAscii: false })
+      const ascii = renderMermaidAscii('graph TD\n  A[X<br>LongLine<br>Y]', {
+        useAscii: false,
+      })
       // The box should contain LongLine without truncation
       expect(ascii).toContain('LongLine')
     })

--- a/src/__tests__/ascii.test.ts
+++ b/src/__tests__/ascii.test.ts
@@ -7,11 +7,11 @@
  *
  * Test data: 44 ASCII files + 22 Unicode files = 66 total.
  */
-import { describe, it, expect } from 'bun:test'
-import { renderMermaidAscii } from '../ascii/index.ts'
-import { hasDiagonalLines, DIAGONAL_CHARS } from '../ascii/validate.ts'
+import { describe, expect, it } from 'bun:test'
 import { readdirSync, readFileSync } from 'node:fs'
 import { join } from 'node:path'
+import { renderMermaidAscii } from '../ascii/index.ts'
+import { DIAGONAL_CHARS, hasDiagonalLines } from '../ascii/validate.ts'
 
 // ============================================================================
 // Test case parser — matches Go's testutil.ReadTestCase format
@@ -74,7 +74,7 @@ function parseTestCase(content: string): TestCase {
     }
   }
 
-  tc.mermaid = mermaidLines.join('\n') + '\n'
+  tc.mermaid = `${mermaidLines.join('\n')}\n`
 
   // Strip final trailing newline (matches Go's strings.TrimSuffix(expected, "\n"))
   let expected = expectedLines.join('\n')
@@ -97,7 +97,7 @@ function parseTestCase(content: string): TestCase {
  */
 function normalizeWhitespace(s: string): string {
   const lines = s.split('\n')
-  let normalized = lines.map(l => l.trimEnd())
+  const normalized = lines.map(l => l.trimEnd())
 
   // Remove leading blank lines
   while (normalized.length > 0 && normalized[0] === '') {
@@ -121,7 +121,9 @@ function visualizeWhitespace(s: string): string {
 // ============================================================================
 
 function runGoldenTests(dir: string, useAscii: boolean): void {
-  const files = readdirSync(dir).filter(f => f.endsWith('.txt')).sort()
+  const files = readdirSync(dir)
+    .filter(f => f.endsWith('.txt'))
+    .sort()
 
   for (const file of files) {
     const testName = file.replace('.txt', '')
@@ -199,7 +201,7 @@ describe('Diagonal validation', () => {
 
   it('ASCII output should never contain diagonal characters', () => {
     // Test all ASCII golden files
-    const files = readdirSync(asciiDir).filter((f) => f.endsWith('.txt'))
+    const files = readdirSync(asciiDir).filter(f => f.endsWith('.txt'))
     for (const file of files) {
       const content = readFileSync(join(asciiDir, file), 'utf-8')
       const { mermaid, paddingX, paddingY } = parseTestCase(content)
@@ -218,7 +220,7 @@ describe('Diagonal validation', () => {
 
   it('Unicode output should never contain diagonal characters', () => {
     // Test all Unicode golden files
-    const files = readdirSync(unicodeDir).filter((f) => f.endsWith('.txt'))
+    const files = readdirSync(unicodeDir).filter(f => f.endsWith('.txt'))
     for (const file of files) {
       const content = readFileSync(join(unicodeDir, file), 'utf-8')
       const { mermaid, paddingX, paddingY } = parseTestCase(content)

--- a/src/__tests__/class-arrow-directions.test.ts
+++ b/src/__tests__/class-arrow-directions.test.ts
@@ -7,11 +7,10 @@
  * - Composition/Aggregation: diamonds are omnidirectional
  */
 
-import { describe, test, expect } from 'bun:test'
+import { describe, expect, test } from 'bun:test'
 import { renderMermaidAscii } from '../ascii/index.ts'
 
 describe('Class Diagram Arrow Directions', () => {
-
   // ============================================================================
   // INHERITANCE (<|--)
   // ============================================================================

--- a/src/__tests__/class-integration.test.ts
+++ b/src/__tests__/class-integration.test.ts
@@ -1,7 +1,7 @@
 /**
  * Integration tests for class diagrams — end-to-end parse → layout → render.
  */
-import { describe, it, expect } from 'bun:test'
+import { describe, expect, it } from 'bun:test'
 import { renderMermaidSVG } from '../index.ts'
 
 describe('renderMermaidSVG – class diagrams', () => {
@@ -83,10 +83,13 @@ describe('renderMermaidSVG – class diagrams', () => {
   })
 
   it('renders with dark colors', () => {
-    const svg = renderMermaidSVG(`classDiagram
+    const svg = renderMermaidSVG(
+      `classDiagram
       class A {
         +x int
-      }`, { bg: '#18181B', fg: '#FAFAFA' })
+      }`,
+      { bg: '#18181B', fg: '#FAFAFA' },
+    )
     expect(svg).toContain('--bg:#18181B')
   })
 

--- a/src/__tests__/class-parser.test.ts
+++ b/src/__tests__/class-parser.test.ts
@@ -4,12 +4,15 @@
  * Covers: class blocks, attributes, methods, visibility, annotations,
  * relationships (all 6 types), cardinality, labels, inline attributes.
  */
-import { describe, it, expect } from 'bun:test'
+import { describe, expect, it } from 'bun:test'
 import { parseClassDiagram } from '../class/parser.ts'
 
 /** Helper to parse — preprocesses text the same way index.ts does */
 function parse(text: string) {
-  const lines = text.split('\n').map(l => l.trim()).filter(l => l.length > 0 && !l.startsWith('%%'))
+  const lines = text
+    .split('\n')
+    .map(l => l.trim())
+    .filter(l => l.length > 0 && !l.startsWith('%%'))
   return parseClassDiagram(lines)
 }
 

--- a/src/__tests__/edge-approach-direction.test.ts
+++ b/src/__tests__/edge-approach-direction.test.ts
@@ -11,9 +11,9 @@
  * but approaches horizontally, creating an awkward bend at the arrowhead.
  */
 
-import { describe, it, expect } from 'bun:test'
-import { parseMermaid } from '../parser.ts'
+import { describe, expect, it } from 'bun:test'
 import { layoutGraphSync } from '../layout.ts'
+import { parseMermaid } from '../parser.ts'
 
 interface Point {
   x: number
@@ -68,12 +68,12 @@ function getApproachSide(
   nodeX: number,
   nodeY: number,
   nodeWidth: number,
-  nodeHeight: number
+  nodeHeight: number,
 ): 'top' | 'bottom' | 'left' | 'right' {
   const cx = nodeX + nodeWidth / 2
   const cy = nodeY + nodeHeight / 2
-  const dx = point.x - cx
-  const dy = point.y - cy
+  const _dx = point.x - cx
+  const _dy = point.y - cy
 
   // Check which edge the point is closest to
   const distTop = Math.abs(point.y - nodeY)
@@ -100,9 +100,7 @@ describe('Edge Approach Direction', () => {
         A --> B`)
       const positioned = layoutGraphSync(parsed, {})
 
-      const edge = positioned.edges.find(
-        (e) => e.source === 'A' && e.target === 'B'
-      )
+      const edge = positioned.edges.find(e => e.source === 'A' && e.target === 'B')
       expect(edge).toBeDefined()
 
       const finalSeg = getFinalSegment(edge!.points)
@@ -119,7 +117,7 @@ describe('Edge Approach Direction', () => {
         Config --> Processor`)
       const positioned = layoutGraphSync(parsed, {})
 
-      const processorNode = positioned.nodes.find((n) => n.id === 'Processor')
+      const processorNode = positioned.nodes.find(n => n.id === 'Processor')
       expect(processorNode).toBeDefined()
 
       // Both edges should approach Processor with vertical final segments
@@ -146,7 +144,7 @@ describe('Edge Approach Direction', () => {
 
       // Check all edges
       for (const edge of positioned.edges) {
-        const targetNode = positioned.nodes.find((n) => n.id === edge.target)
+        const targetNode = positioned.nodes.find(n => n.id === edge.target)
         expect(targetNode).toBeDefined()
 
         const finalSeg = getFinalSegment(edge.points)
@@ -158,7 +156,7 @@ describe('Edge Approach Direction', () => {
           targetNode!.x,
           targetNode!.y,
           targetNode!.width,
-          targetNode!.height
+          targetNode!.height,
         )
 
         // For top/bottom approach, final segment must be vertical
@@ -178,9 +176,7 @@ describe('Edge Approach Direction', () => {
         A --> B`)
       const positioned = layoutGraphSync(parsed, {})
 
-      const edge = positioned.edges.find(
-        (e) => e.source === 'A' && e.target === 'B'
-      )
+      const edge = positioned.edges.find(e => e.source === 'A' && e.target === 'B')
       expect(edge).toBeDefined()
 
       const finalSeg = getFinalSegment(edge!.points)
@@ -251,9 +247,7 @@ describe('Edge Approach Direction', () => {
       const positioned = layoutGraphSync(parsed, {})
 
       // Edge A → B should approach B's top vertically
-      const edgeAB = positioned.edges.find(
-        (e) => e.source === 'A' && e.target === 'B'
-      )
+      const edgeAB = positioned.edges.find(e => e.source === 'A' && e.target === 'B')
       expect(edgeAB).toBeDefined()
 
       const finalSegAB = getFinalSegment(edgeAB!.points)

--- a/src/__tests__/er-integration.test.ts
+++ b/src/__tests__/er-integration.test.ts
@@ -1,7 +1,7 @@
 /**
  * Integration tests for ER diagrams — end-to-end parse → layout → render.
  */
-import { describe, it, expect } from 'bun:test'
+import { describe, expect, it } from 'bun:test'
 import { renderMermaidSVG } from '../index.ts'
 
 describe('renderMermaidSVG – ER diagrams', () => {
@@ -38,7 +38,7 @@ describe('renderMermaidSVG – ER diagrams', () => {
     expect(svg).toContain('<polyline')
   })
 
-  it('renders crow\'s foot cardinality markers', () => {
+  it("renders crow's foot cardinality markers", () => {
     const svg = renderMermaidSVG(`erDiagram
       CUSTOMER ||--o{ ORDER : places`)
     // Crow's foot markers are rendered as lines
@@ -62,8 +62,11 @@ describe('renderMermaidSVG – ER diagrams', () => {
   })
 
   it('renders with dark colors', () => {
-    const svg = renderMermaidSVG(`erDiagram
-      A ||--|| B : links`, { bg: '#18181B', fg: '#FAFAFA' })
+    const svg = renderMermaidSVG(
+      `erDiagram
+      A ||--|| B : links`,
+      { bg: '#18181B', fg: '#FAFAFA' },
+    )
     expect(svg).toContain('--bg:#18181B')
   })
 
@@ -118,26 +121,34 @@ describe('renderMermaidSVG – ER diagrams', () => {
 // ============================================================================
 
 /** Extract entity box rects from SVG: returns Map<label, {x, y, width, height, rightEdge}> */
-function extractEntityBoxes(svg: string): Map<string, { x: number; y: number; width: number; height: number; rightEdge: number }> {
+function extractEntityBoxes(
+  svg: string,
+): Map<string, { x: number; y: number; width: number; height: number; rightEdge: number }> {
   const boxes = new Map<string, { x: number; y: number; width: number; height: number; rightEdge: number }>()
 
   // Entity header text: <text x="..." y="..." ... font-weight="700" ...>LABEL</text>
   const headerPattern = /<text x="([\d.]+)" y="([\d.]+)"[^>]*font-weight="700"[^>]*>([^<]+)<\/text>/g
-  let match
+  let match: RegExpExecArray | null
   while ((match = headerPattern.exec(svg)) !== null) {
     const centerX = parseFloat(match[1]!)
     const label = match[3]!
 
     // Find the corresponding outer rect that contains this text.
     const rectPattern = /<rect x="([\d.]+)" y="([\d.]+)" width="([\d.]+)" height="([\d.]+)" rx="0" ry="0"/g
-    let rectMatch
+    let rectMatch: RegExpExecArray | null
     while ((rectMatch = rectPattern.exec(svg)) !== null) {
       const rx = parseFloat(rectMatch[1]!)
       const ry = parseFloat(rectMatch[2]!)
       const rw = parseFloat(rectMatch[3]!)
       const rh = parseFloat(rectMatch[4]!)
       if (centerX >= rx && centerX <= rx + rw) {
-        boxes.set(label, { x: rx, y: ry, width: rw, height: rh, rightEdge: rx + rw })
+        boxes.set(label, {
+          x: rx,
+          y: ry,
+          width: rw,
+          height: rh,
+          rightEdge: rx + rw,
+        })
         break
       }
     }
@@ -152,9 +163,12 @@ function extractLabelPositions(svg: string): Map<string, { x: number; y: number 
   // Relationship labels use font-size="11" font-weight="400" — match flexibly
   // regardless of attribute order
   const labelPattern = /<text x="([\d.]+)" y="([\d.]+)"[^>]*font-size="11"[^>]*font-weight="400"[^>]*>([^<]+)<\/text>/g
-  let match
+  let match: RegExpExecArray | null
   while ((match = labelPattern.exec(svg)) !== null) {
-    labels.set(match[3]!, { x: parseFloat(match[1]!), y: parseFloat(match[2]!) })
+    labels.set(match[3]!, {
+      x: parseFloat(match[1]!),
+      y: parseFloat(match[2]!),
+    })
   }
   return labels
 }
@@ -164,7 +178,7 @@ function extractPolylines(svg: string): Array<Array<{ x: number; y: number }>> {
   const polylines: Array<Array<{ x: number; y: number }>> = []
   // Match polylines with points attribute anywhere in the tag
   const pattern = /<polyline[^>]*points="([^"]+)"[^>]*>/g
-  let match
+  let match: RegExpExecArray | null
   while ((match = pattern.exec(svg)) !== null) {
     const points = match[1]!.split(' ').map(p => {
       const [x, y] = p.split(',')
@@ -192,7 +206,11 @@ function distanceToPolyline(point: { x: number; y: number }, polyline: Array<{ x
 }
 
 /** Distance from point P to line segment AB */
-function pointToSegmentDist(p: { x: number; y: number }, a: { x: number; y: number }, b: { x: number; y: number }): number {
+function pointToSegmentDist(
+  p: { x: number; y: number },
+  a: { x: number; y: number },
+  b: { x: number; y: number },
+): number {
   const dx = b.x - a.x
   const dy = b.y - a.y
   const lenSq = dx * dx + dy * dy
@@ -208,7 +226,10 @@ function pointToSegmentDist(p: { x: number; y: number }, a: { x: number; y: numb
  * Find the polyline closest to a label position.
  * Returns the minimum distance from the label to any polyline.
  */
-function closestPolylineDistance(label: { x: number; y: number }, polylines: Array<Array<{ x: number; y: number }>>): number {
+function closestPolylineDistance(
+  label: { x: number; y: number },
+  polylines: Array<Array<{ x: number; y: number }>>,
+): number {
   let minDist = Infinity
   for (const pl of polylines) {
     const dist = distanceToPolyline(label, pl)
@@ -412,7 +433,7 @@ describe('renderMermaidSVG – ER label positioning (multi-segment paths)', () =
 
     // Find the background pill rect (rx="2" ry="2" near the label position)
     const pillPattern = /<rect x="([\d.]+)" y="([\d.]+)" width="([\d.]+)" height="([\d.]+)" rx="2" ry="2"/g
-    let pillMatch
+    let pillMatch: RegExpExecArray | null
     let foundPill = false
     while ((pillMatch = pillPattern.exec(svg)) !== null) {
       const px = parseFloat(pillMatch[1]!)

--- a/src/__tests__/er-parser.test.ts
+++ b/src/__tests__/er-parser.test.ts
@@ -4,12 +4,15 @@
  * Covers: entity definitions, attribute parsing (types, names, keys, comments),
  * relationships with all cardinality types, identifying/non-identifying lines.
  */
-import { describe, it, expect } from 'bun:test'
+import { describe, expect, it } from 'bun:test'
 import { parseErDiagram } from '../er/parser.ts'
 
 /** Helper to parse — preprocesses text the same way index.ts does */
 function parse(text: string) {
-  const lines = text.split('\n').map(l => l.trim()).filter(l => l.length > 0 && !l.startsWith('%%'))
+  const lines = text
+    .split('\n')
+    .map(l => l.trim())
+    .filter(l => l.length > 0 && !l.startsWith('%%'))
   return parseErDiagram(lines)
 }
 

--- a/src/__tests__/integration.test.ts
+++ b/src/__tests__/integration.test.ts
@@ -7,7 +7,7 @@
  * Covers: original features, Batch 1 (new shapes), Batch 2 (edges, styles),
  * and Batch 3 (state diagrams).
  */
-import { describe, it, expect } from 'bun:test'
+import { describe, expect, it } from 'bun:test'
 import { renderMermaidSVG } from '../index.ts'
 
 // ============================================================================
@@ -42,7 +42,10 @@ describe('renderMermaidSVG – basic', () => {
 
 describe('renderMermaidSVG – options', () => {
   it('applies dark colors', () => {
-    const svg = renderMermaidSVG('graph TD\n  A --> B', { bg: '#18181B', fg: '#FAFAFA' })
+    const svg = renderMermaidSVG('graph TD\n  A --> B', {
+      bg: '#18181B',
+      fg: '#FAFAFA',
+    })
     expect(svg).toContain('--bg:#18181B')
   })
 
@@ -52,7 +55,9 @@ describe('renderMermaidSVG – options', () => {
   })
 
   it('applies custom font', () => {
-    const svg = renderMermaidSVG('graph TD\n  A --> B', { font: 'JetBrains Mono' })
+    const svg = renderMermaidSVG('graph TD\n  A --> B', {
+      font: 'JetBrains Mono',
+    })
     expect(svg).toContain("'JetBrains Mono'")
   })
 
@@ -340,7 +345,7 @@ describe('renderMermaidSVG – state diagrams', () => {
         const overlapY = a.y < b.y + b.h && a.y + a.h > b.y
         expect(
           overlapX && overlapY,
-          `Label pills ${i} (x=${a.x},y=${a.y},w=${a.w},h=${a.h}) and ${j} (x=${b.x},y=${b.y},w=${b.w},h=${b.h}) overlap`
+          `Label pills ${i} (x=${a.x},y=${a.y},w=${a.w},h=${a.h}) and ${j} (x=${b.x},y=${b.y},w=${b.w},h=${b.h}) overlap`,
         ).toBe(false)
       }
     }
@@ -506,8 +511,20 @@ describe('renderMermaidSVG – all shapes combined', () => {
       K --> L[\\TrapAlt/]`)
 
     // Verify every label renders
-    for (const label of ['Rectangle', 'Rounded', 'Diamond', 'Stadium', 'Circle',
-      'Subroutine', 'DoubleCircle', 'Hexagon', 'Cylinder', 'Flag', 'Trapezoid', 'TrapAlt']) {
+    for (const label of [
+      'Rectangle',
+      'Rounded',
+      'Diamond',
+      'Stadium',
+      'Circle',
+      'Subroutine',
+      'DoubleCircle',
+      'Hexagon',
+      'Cylinder',
+      'Flag',
+      'Trapezoid',
+      'TrapAlt',
+    ]) {
       expect(svg).toContain(`>${label}</text>`)
     }
 

--- a/src/__tests__/layout-disconnected.test.ts
+++ b/src/__tests__/layout-disconnected.test.ts
@@ -7,8 +7,8 @@
  *
  * The key invariant: disconnected components should NEVER overlap.
  */
-import { describe, it, expect } from 'bun:test'
-import { renderMermaidSync, parseMermaid } from '../index.ts'
+import { describe, expect, it } from 'bun:test'
+import { parseMermaid, renderMermaidSync } from '../index.ts'
 import { layoutGraphSync } from '../layout.ts'
 
 // ============================================================================
@@ -18,21 +18,26 @@ import { layoutGraphSync } from '../layout.ts'
 /** Check if two rectangles overlap */
 function rectanglesOverlap(
   r1: { x: number; y: number; width: number; height: number },
-  r2: { x: number; y: number; width: number; height: number }
+  r2: { x: number; y: number; width: number; height: number },
 ): boolean {
   return !(
-    r1.x + r1.width <= r2.x ||   // r1 is left of r2
-    r2.x + r2.width <= r1.x ||   // r2 is left of r1
-    r1.y + r1.height <= r2.y ||  // r1 is above r2
-    r2.y + r2.height <= r1.y     // r2 is above r1
+    (
+      r1.x + r1.width <= r2.x || // r1 is left of r2
+      r2.x + r2.width <= r1.x || // r2 is left of r1
+      r1.y + r1.height <= r2.y || // r1 is above r2
+      r2.y + r2.height <= r1.y
+    ) // r2 is above r1
   )
 }
 
 /** Get bounding box from positioned elements */
-function getBoundingBox(items: Array<{ x: number; y: number; width: number; height: number }>) {
+function _getBoundingBox(items: Array<{ x: number; y: number; width: number; height: number }>) {
   if (items.length === 0) return { x: 0, y: 0, width: 0, height: 0 }
 
-  let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity
+  let minX = Infinity,
+    minY = Infinity,
+    maxX = -Infinity,
+    maxY = -Infinity
   for (const item of items) {
     minX = Math.min(minX, item.x)
     minY = Math.min(minY, item.y)
@@ -114,8 +119,7 @@ describe('layoutGraph – two disconnected subgraphs', () => {
 
     // In LR mode, subgraphs should be stacked vertically (perpendicular to flow)
     // One should be above the other
-    const isVerticallyArranged =
-      (s1.y + s1.height <= s2.y) || (s2.y + s2.height <= s1.y)
+    const isVerticallyArranged = s1.y + s1.height <= s2.y || s2.y + s2.height <= s1.y
 
     expect(isVerticallyArranged).toBe(true)
   })
@@ -139,8 +143,7 @@ describe('layoutGraph – two disconnected subgraphs', () => {
     // ELK may arrange disconnected components in various ways
     // The key requirement is that they don't overlap
     const noOverlap =
-      (s1.x + s1.width <= s2.x) || (s2.x + s2.width <= s1.x) ||
-      (s1.y + s1.height <= s2.y) || (s2.y + s2.height <= s1.y)
+      s1.x + s1.width <= s2.x || s2.x + s2.width <= s1.x || s1.y + s1.height <= s2.y || s2.y + s2.height <= s1.y
 
     expect(noOverlap).toBe(true)
   })
@@ -195,10 +198,7 @@ describe('layoutGraph – multiple disconnected components', () => {
     for (let i = 0; i < result.nodes.length; i++) {
       for (let j = i + 1; j < result.nodes.length; j++) {
         const overlap = rectanglesOverlap(result.nodes[i]!, result.nodes[j]!)
-        expect(
-          overlap,
-          `Nodes ${result.nodes[i]!.id} and ${result.nodes[j]!.id} overlap`
-        ).toBe(false)
+        expect(overlap, `Nodes ${result.nodes[i]!.id} and ${result.nodes[j]!.id} overlap`).toBe(false)
       }
     }
   })
@@ -248,10 +248,7 @@ describe('layoutGraph – mixed connected and disconnected', () => {
 
     // Isolated node should not overlap with any connected node
     for (const node of connectedNodes) {
-      expect(
-        rectanglesOverlap(nodeD, node),
-        `Node D overlaps with node ${node.id}`
-      ).toBe(false)
+      expect(rectanglesOverlap(nodeD, node), `Node D overlaps with node ${node.id}`).toBe(false)
     }
   })
 })

--- a/src/__tests__/linkstyle.test.ts
+++ b/src/__tests__/linkstyle.test.ts
@@ -1,11 +1,14 @@
-import { describe, it, expect } from 'bun:test'
-import { parseMermaid } from '../parser.ts'
+import { describe, expect, it } from 'bun:test'
 import { renderMermaidSVG } from '../index.ts'
+import { parseMermaid } from '../parser.ts'
 
 describe('linkStyle – parser', () => {
   it('parses linkStyle with single index', () => {
     const g = parseMermaid('graph TD\n  A --> B\n  linkStyle 0 stroke:#ff0000,stroke-width:2px')
-    expect(g.linkStyles.get(0)).toEqual({ stroke: '#ff0000', 'stroke-width': '2px' })
+    expect(g.linkStyles.get(0)).toEqual({
+      stroke: '#ff0000',
+      'stroke-width': '2px',
+    })
   })
 
   it('parses linkStyle with comma-separated indices', () => {
@@ -16,7 +19,10 @@ describe('linkStyle – parser', () => {
 
   it('parses linkStyle default', () => {
     const g = parseMermaid('graph TD\n  A --> B\n  linkStyle default stroke:#888888,stroke-width:3px')
-    expect(g.linkStyles.get('default')).toEqual({ stroke: '#888888', 'stroke-width': '3px' })
+    expect(g.linkStyles.get('default')).toEqual({
+      stroke: '#888888',
+      'stroke-width': '3px',
+    })
   })
 
   it('later linkStyle overrides earlier for same index', () => {
@@ -32,7 +38,10 @@ describe('linkStyle – parser', () => {
 
   it('strips trailing semicolons from style values', () => {
     const g = parseMermaid('graph TD\n  A --> B\n  linkStyle 0 stroke:#ff0000,stroke-width:4px;')
-    expect(g.linkStyles.get(0)).toEqual({ stroke: '#ff0000', 'stroke-width': '4px' })
+    expect(g.linkStyles.get(0)).toEqual({
+      stroke: '#ff0000',
+      'stroke-width': '4px',
+    })
   })
 })
 
@@ -68,7 +77,7 @@ describe('linkStyle – SVG integration', () => {
 
   it('index-specific linkStyle overrides default', () => {
     const svg = renderMermaidSVG(
-      'graph TD\n  A --> B\n  B --> C\n  linkStyle default stroke:#888\n  linkStyle 0 stroke:#ff0000'
+      'graph TD\n  A --> B\n  B --> C\n  linkStyle default stroke:#888\n  linkStyle 0 stroke:#ff0000',
     )
     expect(svg).toContain('stroke="#ff0000"')
     expect(svg).toContain('stroke="#888"')

--- a/src/__tests__/multiline-labels.test.ts
+++ b/src/__tests__/multiline-labels.test.ts
@@ -8,14 +8,14 @@
  * - Renderer: <tspan> generation for node and edge labels
  * - Integration: full SVG output with multi-line labels
  */
-import { describe, it, expect } from 'bun:test'
-import { parseMermaid } from '../parser.ts'
-import { parseSequenceDiagram } from '../sequence/parser.ts'
+import { describe, expect, it } from 'bun:test'
 import { parseClassDiagram } from '../class/parser.ts'
 import { parseErDiagram } from '../er/parser.ts'
-import { measureMultilineText, LINE_HEIGHT_RATIO, measureTextWidth } from '../text-metrics.ts'
 import { renderMermaid } from '../index.ts'
 import { normalizeBrTags, stripFormattingTags } from '../multiline-utils.ts'
+import { parseMermaid } from '../parser.ts'
+import { parseSequenceDiagram } from '../sequence/parser.ts'
+import { LINE_HEIGHT_RATIO, measureMultilineText, measureTextWidth } from '../text-metrics.ts'
 
 // ============================================================================
 // Parser: <br> tag normalization
@@ -150,7 +150,15 @@ describe('parseMermaid – <br> tag normalization', () => {
     })
 
     it('normalizes <br> in divider labels', () => {
-      const lines = ['sequenceDiagram', 'A->>B: Hello', 'alt First<br>case', 'A->>B: a', 'else Second<br>case', 'A->>B: b', 'end']
+      const lines = [
+        'sequenceDiagram',
+        'A->>B: Hello',
+        'alt First<br>case',
+        'A->>B: a',
+        'else Second<br>case',
+        'A->>B: b',
+        'end',
+      ]
       const diagram = parseSequenceDiagram(lines)
       expect(diagram.blocks[0]!.dividers[0]!.label).toBe('Second\ncase')
     })

--- a/src/__tests__/parser.test.ts
+++ b/src/__tests__/parser.test.ts
@@ -9,7 +9,7 @@
  *   state aliases, direction override
  * - Comments and error cases
  */
-import { describe, it, expect } from 'bun:test'
+import { describe, expect, it } from 'bun:test'
 import { parseMermaid } from '../parser.ts'
 
 // ============================================================================
@@ -27,7 +27,7 @@ describe('parseMermaid – graph header', () => {
     expect(g.direction).toBe('LR')
   })
 
-  it.each(['TD', 'TB', 'LR', 'BT', 'RL'] as const)('accepts direction %s', (dir) => {
+  it.each(['TD', 'TB', 'LR', 'BT', 'RL'] as const)('accepts direction %s', dir => {
     const g = parseMermaid(`graph ${dir}\n  A --> B`)
     expect(g.direction).toBe(dir)
   })
@@ -306,7 +306,7 @@ describe('parseMermaid – bidirectional arrows', () => {
     expect(g.edges[0]!.hasArrowEnd).toBe(true)
   })
 
-  it('parses dotted bidirectional: <-.->',  () => {
+  it('parses dotted bidirectional: <-.->', () => {
     const g = parseMermaid('graph TD\n  A <-.-> B')
     expect(g.edges[0]!.style).toBe('dotted')
     expect(g.edges[0]!.hasArrowStart).toBe(true)
@@ -619,8 +619,8 @@ describe('parseMermaid – classDef and class', () => {
       A --> B`)
     expect(g.classDefs.has('highlight')).toBe(true)
     const props = g.classDefs.get('highlight')!
-    expect(props['fill']).toBe('#f96')
-    expect(props['stroke']).toBe('#333')
+    expect(props.fill).toBe('#f96')
+    expect(props.stroke).toBe('#333')
   })
 
   it('parses class assignments to single node', () => {

--- a/src/__tests__/renderer.test.ts
+++ b/src/__tests__/renderer.test.ts
@@ -4,10 +4,10 @@
  * Uses hand-crafted PositionedGraph data to test SVG output without
  * depending on the layout engine.
  */
-import { describe, it, expect } from 'bun:test'
+import { describe, expect, it } from 'bun:test'
 import { renderSvg } from '../renderer.ts'
 import type { DiagramColors } from '../theme.ts'
-import type { PositionedGraph, PositionedNode, PositionedEdge, PositionedGroup } from '../types.ts'
+import type { PositionedEdge, PositionedGraph, PositionedGroup, PositionedNode } from '../types.ts'
 
 /** Minimal positioned graph for testing */
 function makeGraph(overrides: Partial<PositionedGraph> = {}): PositionedGraph {
@@ -43,7 +43,10 @@ function makeEdge(overrides: Partial<PositionedEdge> = {}): PositionedEdge {
     style: 'solid',
     hasArrowStart: false,
     hasArrowEnd: true,
-    points: [{ x: 100, y: 120 }, { x: 100, y: 200 }],
+    points: [
+      { x: 100, y: 120 },
+      { x: 100, y: 200 },
+    ],
     ...overrides,
   }
 }
@@ -245,7 +248,12 @@ describe('renderSvg – new shapes (Batch 2)', () => {
 
 describe('renderSvg – state pseudostates', () => {
   it('renders state-start as a filled circle', () => {
-    const node = makeNode({ shape: 'state-start', label: '', width: 28, height: 28 })
+    const node = makeNode({
+      shape: 'state-start',
+      label: '',
+      width: 28,
+      height: 28,
+    })
     const graph = makeGraph({ nodes: [node] })
     const svg = renderSvg(graph, lightColors)
     expect(svg).toContain('<circle')
@@ -254,7 +262,12 @@ describe('renderSvg – state pseudostates', () => {
   })
 
   it('renders state-end as bullseye (two circles)', () => {
-    const node = makeNode({ shape: 'state-end', label: '', width: 28, height: 28 })
+    const node = makeNode({
+      shape: 'state-end',
+      label: '',
+      width: 28,
+      height: 28,
+    })
     const graph = makeGraph({ nodes: [node] })
     const svg = renderSvg(graph, lightColors)
     const circleMatches = svg.match(/<circle/g) ?? []
@@ -352,7 +365,10 @@ describe('renderSvg – edge labels', () => {
     // labelPosition overrides to (50, 80) — verify the SVG uses that coordinate.
     const edge = makeEdge({
       label: 'Go',
-      points: [{ x: 100, y: 120 }, { x: 100, y: 200 }],
+      points: [
+        { x: 100, y: 120 },
+        { x: 100, y: 200 },
+      ],
       labelPosition: { x: 50, y: 80 },
     })
     const graph = makeGraph({ edges: [edge] })
@@ -372,8 +388,13 @@ describe('renderSvg – edge labels', () => {
 describe('renderSvg – groups', () => {
   it('renders group with outer rectangle and header band', () => {
     const group: PositionedGroup = {
-      id: 'sg1', label: 'Backend',
-      x: 20, y: 20, width: 200, height: 150, children: [],
+      id: 'sg1',
+      label: 'Backend',
+      x: 20,
+      y: 20,
+      width: 200,
+      height: 150,
+      children: [],
     }
     const graph = makeGraph({ groups: [group] })
     const svg = renderSvg(graph, lightColors)
@@ -384,12 +405,22 @@ describe('renderSvg – groups', () => {
 
   it('renders nested groups recursively', () => {
     const inner: PositionedGroup = {
-      id: 'inner', label: 'Inner',
-      x: 40, y: 60, width: 120, height: 80, children: [],
+      id: 'inner',
+      label: 'Inner',
+      x: 40,
+      y: 60,
+      width: 120,
+      height: 80,
+      children: [],
     }
     const outer: PositionedGroup = {
-      id: 'outer', label: 'Outer',
-      x: 20, y: 20, width: 200, height: 150, children: [inner],
+      id: 'outer',
+      label: 'Outer',
+      x: 20,
+      y: 20,
+      width: 200,
+      height: 150,
+      children: [inner],
     }
     const graph = makeGraph({ groups: [outer] })
     const svg = renderSvg(graph, lightColors)
@@ -456,8 +487,13 @@ describe('renderSvg – XML escaping', () => {
 
   it('escapes special characters in group labels', () => {
     const group: PositionedGroup = {
-      id: 'g1', label: 'A < B',
-      x: 0, y: 0, width: 100, height: 100, children: [],
+      id: 'g1',
+      label: 'A < B',
+      x: 0,
+      y: 0,
+      width: 100,
+      height: 100,
+      children: [],
     }
     const graph = makeGraph({ groups: [group] })
     const svg = renderSvg(graph, lightColors)
@@ -471,7 +507,9 @@ describe('renderSvg – XML escaping', () => {
 
 describe('renderSvg – inline style XSS prevention', () => {
   it('escapes attribute injection in inline style fill', () => {
-    const node = makeNode({ inlineStyle: { fill: 'red" onmouseover="alert(1)' } })
+    const node = makeNode({
+      inlineStyle: { fill: 'red" onmouseover="alert(1)' },
+    })
     const graph = makeGraph({ nodes: [node] })
     const svg = renderSvg(graph, lightColors)
     expect(svg).not.toContain('onmouseover="alert')
@@ -479,7 +517,9 @@ describe('renderSvg – inline style XSS prevention', () => {
   })
 
   it('escapes element injection in inline style fill', () => {
-    const node = makeNode({ inlineStyle: { fill: 'red"/><svg onload="alert(1)"><rect fill="x' } })
+    const node = makeNode({
+      inlineStyle: { fill: 'red"/><svg onload="alert(1)"><rect fill="x' },
+    })
     const graph = makeGraph({ nodes: [node] })
     const svg = renderSvg(graph, lightColors)
     expect(svg).not.toContain('<svg onload')
@@ -487,7 +527,9 @@ describe('renderSvg – inline style XSS prevention', () => {
   })
 
   it('escapes injection in inline style stroke', () => {
-    const node = makeNode({ inlineStyle: { stroke: 'blue" onclick="alert(1)' } })
+    const node = makeNode({
+      inlineStyle: { stroke: 'blue" onclick="alert(1)' },
+    })
     const graph = makeGraph({ nodes: [node] })
     const svg = renderSvg(graph, lightColors)
     expect(svg).not.toContain('onclick="alert')
@@ -495,7 +537,9 @@ describe('renderSvg – inline style XSS prevention', () => {
   })
 
   it('escapes injection in inline style stroke-width', () => {
-    const node = makeNode({ inlineStyle: { 'stroke-width': '2" onmouseover="alert(1)' } })
+    const node = makeNode({
+      inlineStyle: { 'stroke-width': '2" onmouseover="alert(1)' },
+    })
     const graph = makeGraph({ nodes: [node] })
     const svg = renderSvg(graph, lightColors)
     expect(svg).not.toContain('onmouseover="alert')
@@ -503,7 +547,9 @@ describe('renderSvg – inline style XSS prevention', () => {
   })
 
   it('escapes injection in inline style color', () => {
-    const node = makeNode({ inlineStyle: { color: 'green" onfocus="alert(1)' } })
+    const node = makeNode({
+      inlineStyle: { color: 'green" onfocus="alert(1)' },
+    })
     const graph = makeGraph({ nodes: [node] })
     const svg = renderSvg(graph, lightColors)
     expect(svg).not.toContain('onfocus="alert')

--- a/src/__tests__/sequence-integration.test.ts
+++ b/src/__tests__/sequence-integration.test.ts
@@ -1,7 +1,7 @@
 /**
  * Integration tests for sequence diagrams — end-to-end parse → layout → render.
  */
-import { describe, it, expect } from 'bun:test'
+import { describe, expect, it } from 'bun:test'
 import { renderMermaidSVG } from '../index.ts'
 
 describe('renderMermaidSVG – sequence diagrams', () => {
@@ -81,8 +81,11 @@ describe('renderMermaidSVG – sequence diagrams', () => {
   })
 
   it('renders with dark colors', () => {
-    const svg = renderMermaidSVG(`sequenceDiagram
-      A->>B: Hello`, { bg: '#18181B', fg: '#FAFAFA' })
+    const svg = renderMermaidSVG(
+      `sequenceDiagram
+      A->>B: Hello`,
+      { bg: '#18181B', fg: '#FAFAFA' },
+    )
     expect(svg).toContain('--bg:#18181B')
   })
 

--- a/src/__tests__/sequence-layout.test.ts
+++ b/src/__tests__/sequence-layout.test.ts
@@ -5,9 +5,9 @@
  * These tests call parseSequenceDiagram + layoutSequenceDiagram directly
  * to inspect Y coordinates, rather than checking SVG output.
  */
-import { describe, it, expect } from 'bun:test'
-import { parseSequenceDiagram } from '../sequence/parser.ts'
+import { describe, expect, it } from 'bun:test'
 import { layoutSequenceDiagram } from '../sequence/layout.ts'
+import { parseSequenceDiagram } from '../sequence/parser.ts'
 
 /** Helper: parse and layout a sequence diagram from source lines */
 function layout(source: string) {
@@ -462,7 +462,7 @@ describe('sequence layout – render clearance', () => {
     const msgAfter = result.messages[2]!
 
     // Default offset 28: baseline clearance = (msg.y - 6) - (msg.y - 28 + 14) = 8
-    const baselineClearance = (msgAfter.y - 6) - (divider.y + 14)
+    const baselineClearance = msgAfter.y - 6 - (divider.y + 14)
     expect(baselineClearance).toBe(8)
   })
 })

--- a/src/__tests__/sequence-parser.test.ts
+++ b/src/__tests__/sequence-parser.test.ts
@@ -4,12 +4,15 @@
  * Covers: participants, actors, messages (solid/dashed, filled/open arrows),
  * activation/deactivation, blocks (loop/alt/opt/par), notes, auto-created actors.
  */
-import { describe, it, expect } from 'bun:test'
+import { describe, expect, it } from 'bun:test'
 import { parseSequenceDiagram } from '../sequence/parser.ts'
 
 /** Helper to parse — preprocesses text the same way index.ts does */
 function parse(text: string) {
-  const lines = text.split('\n').map(l => l.trim()).filter(l => l.length > 0 && !l.startsWith('%%'))
+  const lines = text
+    .split('\n')
+    .map(l => l.trim())
+    .filter(l => l.length > 0 && !l.startsWith('%%'))
   return parseSequenceDiagram(lines)
 }
 

--- a/src/__tests__/styles.test.ts
+++ b/src/__tests__/styles.test.ts
@@ -2,10 +2,10 @@
  * Tests for styles module — text measurement and constants.
  * Theme resolution tests are in theme.test.ts (CSS custom property system).
  */
-import { describe, it, expect } from 'bun:test'
-import { estimateTextWidth, FONT_SIZES, FONT_WEIGHTS, NODE_PADDING, STROKE_WIDTHS, ARROW_HEAD } from '../styles.ts'
-import { THEMES, DEFAULTS, fromShikiTheme, buildStyleBlock, svgOpenTag } from '../theme.ts'
+import { describe, expect, it } from 'bun:test'
+import { ARROW_HEAD, estimateTextWidth, FONT_SIZES, FONT_WEIGHTS, NODE_PADDING, STROKE_WIDTHS } from '../styles.ts'
 import type { DiagramColors } from '../theme.ts'
+import { buildStyleBlock, DEFAULTS, fromShikiTheme, svgOpenTag, THEMES } from '../theme.ts'
 
 // ============================================================================
 // Theme system (CSS custom properties)
@@ -17,11 +17,11 @@ describe('THEMES', () => {
     expect(THEMES['zinc-dark']).toBeDefined()
     expect(THEMES['tokyo-night']).toBeDefined()
     expect(THEMES['catppuccin-mocha']).toBeDefined()
-    expect(THEMES['nord']).toBeDefined()
+    expect(THEMES.nord).toBeDefined()
   })
 
   it('each theme has valid bg and fg colors', () => {
-    for (const [name, colors] of Object.entries(THEMES)) {
+    for (const [_name, colors] of Object.entries(THEMES)) {
       expect(colors.bg).toMatch(/^#[0-9a-fA-F]{6}$/)
       expect(colors.fg).toMatch(/^#[0-9a-fA-F]{6}$/)
     }
@@ -45,8 +45,10 @@ describe('svgOpenTag', () => {
 
   it('includes optional enrichment variables when provided', () => {
     const colors: DiagramColors = {
-      bg: '#1a1b26', fg: '#a9b1d6',
-      line: '#3d59a1', accent: '#7aa2f7',
+      bg: '#1a1b26',
+      fg: '#a9b1d6',
+      line: '#3d59a1',
+      accent: '#7aa2f7',
     }
     const tag = svgOpenTag(400, 300, colors)
     expect(tag).toContain('--line:#3d59a1')

--- a/src/__tests__/text-metrics.test.ts
+++ b/src/__tests__/text-metrics.test.ts
@@ -1,7 +1,7 @@
 /**
  * Tests for text-metrics module — variable-width character measurement.
  */
-import { describe, it, expect } from 'bun:test'
+import { describe, expect, it } from 'bun:test'
 import { getCharWidth, measureTextWidth } from '../text-metrics'
 
 // ============================================================================

--- a/src/__tests__/xychart-ascii.test.ts
+++ b/src/__tests__/xychart-ascii.test.ts
@@ -4,7 +4,7 @@
  * Tests bar charts, line charts, mixed charts, horizontal orientation,
  * multi-series support, staircase line routing, and edge cases.
  */
-import { describe, it, expect } from 'bun:test'
+import { describe, expect, it } from 'bun:test'
 import { renderMermaidASCII } from '../ascii/index.ts'
 
 // ============================================================================
@@ -31,9 +31,12 @@ describe('xychart ASCII – bar charts', () => {
   })
 
   it('renders bars with # in ASCII mode', () => {
-    const result = render(`xychart-beta
+    const result = render(
+      `xychart-beta
       x-axis [A, B, C]
-      bar [10, 20, 30]`, true)
+      bar [10, 20, 30]`,
+      true,
+    )
     expect(result).toContain('#')
     expect(result).not.toContain('█')
   })
@@ -128,9 +131,12 @@ describe('xychart ASCII – line charts', () => {
   })
 
   it('uses + for corners in ASCII mode', () => {
-    const result = render(`xychart-beta
+    const result = render(
+      `xychart-beta
       x-axis [A, B]
-      line [10, 50]`, true)
+      line [10, 50]`,
+      true,
+    )
     expect(result).toContain('+')
     expect(result).not.toContain('╭')
     expect(result).not.toContain('╰')
@@ -298,10 +304,13 @@ describe('xychart ASCII – axis structure', () => {
   })
 
   it('uses + for axis characters in ASCII mode', () => {
-    const result = render(`xychart-beta
+    const result = render(
+      `xychart-beta
       x-axis [A, B, C]
       y-axis 0 --> 100
-      bar [25, 50, 75]`, true)
+      bar [25, 50, 75]`,
+      true,
+    )
     expect(result).toContain('+')
     expect(result).not.toContain('┤')
     expect(result).not.toContain('┬')

--- a/src/__tests__/xychart-integration.test.ts
+++ b/src/__tests__/xychart-integration.test.ts
@@ -4,7 +4,7 @@
  * Tests data-* attributes (always emitted) and interactive tooltip
  * groups (only when interactive: true).
  */
-import { describe, it, expect } from 'bun:test'
+import { describe, expect, it } from 'bun:test'
 import { renderMermaid } from '../index.ts'
 
 const BAR_CHART = `xychart-beta

--- a/src/ascii/ansi.ts
+++ b/src/ascii/ansi.ts
@@ -6,9 +6,9 @@
 // for browser rendering.
 // ============================================================================
 
-import type { CharRole, AsciiTheme, ColorMode } from './types.ts'
 import type { DiagramColors } from '../theme.ts'
 import { MIX } from '../theme.ts'
+import type { AsciiTheme, CharRole, ColorMode } from './types.ts'
 
 declare const document: unknown
 
@@ -21,11 +21,11 @@ declare const document: unknown
  * Uses the same mixing ratios to maintain visual consistency.
  */
 export const DEFAULT_ASCII_THEME: AsciiTheme = {
-  fg: '#27272a',      // zinc-800 — primary text
-  border: '#a1a1aa',  // zinc-400 — node borders (12% mix)
-  line: '#71717a',    // zinc-500 — edge lines (35% mix)
-  arrow: '#52525b',   // zinc-600 — arrowheads (60% mix)
-  corner: '#71717a',  // same as line
+  fg: '#27272a', // zinc-800 — primary text
+  border: '#a1a1aa', // zinc-400 — node borders (12% mix)
+  line: '#71717a', // zinc-500 — edge lines (35% mix)
+  arrow: '#52525b', // zinc-600 — arrowheads (60% mix)
+  corner: '#71717a', // same as line
   junction: '#a1a1aa', // same as border
 }
 
@@ -39,10 +39,13 @@ export const DEFAULT_ASCII_THEME: AsciiTheme = {
 
 /** Mix fg into bg at a given percentage (replicates CSS color-mix(in srgb)). */
 function mixColors(fg: string, bg: string, pct: number): string {
-  const f = parseHex(fg), b = parseHex(bg)
+  const f = parseHex(fg),
+    b = parseHex(bg)
   const mix = (a: number, z: number) => Math.round(a * (pct / 100) + z * (1 - pct / 100))
-  const r = mix(f.r, b.r), g = mix(f.g, b.g), bl = mix(f.b, b.b)
-  return '#' + [r, g, bl].map(c => c.toString(16).padStart(2, '0')).join('')
+  const r = mix(f.r, b.r),
+    g = mix(f.g, b.g),
+    bl = mix(f.b, b.b)
+  return `#${[r, g, bl].map(c => c.toString(16).padStart(2, '0')).join('')}`
 }
 
 /**
@@ -54,13 +57,13 @@ export function diagramColorsToAsciiTheme(colors: DiagramColors): AsciiTheme {
   const line = colors.line ?? mixColors(colors.fg, colors.bg, MIX.line)
   const border = colors.border ?? mixColors(colors.fg, colors.bg, MIX.nodeStroke)
   return {
-    fg:       colors.fg,
+    fg: colors.fg,
     border,
     line,
-    arrow:    colors.accent ?? mixColors(colors.fg, colors.bg, MIX.arrow),
-    accent:   colors.accent,
-    bg:       colors.bg,
-    corner:   line,
+    arrow: colors.accent ?? mixColors(colors.fg, colors.bg, MIX.arrow),
+    accent: colors.accent,
+    bg: colors.bg,
+    corner: line,
     junction: border,
   }
 }
@@ -83,7 +86,14 @@ export function diagramColorsToAsciiTheme(colors: DiagramColors): AsciiTheme {
 export function detectColorMode(): ColorMode {
   // Check if we're in a Node.js-like environment with process object
   // Use globalThis to safely check for process without TypeScript errors
-  const proc = (globalThis as { process?: { stdout?: { isTTY?: boolean }, env?: Record<string, string | undefined> } }).process
+  const proc = (
+    globalThis as {
+      process?: {
+        stdout?: { isTTY?: boolean }
+        env?: Record<string, string | undefined>
+      }
+    }
+  ).process
 
   if (proc) {
     // Check if stdout is a TTY (not piped/redirected)
@@ -193,7 +203,7 @@ function rgbTo256(r: number, g: number, b: number): number {
   const gi = toIndex(g)
   const bi = toIndex(b)
 
-  return 16 + (36 * ri) + (6 * gi) + bi
+  return 16 + 36 * ri + 6 * gi + bi
 }
 
 /**
@@ -223,14 +233,22 @@ function ansi16Fg(hex: string): string {
 
   // Determine base color based on dominant channel
   let code: number
-  if (r > 180 && g < 100 && b < 100) code = 31 // red
-  else if (g > 180 && r < 100 && b < 100) code = 32 // green
-  else if (r > 150 && g > 150 && b < 100) code = 33 // yellow
-  else if (b > 180 && r < 100 && g < 100) code = 34 // blue
-  else if (r > 150 && b > 150 && g < 100) code = 35 // magenta
-  else if (g > 150 && b > 150 && r < 100) code = 36 // cyan
-  else if (luma > 200) code = 37 // white
-  else if (luma < 50) code = 30 // black
+  if (r > 180 && g < 100 && b < 100)
+    code = 31 // red
+  else if (g > 180 && r < 100 && b < 100)
+    code = 32 // green
+  else if (r > 150 && g > 150 && b < 100)
+    code = 33 // yellow
+  else if (b > 180 && r < 100 && g < 100)
+    code = 34 // blue
+  else if (r > 150 && b > 150 && g < 100)
+    code = 35 // magenta
+  else if (g > 150 && b > 150 && r < 100)
+    code = 36 // cyan
+  else if (luma > 200)
+    code = 37 // white
+  else if (luma < 50)
+    code = 30 // black
   else code = 37 // default to white for grays
 
   return `${ESC}${code + bright}m`
@@ -259,13 +277,20 @@ function htmlSpan(hex: string, text: string): string {
  */
 function getRoleColor(role: CharRole, theme: AsciiTheme): string {
   switch (role) {
-    case 'text': return theme.fg
-    case 'border': return theme.border
-    case 'line': return theme.line
-    case 'arrow': return theme.arrow
-    case 'corner': return theme.corner ?? theme.line
-    case 'junction': return theme.junction ?? theme.border
-    default: return theme.fg
+    case 'text':
+      return theme.fg
+    case 'border':
+      return theme.border
+    case 'line':
+      return theme.line
+    case 'arrow':
+      return theme.arrow
+    case 'corner':
+      return theme.corner ?? theme.line
+    case 'junction':
+      return theme.junction ?? theme.border
+    default:
+      return theme.fg
   }
 }
 
@@ -278,10 +303,14 @@ export function getAnsiColor(role: CharRole, theme: AsciiTheme, mode: ColorMode)
   const hex = getRoleColor(role, theme)
 
   switch (mode) {
-    case 'truecolor': return truecolorFg(hex)
-    case 'ansi256': return ansi256Fg(hex)
-    case 'ansi16': return ansi16Fg(hex)
-    default: return ''
+    case 'truecolor':
+      return truecolorFg(hex)
+    case 'ansi256':
+      return ansi256Fg(hex)
+    case 'ansi16':
+      return ansi16Fg(hex)
+    default:
+      return ''
   }
 }
 
@@ -295,12 +324,7 @@ export function getAnsiReset(mode: ColorMode): string {
 /**
  * Wrap a character with ANSI color codes based on its role.
  */
-export function colorizeChar(
-  char: string,
-  role: CharRole | null,
-  theme: AsciiTheme,
-  mode: ColorMode,
-): string {
+export function colorizeChar(char: string, role: CharRole | null, theme: AsciiTheme, mode: ColorMode): string {
   if (mode === 'none' || role === null || char === ' ') {
     return char
   }
@@ -313,12 +337,7 @@ export function colorizeChar(
  * Colorize an entire line efficiently by grouping consecutive same-role characters.
  * This reduces the number of escape sequences (ANSI) or span tags (HTML) in the output.
  */
-export function colorizeLine(
-  chars: string[],
-  roles: (CharRole | null)[],
-  theme: AsciiTheme,
-  mode: ColorMode,
-): string {
+export function colorizeLine(chars: string[], roles: (CharRole | null)[], theme: AsciiTheme, mode: ColorMode): string {
   if (mode === 'none') {
     return chars.join('')
   }
@@ -384,11 +403,7 @@ export function colorizeLine(
  * Groups consecutive same-role characters into <span> tags with inline color styles.
  * Whitespace is emitted bare (no wrapping) to keep output compact.
  */
-function colorizeLineHtml(
-  chars: string[],
-  roles: (CharRole | null)[],
-  theme: AsciiTheme,
-): string {
+function colorizeLineHtml(chars: string[], roles: (CharRole | null)[], theme: AsciiTheme): string {
   let result = ''
   let currentRole: CharRole | null = null
   let buffer = ''
@@ -438,10 +453,17 @@ export function colorizeText(text: string, hex: string, mode: ColorMode): string
   if (mode === 'html') return htmlSpan(hex, text)
   let code: string
   switch (mode) {
-    case 'truecolor': code = truecolorFg(hex); break
-    case 'ansi256': code = ansi256Fg(hex); break
-    case 'ansi16': code = ansi16Fg(hex); break
-    default: return text
+    case 'truecolor':
+      code = truecolorFg(hex)
+      break
+    case 'ansi256':
+      code = ansi256Fg(hex)
+      break
+    case 'ansi16':
+      code = ansi16Fg(hex)
+      break
+    default:
+      return text
   }
   return `${code}${text}${RESET}`
 }

--- a/src/ascii/canvas.ts
+++ b/src/ascii/canvas.ts
@@ -6,8 +6,8 @@
 // canvas[x][y] gives the character at column x, row y.
 // ============================================================================
 
-import type { Canvas, DrawingCoord, RoleCanvas, CharRole, AsciiTheme, ColorMode } from './types.ts'
 import { colorizeLine, DEFAULT_ASCII_THEME } from './ansi.ts'
+import type { AsciiTheme, Canvas, CharRole, ColorMode, DrawingCoord, RoleCanvas } from './types.ts'
 
 /**
  * Create a blank canvas filled with spaces.
@@ -95,11 +95,7 @@ export function setRole(roleCanvas: RoleCanvas, x: number, y: number, role: Char
  * Merge role canvases — same logic as mergeCanvases but for roles.
  * Non-null roles in overlays overwrite null roles in base.
  */
-export function mergeRoleCanvases(
-  base: RoleCanvas,
-  offset: DrawingCoord,
-  ...overlays: RoleCanvas[]
-): RoleCanvas {
+export function mergeRoleCanvases(base: RoleCanvas, offset: DrawingCoord, ...overlays: RoleCanvas[]): RoleCanvas {
   let maxX = base.length - 1
   let maxY = (base[0]?.length ?? 1) - 1
 
@@ -170,9 +166,7 @@ export function increaseSize(canvas: Canvas, newX: number, newY: number): Canvas
 // ============================================================================
 
 /** All Unicode box-drawing characters that participate in junction merging. */
-const JUNCTION_CHARS = new Set([
-  '─', '│', '┌', '┐', '└', '┘', '├', '┤', '┬', '┴', '┼', '╴', '╵', '╶', '╷',
-])
+const JUNCTION_CHARS = new Set(['─', '│', '┌', '┐', '└', '┘', '├', '┤', '┬', '┴', '┼', '╴', '╵', '╶', '╷'])
 
 export function isJunctionChar(c: string): boolean {
   return JUNCTION_CHARS.has(c)
@@ -189,16 +183,116 @@ function isAlphanumeric(c: string): boolean {
  * E.g., '─' overlapping '│' becomes '┼'.
  */
 const JUNCTION_MAP: Record<string, Record<string, string>> = {
-  '─': { '│': '┼', '┌': '┬', '┐': '┬', '└': '┴', '┘': '┴', '├': '┼', '┤': '┼', '┬': '┬', '┴': '┴' },
-  '│': { '─': '┼', '┌': '├', '┐': '┤', '└': '├', '┘': '┤', '├': '├', '┤': '┤', '┬': '┼', '┴': '┼' },
-  '┌': { '─': '┬', '│': '├', '┐': '┬', '└': '├', '┘': '┼', '├': '├', '┤': '┼', '┬': '┬', '┴': '┼' },
-  '┐': { '─': '┬', '│': '┤', '┌': '┬', '└': '┼', '┘': '┤', '├': '┼', '┤': '┤', '┬': '┬', '┴': '┼' },
-  '└': { '─': '┴', '│': '├', '┌': '├', '┐': '┼', '┘': '┴', '├': '├', '┤': '┼', '┬': '┼', '┴': '┴' },
-  '┘': { '─': '┴', '│': '┤', '┌': '┼', '┐': '┤', '└': '┴', '├': '┼', '┤': '┤', '┬': '┼', '┴': '┴' },
-  '├': { '─': '┼', '│': '├', '┌': '├', '┐': '┼', '└': '├', '┘': '┼', '┤': '┼', '┬': '┼', '┴': '┼' },
-  '┤': { '─': '┼', '│': '┤', '┌': '┼', '┐': '┤', '└': '┼', '┘': '┤', '├': '┼', '┬': '┼', '┴': '┼' },
-  '┬': { '─': '┬', '│': '┼', '┌': '┬', '┐': '┬', '└': '┼', '┘': '┼', '├': '┼', '┤': '┼', '┴': '┼' },
-  '┴': { '─': '┴', '│': '┼', '┌': '┼', '┐': '┼', '└': '┴', '┘': '┴', '├': '┼', '┤': '┼', '┬': '┼' },
+  '─': {
+    '│': '┼',
+    '┌': '┬',
+    '┐': '┬',
+    '└': '┴',
+    '┘': '┴',
+    '├': '┼',
+    '┤': '┼',
+    '┬': '┬',
+    '┴': '┴',
+  },
+  '│': {
+    '─': '┼',
+    '┌': '├',
+    '┐': '┤',
+    '└': '├',
+    '┘': '┤',
+    '├': '├',
+    '┤': '┤',
+    '┬': '┼',
+    '┴': '┼',
+  },
+  '┌': {
+    '─': '┬',
+    '│': '├',
+    '┐': '┬',
+    '└': '├',
+    '┘': '┼',
+    '├': '├',
+    '┤': '┼',
+    '┬': '┬',
+    '┴': '┼',
+  },
+  '┐': {
+    '─': '┬',
+    '│': '┤',
+    '┌': '┬',
+    '└': '┼',
+    '┘': '┤',
+    '├': '┼',
+    '┤': '┤',
+    '┬': '┬',
+    '┴': '┼',
+  },
+  '└': {
+    '─': '┴',
+    '│': '├',
+    '┌': '├',
+    '┐': '┼',
+    '┘': '┴',
+    '├': '├',
+    '┤': '┼',
+    '┬': '┼',
+    '┴': '┴',
+  },
+  '┘': {
+    '─': '┴',
+    '│': '┤',
+    '┌': '┼',
+    '┐': '┤',
+    '└': '┴',
+    '├': '┼',
+    '┤': '┤',
+    '┬': '┼',
+    '┴': '┴',
+  },
+  '├': {
+    '─': '┼',
+    '│': '├',
+    '┌': '├',
+    '┐': '┼',
+    '└': '├',
+    '┘': '┼',
+    '┤': '┼',
+    '┬': '┼',
+    '┴': '┼',
+  },
+  '┤': {
+    '─': '┼',
+    '│': '┤',
+    '┌': '┼',
+    '┐': '┤',
+    '└': '┼',
+    '┘': '┤',
+    '├': '┼',
+    '┬': '┼',
+    '┴': '┼',
+  },
+  '┬': {
+    '─': '┬',
+    '│': '┼',
+    '┌': '┬',
+    '┐': '┬',
+    '└': '┼',
+    '┘': '┼',
+    '├': '┼',
+    '┤': '┼',
+    '┴': '┼',
+  },
+  '┴': {
+    '─': '┴',
+    '│': '┼',
+    '┌': '┼',
+    '┐': '┼',
+    '└': '┴',
+    '┘': '┴',
+    '├': '┼',
+    '┤': '┼',
+    '┬': '┼',
+  },
 }
 
 export function mergeJunctions(c1: string, c2: string): string {
@@ -214,12 +308,7 @@ export function mergeJunctions(c1: string, c2: string): string {
  * Non-space characters in overlays overwrite the base.
  * When both characters are Unicode junction chars, they're merged intelligently.
  */
-export function mergeCanvases(
-  base: Canvas,
-  offset: DrawingCoord,
-  useAscii: boolean,
-  ...overlays: Canvas[]
-): Canvas {
+export function mergeCanvases(base: Canvas, offset: DrawingCoord, useAscii: boolean, ...overlays: Canvas[]): Canvas {
   let [maxX, maxY] = getCanvasSize(base)
   for (const overlay of overlays) {
     const [oX, oY] = getCanvasSize(overlay)
@@ -326,18 +415,26 @@ export function canvasToString(canvas: Canvas, options?: CanvasToStringOptions):
  */
 const VERTICAL_FLIP_MAP: Record<string, string> = {
   // Unicode arrows
-  '▲': '▼', '▼': '▲',
-  '◤': '◣', '◣': '◤',
-  '◥': '◢', '◢': '◥',
+  '▲': '▼',
+  '▼': '▲',
+  '◤': '◣',
+  '◣': '◤',
+  '◥': '◢',
+  '◢': '◥',
   // ASCII arrows
-  '^': 'v', 'v': '^',
+  '^': 'v',
+  v: '^',
   // Unicode corners
-  '┌': '└', '└': '┌',
-  '┐': '┘', '┘': '┐',
+  '┌': '└',
+  '└': '┌',
+  '┐': '┘',
+  '┘': '┐',
   // Unicode junctions (T-pieces flip vertically)
-  '┬': '┴', '┴': '┬',
+  '┬': '┴',
+  '┴': '┬',
   // Box-start junctions (exit points from node boxes)
-  '╵': '╷', '╷': '╵',
+  '╵': '╷',
+  '╷': '╵',
 }
 
 /**
@@ -381,12 +478,7 @@ export function flipRoleCanvasVertically(roleCanvas: RoleCanvas): RoleCanvas {
  * By default, preserves existing non-space characters (labels don't overwrite each other).
  * Set forceOverwrite=true to always overwrite (for box content).
  */
-export function drawText(
-  canvas: Canvas,
-  start: DrawingCoord,
-  text: string,
-  forceOverwrite = false
-): void {
+export function drawText(canvas: Canvas, start: DrawingCoord, text: string, forceOverwrite = false): void {
   increaseSize(canvas, start.x + text.length, start.y)
   for (let i = 0; i < text.length; i++) {
     const x = start.x + i

--- a/src/ascii/class-diagram.ts
+++ b/src/ascii/class-diagram.ts
@@ -11,11 +11,11 @@
 // ============================================================================
 
 import { parseClassDiagram } from '../class/parser.ts'
-import type { ClassDiagram, ClassNode, ClassMember, ClassRelationship, RelationshipType } from '../class/types.ts'
-import type { Canvas, AsciiConfig, RoleCanvas, CharRole, AsciiTheme, ColorMode } from './types.ts'
-import { mkCanvas, mkRoleCanvas, canvasToString, increaseSize, increaseRoleCanvasSize, setRole } from './canvas.ts'
+import type { ClassMember, ClassNode, RelationshipType } from '../class/types.ts'
+import { canvasToString, increaseRoleCanvasSize, increaseSize, mkCanvas, mkRoleCanvas, setRole } from './canvas.ts'
 import { drawMultiBox } from './draw.ts'
 import { splitLines } from './multiline-utils.ts'
+import type { AsciiConfig, AsciiTheme, CharRole, ColorMode } from './types.ts'
 
 /** Classify a character from a box drawing as 'border' or 'text'. */
 function classifyBoxChar(ch: string): CharRole {
@@ -87,7 +87,7 @@ function getRelMarker(type: RelationshipType, markerAt: 'from' | 'to'): RelMarke
 function getMarkerShape(
   type: RelationshipType,
   useAscii: boolean,
-  direction?: 'up' | 'down' | 'left' | 'right'
+  direction?: 'up' | 'down' | 'left' | 'right',
 ): string {
   switch (type) {
     case 'inheritance':
@@ -149,14 +149,17 @@ interface PlacedClass {
  * Pipeline: parse → build boxes → level-based layout → draw boxes → draw relationships → string.
  */
 export function renderClassAscii(text: string, config: AsciiConfig, colorMode?: ColorMode, theme?: AsciiTheme): string {
-  const lines = text.split('\n').map(l => l.trim()).filter(l => l.length > 0 && !l.startsWith('%%'))
+  const lines = text
+    .split('\n')
+    .map(l => l.trim())
+    .filter(l => l.length > 0 && !l.startsWith('%%'))
   const diagram = parseClassDiagram(lines)
 
   if (diagram.classes.length === 0) return ''
 
   const useAscii = config.useAscii
-  const hGap = 4  // horizontal gap between class boxes
-  const vGap = 3  // vertical gap between levels (enough for relationship lines)
+  const hGap = 4 // horizontal gap between class boxes
+  const vGap = 3 // vertical gap between levels (enough for relationship lines)
 
   // --- Build box dimensions for each class ---
   const classSections = new Map<string, string[][]>()
@@ -194,7 +197,7 @@ export function renderClassAscii(text: string, config: AsciiConfig, colorMode?: 
   const classById = new Map<string, ClassNode>()
   for (const cls of diagram.classes) classById.set(cls.id, cls)
 
-  const parents = new Map<string, Set<string>>()  // child → set of parent IDs
+  const parents = new Map<string, Set<string>>() // child → set of parent IDs
   const children = new Map<string, Set<string>>() // parent → set of child IDs
 
   for (const rel of diagram.relationships) {
@@ -671,7 +674,7 @@ export function renderClassAscii(text: string, config: AsciiConfig, colorMode?: 
       const startY = labelY - halfHeight
 
       for (let lineIdx = 0; lineIdx < lines.length; lineIdx++) {
-        const paddedLine = ` ${lines[lineIdx]!} `  // Add space padding on both sides
+        const paddedLine = ` ${lines[lineIdx]!} ` // Add space padding on both sides
         // Calculate label start, but ensure it doesn't go negative
         const idealLabelStart = idealMidX - Math.floor(paddedLine.length / 2)
         const labelStart = Math.max(0, idealLabelStart)

--- a/src/ascii/converter.ts
+++ b/src/ascii/converter.ts
@@ -7,11 +7,9 @@
 // ============================================================================
 
 import type { MermaidGraph, MermaidSubgraph } from '../types.ts'
-import type {
-  AsciiGraph, AsciiNode, AsciiEdge, AsciiSubgraph, AsciiConfig,
-} from './types.ts'
-import { EMPTY_STYLE } from './types.ts'
 import { mkCanvas, mkRoleCanvas } from './canvas.ts'
+import type { AsciiConfig, AsciiEdge, AsciiGraph, AsciiNode, AsciiSubgraph } from './types.ts'
+import { EMPTY_STYLE } from './types.ts'
 
 /**
  * Convert a parsed MermaidGraph into an AsciiGraph ready for grid layout.
@@ -124,7 +122,7 @@ function convertSubgraph(
   // Normalize subgraph direction: BT→TD, RL→LR (same as root graph normalization)
   let normalizedDirection: 'LR' | 'TD' | undefined
   if (mSg.direction) {
-    normalizedDirection = (mSg.direction === 'LR' || mSg.direction === 'RL') ? 'LR' : 'TD'
+    normalizedDirection = mSg.direction === 'LR' || mSg.direction === 'RL' ? 'LR' : 'TD'
   }
 
   const sg: AsciiSubgraph = {
@@ -132,7 +130,10 @@ function convertSubgraph(
     nodes: [],
     parent,
     children: [],
-    minX: 0, minY: 0, maxX: 0, maxY: 0,
+    minX: 0,
+    minY: 0,
+    maxX: 0,
+    maxY: 0,
     direction: normalizedDirection,
   }
 
@@ -178,7 +179,7 @@ function deduplicateSubgraphNodes(
   mermaidSubgraphs: MermaidSubgraph[],
   asciiSubgraphs: AsciiSubgraph[],
   nodeMap: Map<string, AsciiNode>,
-  parsed: MermaidGraph,
+  _parsed: MermaidGraph,
 ): void {
   // Build a map from MermaidSubgraph to its corresponding AsciiSubgraph.
   // The ordering matches since we convert them in the same order.
@@ -224,7 +225,10 @@ function deduplicateSubgraphNodes(
       // Find this node's ID in the nodeMap
       let nodeId: string | undefined
       for (const [id, n] of nodeMap) {
-        if (n === node) { nodeId = id; break }
+        if (n === node) {
+          nodeId = id
+          break
+        }
       }
       if (!nodeId) return false
 
@@ -248,11 +252,7 @@ function isAncestorOrSelf(candidate: AsciiSubgraph, target: AsciiSubgraph): bool
 }
 
 /** Build a mapping from MermaidSubgraph → AsciiSubgraph (matching by position). */
-function buildSgMap(
-  mSgs: MermaidSubgraph[],
-  aSgs: AsciiSubgraph[],
-  result: Map<MermaidSubgraph, AsciiSubgraph>,
-): void {
+function buildSgMap(mSgs: MermaidSubgraph[], aSgs: AsciiSubgraph[], result: Map<MermaidSubgraph, AsciiSubgraph>): void {
   // The asciiSubgraphs array is flat (all subgraphs including nested ones),
   // while mermaidSubgraphs is hierarchical. We need to flatten the mermaid tree
   // in the same order the converter processes them (pre-order DFS).

--- a/src/ascii/draw.ts
+++ b/src/ascii/draw.ts
@@ -6,21 +6,38 @@
 // subgraphs, labels, and the top-level draw orchestrator.
 // ============================================================================
 
-import type {
-  Canvas, DrawingCoord, GridCoord, Direction,
-  AsciiGraph, AsciiNode, AsciiEdge, AsciiSubgraph, AsciiEdgeStyle, EdgeBundle,
-} from './types.ts'
-import {
-  Up, Down, Left, Right, UpperLeft, UpperRight, LowerLeft, LowerRight, Middle,
-  drawingCoordEquals,
-} from './types.ts'
-import { mkCanvas, copyCanvas, getCanvasSize, mergeCanvases, drawText, mkRoleCanvas, setRole, mergeRoleCanvases } from './canvas.ts'
-import type { RoleCanvas, CharRole } from './types.ts'
+import { copyCanvas, drawText, mergeCanvases, mkCanvas, setRole } from './canvas.ts'
 import { determineDirection, dirEquals } from './edge-routing.ts'
 import { gridToDrawingCoord, lineToDrawing } from './grid.ts'
 import { splitLines } from './multiline-utils.ts'
 import { getCorners } from './shapes/corners.ts'
 import { getShapeAttachmentPoint } from './shapes/index.ts'
+import type {
+  AsciiEdge,
+  AsciiEdgeStyle,
+  AsciiGraph,
+  AsciiNode,
+  AsciiSubgraph,
+  Canvas,
+  CharRole,
+  Direction,
+  DrawingCoord,
+  EdgeBundle,
+  GridCoord,
+  RoleCanvas,
+} from './types.ts'
+import {
+  Down,
+  drawingCoordEquals,
+  Left,
+  LowerLeft,
+  LowerRight,
+  Middle,
+  Right,
+  Up,
+  UpperLeft,
+  UpperRight,
+} from './types.ts'
 
 // ============================================================================
 // Node drawing — renders a node using shape-aware rendering
@@ -77,13 +94,11 @@ function drawBoxWithGridDimensions(node: AsciiNode, graph: AsciiGraph): Canvas {
 
   // State-end uses double border to differentiate from state-start
   const isDoubleBox = node.shape === 'state-end'
-  const hChar = useAscii ? (isDoubleBox ? '=' : '-') : (isDoubleBox ? '═' : '─')
-  const vChar = useAscii ? (isDoubleBox ? '‖' : '|') : (isDoubleBox ? '║' : '│')
+  const hChar = useAscii ? (isDoubleBox ? '=' : '-') : isDoubleBox ? '═' : '─'
+  const vChar = useAscii ? (isDoubleBox ? '‖' : '|') : isDoubleBox ? '║' : '│'
 
   // Double-box corners (for state-end)
-  const doubleCorners = useAscii
-    ? { tl: '#', tr: '#', bl: '#', br: '#' }
-    : { tl: '╔', tr: '╗', bl: '╚', br: '╝' }
+  const doubleCorners = useAscii ? { tl: '#', tr: '#', bl: '#', br: '#' } : { tl: '╔', tr: '╗', bl: '╚', br: '╝' }
   const effectiveCorners = isDoubleBox ? doubleCorners : corners
 
   // Draw box border with shape-specific corners
@@ -138,11 +153,7 @@ export function drawBox(node: AsciiNode, graph: AsciiGraph): Canvas {
  * @param padding - horizontal padding inside the box (default 1)
  * @returns A standalone Canvas containing the multi-section box
  */
-export function drawMultiBox(
-  sections: string[][],
-  useAscii: boolean,
-  padding: number = 1,
-): Canvas {
+export function drawMultiBox(sections: string[][], useAscii: boolean, padding: number = 1): Canvas {
   // Compute width: widest line across all sections + 2*padding + 2 border chars
   let maxTextWidth = 0
   for (const section of sections) {
@@ -377,10 +388,7 @@ export function drawLine(
  *
  * Supports bidirectional arrows via edge.hasArrowStart and edge.hasArrowEnd.
  */
-export function drawArrow(
-  graph: AsciiGraph,
-  edge: AsciiEdge,
-): [Canvas, Canvas, Canvas, Canvas, Canvas, Canvas] {
+export function drawArrow(graph: AsciiGraph, edge: AsciiEdge): [Canvas, Canvas, Canvas, Canvas, Canvas, Canvas] {
   if (edge.path.length === 0) {
     const empty = copyCanvas(graph.canvas)
     return [empty, empty, empty, empty, empty, empty]
@@ -393,11 +401,7 @@ export function drawArrow(
   // Draw end arrowhead only if hasArrowEnd is true (default behavior)
   let arrowHeadEndCanvas: Canvas
   if (edge.hasArrowEnd) {
-    arrowHeadEndCanvas = drawArrowHead(
-      graph,
-      linesDrawn[linesDrawn.length - 1]!,
-      lineDirs[lineDirs.length - 1]!,
-    )
+    arrowHeadEndCanvas = drawArrowHead(graph, linesDrawn[linesDrawn.length - 1]!, lineDirs[lineDirs.length - 1]!)
   } else {
     arrowHeadEndCanvas = copyCanvas(graph.canvas)
   }
@@ -485,12 +489,7 @@ function drawPath(
  * Only applies to Unicode mode (ASCII mode just uses the line characters).
  * Skips drawing for state pseudo-states which have their own visual borders.
  */
-function drawBoxStart(
-  graph: AsciiGraph,
-  path: GridCoord[],
-  firstLine: DrawingCoord[],
-  sourceShape: string,
-): Canvas {
+function drawBoxStart(graph: AsciiGraph, path: GridCoord[], firstLine: DrawingCoord[], sourceShape: string): Canvas {
   const canvas = copyCanvas(graph.canvas)
   if (graph.config.useAscii) return canvas
 
@@ -514,11 +513,7 @@ function drawBoxStart(
  * Draw the arrowhead at the end of an edge path.
  * Uses triangular Unicode symbols (▲▼◄►) or ASCII symbols (^v<>).
  */
-function drawArrowHead(
-  graph: AsciiGraph,
-  lastLine: DrawingCoord[],
-  fallbackDir: Direction,
-): Canvas {
+function drawArrowHead(graph: AsciiGraph, lastLine: DrawingCoord[], fallbackDir: Direction): Canvas {
   const canvas = copyCanvas(graph.canvas)
   if (lastLine.length === 0) return canvas
 
@@ -583,17 +578,25 @@ function drawCorners(graph: AsciiGraph, path: GridCoord[]): Canvas {
 
     let corner: string
     if (!graph.config.useAscii) {
-      if ((dirEquals(prevDir, Right) && dirEquals(nextDir, Down)) ||
-          (dirEquals(prevDir, Up) && dirEquals(nextDir, Left))) {
+      if (
+        (dirEquals(prevDir, Right) && dirEquals(nextDir, Down)) ||
+        (dirEquals(prevDir, Up) && dirEquals(nextDir, Left))
+      ) {
         corner = '┐'
-      } else if ((dirEquals(prevDir, Right) && dirEquals(nextDir, Up)) ||
-                 (dirEquals(prevDir, Down) && dirEquals(nextDir, Left))) {
+      } else if (
+        (dirEquals(prevDir, Right) && dirEquals(nextDir, Up)) ||
+        (dirEquals(prevDir, Down) && dirEquals(nextDir, Left))
+      ) {
         corner = '┘'
-      } else if ((dirEquals(prevDir, Left) && dirEquals(nextDir, Down)) ||
-                 (dirEquals(prevDir, Up) && dirEquals(nextDir, Right))) {
+      } else if (
+        (dirEquals(prevDir, Left) && dirEquals(nextDir, Down)) ||
+        (dirEquals(prevDir, Up) && dirEquals(nextDir, Right))
+      ) {
         corner = '┌'
-      } else if ((dirEquals(prevDir, Left) && dirEquals(nextDir, Up)) ||
-                 (dirEquals(prevDir, Down) && dirEquals(nextDir, Right))) {
+      } else if (
+        (dirEquals(prevDir, Left) && dirEquals(nextDir, Up)) ||
+        (dirEquals(prevDir, Down) && dirEquals(nextDir, Right))
+      ) {
         corner = '└'
       } else {
         corner = '+'
@@ -688,11 +691,7 @@ function drawTextOnLine(canvas: Canvas, line: DrawingCoord[], label: string, isU
  * drawn box (which may be wider/taller than the intrinsic shape dimensions
  * when sharing a column/row with a larger node).
  */
-function getNodeAttachmentPoint(
-  graph: AsciiGraph,
-  node: AsciiNode,
-  dir: Direction,
-): DrawingCoord {
+function getNodeAttachmentPoint(graph: AsciiGraph, node: AsciiNode, dir: Direction): DrawingCoord {
   const gc = node.gridCoord!
 
   // Calculate actual drawn dimensions from grid (matching drawBoxWithGridDimensions)
@@ -781,17 +780,25 @@ function drawBundledEdgeSegment(
 
     let corner: string
     if (!useAscii) {
-      if ((dirEquals(prevDir, Right) && dirEquals(nextDir, Down)) ||
-          (dirEquals(prevDir, Up) && dirEquals(nextDir, Left))) {
+      if (
+        (dirEquals(prevDir, Right) && dirEquals(nextDir, Down)) ||
+        (dirEquals(prevDir, Up) && dirEquals(nextDir, Left))
+      ) {
         corner = '┐'
-      } else if ((dirEquals(prevDir, Right) && dirEquals(nextDir, Up)) ||
-                 (dirEquals(prevDir, Down) && dirEquals(nextDir, Left))) {
+      } else if (
+        (dirEquals(prevDir, Right) && dirEquals(nextDir, Up)) ||
+        (dirEquals(prevDir, Down) && dirEquals(nextDir, Left))
+      ) {
         corner = '┘'
-      } else if ((dirEquals(prevDir, Left) && dirEquals(nextDir, Down)) ||
-                 (dirEquals(prevDir, Up) && dirEquals(nextDir, Right))) {
+      } else if (
+        (dirEquals(prevDir, Left) && dirEquals(nextDir, Down)) ||
+        (dirEquals(prevDir, Up) && dirEquals(nextDir, Right))
+      ) {
         corner = '┌'
-      } else if ((dirEquals(prevDir, Left) && dirEquals(nextDir, Up)) ||
-                 (dirEquals(prevDir, Down) && dirEquals(nextDir, Right))) {
+      } else if (
+        (dirEquals(prevDir, Left) && dirEquals(nextDir, Up)) ||
+        (dirEquals(prevDir, Down) && dirEquals(nextDir, Right))
+      ) {
         corner = '└'
       } else {
         corner = '+'
@@ -877,17 +884,25 @@ function drawBundleSharedPath(graph: AsciiGraph, bundle: EdgeBundle): [Canvas, C
 
     let corner: string
     if (!useAscii) {
-      if ((dirEquals(prevDir, Right) && dirEquals(nextDir, Down)) ||
-          (dirEquals(prevDir, Up) && dirEquals(nextDir, Left))) {
+      if (
+        (dirEquals(prevDir, Right) && dirEquals(nextDir, Down)) ||
+        (dirEquals(prevDir, Up) && dirEquals(nextDir, Left))
+      ) {
         corner = '┐'
-      } else if ((dirEquals(prevDir, Right) && dirEquals(nextDir, Up)) ||
-                 (dirEquals(prevDir, Down) && dirEquals(nextDir, Left))) {
+      } else if (
+        (dirEquals(prevDir, Right) && dirEquals(nextDir, Up)) ||
+        (dirEquals(prevDir, Down) && dirEquals(nextDir, Left))
+      ) {
         corner = '┘'
-      } else if ((dirEquals(prevDir, Left) && dirEquals(nextDir, Down)) ||
-                 (dirEquals(prevDir, Up) && dirEquals(nextDir, Right))) {
+      } else if (
+        (dirEquals(prevDir, Left) && dirEquals(nextDir, Down)) ||
+        (dirEquals(prevDir, Up) && dirEquals(nextDir, Right))
+      ) {
         corner = '┌'
-      } else if ((dirEquals(prevDir, Left) && dirEquals(nextDir, Up)) ||
-                 (dirEquals(prevDir, Down) && dirEquals(nextDir, Right))) {
+      } else if (
+        (dirEquals(prevDir, Left) && dirEquals(nextDir, Up)) ||
+        (dirEquals(prevDir, Down) && dirEquals(nextDir, Right))
+      ) {
         corner = '└'
       } else {
         corner = '+'
@@ -933,13 +948,13 @@ function drawBundleArrowhead(graph: AsciiGraph, bundle: EdgeBundle): Canvas {
     else if (dirEquals(dir, Down)) char = '▼'
     else if (dirEquals(dir, Left)) char = '◄'
     else if (dirEquals(dir, Right)) char = '►'
-    else char = '▼'  // default
+    else char = '▼' // default
   } else {
     if (dirEquals(dir, Up)) char = '^'
     else if (dirEquals(dir, Down)) char = 'v'
     else if (dirEquals(dir, Left)) char = '<'
     else if (dirEquals(dir, Right)) char = '>'
-    else char = 'v'  // default
+    else char = 'v' // default
   }
 
   canvas[dc.x]![dc.y] = char
@@ -975,13 +990,13 @@ function drawBundledEdgeArrowhead(graph: AsciiGraph, edge: AsciiEdge): Canvas {
     else if (dirEquals(dir, Down)) char = '▼'
     else if (dirEquals(dir, Left)) char = '◄'
     else if (dirEquals(dir, Right)) char = '►'
-    else char = '▼'  // default
+    else char = '▼' // default
   } else {
     if (dirEquals(dir, Up)) char = '^'
     else if (dirEquals(dir, Down)) char = 'v'
     else if (dirEquals(dir, Left)) char = '<'
     else if (dirEquals(dir, Right)) char = '>'
-    else char = 'v'  // default
+    else char = 'v' // default
   }
 
   canvas[dc.x]![dc.y] = char
@@ -1018,10 +1033,7 @@ function drawJunctionCharacter(graph: AsciiGraph, bundle: EdgeBundle): Canvas {
     // For fan-out: shared path goes FROM source TO junction (last index is junction)
     const junctionIdx = bundle.type === 'fan-in' ? 0 : bundle.sharedPath.length - 1
     const adjacentIdx = bundle.type === 'fan-in' ? 1 : bundle.sharedPath.length - 2
-    const sharedDir = determineDirection(
-      bundle.sharedPath[junctionIdx]!,
-      bundle.sharedPath[adjacentIdx]!
-    )
+    const sharedDir = determineDirection(bundle.sharedPath[junctionIdx]!, bundle.sharedPath[adjacentIdx]!)
     // This is the direction the shared path GOES from junction
     if (dirEquals(sharedDir, Down)) hasDown = true
     else if (dirEquals(sharedDir, Up)) hasUp = true
@@ -1034,20 +1046,14 @@ function drawJunctionCharacter(graph: AsciiGraph, bundle: EdgeBundle): Canvas {
     if (edge.pathToJunction && edge.pathToJunction.length >= 2) {
       // For fan-in: pathToJunction goes FROM source TO junction (last is junction)
       // For fan-out: pathToJunction goes FROM junction TO target (first is junction)
-      const junctionIdx = bundle.type === 'fan-in'
-        ? edge.pathToJunction.length - 1
-        : 0
-      const adjacentIdx = bundle.type === 'fan-in'
-        ? edge.pathToJunction.length - 2
-        : 1
+      const junctionIdx = bundle.type === 'fan-in' ? edge.pathToJunction.length - 1 : 0
+      const adjacentIdx = bundle.type === 'fan-in' ? edge.pathToJunction.length - 2 : 1
 
-      const arrivalDir = determineDirection(
-        edge.pathToJunction[adjacentIdx]!,
-        edge.pathToJunction[junctionIdx]!
-      )
+      const arrivalDir = determineDirection(edge.pathToJunction[adjacentIdx]!, edge.pathToJunction[junctionIdx]!)
       // This is the direction the edge ARRIVES at junction from
       // e.g., if arrivalDir is Right, the line comes FROM the left
-      if (dirEquals(arrivalDir, Down)) hasUp = true    // arrived going down = came from up
+      if (dirEquals(arrivalDir, Down))
+        hasUp = true // arrived going down = came from up
       else if (dirEquals(arrivalDir, Up)) hasDown = true
       else if (dirEquals(arrivalDir, Right)) hasLeft = true
       else if (dirEquals(arrivalDir, Left)) hasRight = true
@@ -1058,21 +1064,21 @@ function drawJunctionCharacter(graph: AsciiGraph, bundle: EdgeBundle): Canvas {
   let char: string
   if (!useAscii) {
     if (hasUp && hasDown && hasLeft && hasRight) {
-      char = '┼'  // cross - all 4 directions
+      char = '┼' // cross - all 4 directions
     } else if (hasDown && hasLeft && hasRight && !hasUp) {
-      char = '┬'  // T pointing down
+      char = '┬' // T pointing down
     } else if (hasUp && hasLeft && hasRight && !hasDown) {
-      char = '┴'  // T pointing up
+      char = '┴' // T pointing up
     } else if (hasUp && hasDown && hasRight && !hasLeft) {
-      char = '├'  // T pointing right
+      char = '├' // T pointing right
     } else if (hasUp && hasDown && hasLeft && !hasRight) {
-      char = '┤'  // T pointing left
+      char = '┤' // T pointing left
     } else if (hasLeft && hasRight) {
-      char = '─'  // horizontal only
+      char = '─' // horizontal only
     } else if (hasUp && hasDown) {
-      char = '│'  // vertical only
+      char = '│' // vertical only
     } else if (hasDown && hasRight) {
-      char = '┌'  // corner
+      char = '┌' // corner
     } else if (hasDown && hasLeft) {
       char = '┐'
     } else if (hasUp && hasRight) {
@@ -1080,7 +1086,7 @@ function drawJunctionCharacter(graph: AsciiGraph, bundle: EdgeBundle): Canvas {
     } else if (hasUp && hasLeft) {
       char = '┘'
     } else {
-      char = '┼'  // fallback
+      char = '┼' // fallback
     }
   } else {
     char = '+'
@@ -1128,7 +1134,7 @@ export function drawSubgraphBox(sg: AsciiSubgraph, graph: AsciiGraph): Canvas {
 }
 
 /** Draw a subgraph label centered in its header area. Supports multi-line labels. */
-export function drawSubgraphLabel(sg: AsciiSubgraph, graph: AsciiGraph): [Canvas, DrawingCoord] {
+export function drawSubgraphLabel(sg: AsciiSubgraph, _graph: AsciiGraph): [Canvas, DrawingCoord] {
   const width = sg.maxX - sg.minX
   const height = sg.maxY - sg.minY
   if (width <= 0 || height <= 0) return [mkCanvas(0, 0), { x: 0, y: 0 }]
@@ -1177,12 +1183,7 @@ function sortSubgraphsByDepth(subgraphs: AsciiSubgraph[]): AsciiSubgraph[] {
  * Fill roles for all non-space characters in a canvas region.
  * Used after drawing a layer to record what role those characters have.
  */
-function fillRolesFromCanvas(
-  roleCanvas: RoleCanvas,
-  canvas: Canvas,
-  offset: DrawingCoord,
-  role: CharRole,
-): void {
+function fillRolesFromCanvas(roleCanvas: RoleCanvas, canvas: Canvas, offset: DrawingCoord, role: CharRole): void {
   for (let x = 0; x < canvas.length; x++) {
     for (let y = 0; y < (canvas[0]?.length ?? 0); y++) {
       const char = canvas[x]?.[y]
@@ -1201,12 +1202,7 @@ function fillRolesFromCanvas(
 /**
  * Fill roles for multiple canvases with the same role.
  */
-function fillRolesFromCanvases(
-  roleCanvas: RoleCanvas,
-  canvases: Canvas[],
-  offset: DrawingCoord,
-  role: CharRole,
-): void {
+function fillRolesFromCanvases(roleCanvas: RoleCanvas, canvases: Canvas[], offset: DrawingCoord, role: CharRole): void {
   for (const canvas of canvases) {
     fillRolesFromCanvas(roleCanvas, canvas, offset, role)
   }
@@ -1216,11 +1212,7 @@ function fillRolesFromCanvases(
  * Special handling for node boxes: border chars get 'border' role, text gets 'text' role.
  * Detects text by checking if character is alphanumeric or common punctuation.
  */
-function fillRolesForNodeBox(
-  roleCanvas: RoleCanvas,
-  canvas: Canvas,
-  offset: DrawingCoord,
-): void {
+function fillRolesForNodeBox(roleCanvas: RoleCanvas, canvas: Canvas, offset: DrawingCoord): void {
   const isBorderChar = (c: string) => /^[┌┐└┘├┤┬┴┼│─╭╮╰╯+\-|.':]$/.test(c)
 
   for (let x = 0; x < canvas.length; x++) {

--- a/src/ascii/edge-bundling.ts
+++ b/src/ascii/edge-bundling.ts
@@ -11,12 +11,10 @@
 //   - routeBundledEdges(): Routes edges through junction points
 // ============================================================================
 
-import type {
-  AsciiGraph, AsciiNode, AsciiEdge, EdgeBundle, GridCoord, Direction,
-} from './types.ts'
-import { Up, Down, Left, Right, Middle, gridKey, gridCoordEquals } from './types.ts'
-import { getPath, mergePath } from './pathfinder.ts'
 import { getNodeSubgraph } from './grid.ts'
+import { getPath, mergePath } from './pathfinder.ts'
+import type { AsciiEdge, AsciiGraph, AsciiNode, EdgeBundle, GridCoord } from './types.ts'
+import { Down, Left, Middle, Right, Up } from './types.ts'
 
 // ============================================================================
 // Bundle analysis
@@ -175,10 +173,7 @@ function canBundle(edges: AsciiEdge[], graph: AsciiGraph): boolean {
  *   - In TD: below the source, horizontally centered between targets
  *   - In LR: right of the source, vertically centered between targets
  */
-export function calculateJunctionPoint(
-  graph: AsciiGraph,
-  bundle: EdgeBundle,
-): GridCoord {
+export function calculateJunctionPoint(graph: AsciiGraph, bundle: EdgeBundle): GridCoord {
   const dir = graph.config.graphDirection
   const sharedCoord = bundle.sharedNode.gridCoord!
   const otherCoords = bundle.otherNodes.map(n => n.gridCoord!)
@@ -188,15 +183,15 @@ export function calculateJunctionPoint(
     // Calculate center of sources
     const minX = Math.min(...otherCoords.map(c => c.x))
     const maxX = Math.max(...otherCoords.map(c => c.x))
-    const minY = Math.min(...otherCoords.map(c => c.y))
-    const maxY = Math.max(...otherCoords.map(c => c.y))
+    const _minY = Math.min(...otherCoords.map(c => c.y))
+    const _maxY = Math.max(...otherCoords.map(c => c.y))
 
     if (dir === 'TD') {
       // Junction above target, centered between sources
       // Place it one row above the target's entry point
       const junctionY = sharedCoord.y - 1
       // X is centered between sources, but clamped to shared node's X for alignment
-      const centerX = Math.floor((minX + maxX) / 2) + 1 // +1 for center of 3x3 block
+      const _centerX = Math.floor((minX + maxX) / 2) + 1 // +1 for center of 3x3 block
       const junctionX = sharedCoord.x + 1 // Align with target's center
 
       return { x: junctionX, y: junctionY }
@@ -209,10 +204,10 @@ export function calculateJunctionPoint(
     }
   } else {
     // fan-out: Junction is AFTER the shared source
-    const minX = Math.min(...otherCoords.map(c => c.x))
-    const maxX = Math.max(...otherCoords.map(c => c.x))
-    const minY = Math.min(...otherCoords.map(c => c.y))
-    const maxY = Math.max(...otherCoords.map(c => c.y))
+    const _minX = Math.min(...otherCoords.map(c => c.x))
+    const _maxX = Math.max(...otherCoords.map(c => c.x))
+    const _minY = Math.min(...otherCoords.map(c => c.y))
+    const _maxY = Math.max(...otherCoords.map(c => c.y))
 
     if (dir === 'TD') {
       // Junction below source, will then split to targets
@@ -260,9 +255,10 @@ export function routeBundledEdges(graph: AsciiGraph, bundle: EdgeBundle): void {
 
     // Route junction → target (shared path)
     const targetCoord = bundle.sharedNode.gridCoord!
-    const targetEntry = dir === 'TD'
-      ? { x: targetCoord.x + 1, y: targetCoord.y } // Top center of target
-      : { x: targetCoord.x, y: targetCoord.y + 1 } // Left center of target
+    const targetEntry =
+      dir === 'TD'
+        ? { x: targetCoord.x + 1, y: targetCoord.y } // Top center of target
+        : { x: targetCoord.x, y: targetCoord.y + 1 } // Left center of target
 
     const sharedPath = getPath(graph.grid, junction, targetEntry)
     bundle.sharedPath = sharedPath ? mergePath(sharedPath) : [junction, targetEntry]
@@ -270,9 +266,10 @@ export function routeBundledEdges(graph: AsciiGraph, bundle: EdgeBundle): void {
     // Route each source → junction
     for (const edge of bundle.edges) {
       const sourceCoord = edge.from.gridCoord!
-      const sourceExit = dir === 'TD'
-        ? { x: sourceCoord.x + 1, y: sourceCoord.y + 2 } // Bottom center of source
-        : { x: sourceCoord.x + 2, y: sourceCoord.y + 1 } // Right center of source
+      const sourceExit =
+        dir === 'TD'
+          ? { x: sourceCoord.x + 1, y: sourceCoord.y + 2 } // Bottom center of source
+          : { x: sourceCoord.x + 2, y: sourceCoord.y + 1 } // Right center of source
 
       const pathToJunction = getPath(graph.grid, sourceExit, junction)
       edge.pathToJunction = pathToJunction ? mergePath(pathToJunction) : [sourceExit, junction]
@@ -291,9 +288,10 @@ export function routeBundledEdges(graph: AsciiGraph, bundle: EdgeBundle): void {
 
     // Route source → junction (shared path)
     const sourceCoord = bundle.sharedNode.gridCoord!
-    const sourceExit = dir === 'TD'
-      ? { x: sourceCoord.x + 1, y: sourceCoord.y + 2 } // Bottom center of source
-      : { x: sourceCoord.x + 2, y: sourceCoord.y + 1 } // Right center of source
+    const sourceExit =
+      dir === 'TD'
+        ? { x: sourceCoord.x + 1, y: sourceCoord.y + 2 } // Bottom center of source
+        : { x: sourceCoord.x + 2, y: sourceCoord.y + 1 } // Right center of source
 
     const sharedPath = getPath(graph.grid, sourceExit, junction)
     bundle.sharedPath = sharedPath ? mergePath(sharedPath) : [sourceExit, junction]
@@ -301,9 +299,10 @@ export function routeBundledEdges(graph: AsciiGraph, bundle: EdgeBundle): void {
     // Route junction → each target
     for (const edge of bundle.edges) {
       const targetCoord = edge.to.gridCoord!
-      const targetEntry = dir === 'TD'
-        ? { x: targetCoord.x + 1, y: targetCoord.y } // Top center of target
-        : { x: targetCoord.x, y: targetCoord.y + 1 } // Left center of target
+      const targetEntry =
+        dir === 'TD'
+          ? { x: targetCoord.x + 1, y: targetCoord.y } // Top center of target
+          : { x: targetCoord.x, y: targetCoord.y + 1 } // Left center of target
 
       const pathToJunction = getPath(graph.grid, junction, targetEntry)
       edge.pathToJunction = pathToJunction ? mergePath(pathToJunction) : [junction, targetEntry]

--- a/src/ascii/edge-routing.ts
+++ b/src/ascii/edge-routing.ts
@@ -6,13 +6,21 @@
 // and dual-path comparison for optimal edge routing.
 // ============================================================================
 
-import type { GridCoord, Direction, AsciiEdge, AsciiGraph } from './types.ts'
-import {
-  Up, Down, Left, Right, UpperRight, UpperLeft, LowerRight, LowerLeft, Middle,
-  gridCoordDirection,
-} from './types.ts'
+import { getNodeSubgraph } from './grid.ts'
 import { getPath, mergePath } from './pathfinder.ts'
-import { getEffectiveDirection, getNodeSubgraph } from './grid.ts'
+import type { AsciiEdge, AsciiGraph, Direction, GridCoord } from './types.ts'
+import {
+  Down,
+  gridCoordDirection,
+  Left,
+  LowerLeft,
+  LowerRight,
+  Middle,
+  Right,
+  Up,
+  UpperLeft,
+  UpperRight,
+} from './types.ts'
 
 // ============================================================================
 // Direction utilities
@@ -81,57 +89,82 @@ export function determineStartAndEndDir(
   let alternativeDir: Direction
   let alternativeOppositeDir: Direction
 
-  const isBackwards = graphDirection === 'LR'
-    ? (dirEquals(d, Left) || dirEquals(d, UpperLeft) || dirEquals(d, LowerLeft))
-    : (dirEquals(d, Up) || dirEquals(d, UpperLeft) || dirEquals(d, UpperRight))
+  const isBackwards =
+    graphDirection === 'LR'
+      ? dirEquals(d, Left) || dirEquals(d, UpperLeft) || dirEquals(d, LowerLeft)
+      : dirEquals(d, Up) || dirEquals(d, UpperLeft) || dirEquals(d, UpperRight)
 
   if (dirEquals(d, LowerRight)) {
     if (graphDirection === 'LR') {
-      preferredDir = Down; preferredOppositeDir = Left
-      alternativeDir = Right; alternativeOppositeDir = Up
+      preferredDir = Down
+      preferredOppositeDir = Left
+      alternativeDir = Right
+      alternativeOppositeDir = Up
     } else {
-      preferredDir = Right; preferredOppositeDir = Up
-      alternativeDir = Down; alternativeOppositeDir = Left
+      preferredDir = Right
+      preferredOppositeDir = Up
+      alternativeDir = Down
+      alternativeOppositeDir = Left
     }
   } else if (dirEquals(d, UpperRight)) {
     if (graphDirection === 'LR') {
-      preferredDir = Up; preferredOppositeDir = Left
-      alternativeDir = Right; alternativeOppositeDir = Down
+      preferredDir = Up
+      preferredOppositeDir = Left
+      alternativeDir = Right
+      alternativeOppositeDir = Down
     } else {
-      preferredDir = Right; preferredOppositeDir = Down
-      alternativeDir = Up; alternativeOppositeDir = Left
+      preferredDir = Right
+      preferredOppositeDir = Down
+      alternativeDir = Up
+      alternativeOppositeDir = Left
     }
   } else if (dirEquals(d, LowerLeft)) {
     if (graphDirection === 'LR') {
-      preferredDir = Down; preferredOppositeDir = Down
-      alternativeDir = Left; alternativeOppositeDir = Up
+      preferredDir = Down
+      preferredOppositeDir = Down
+      alternativeDir = Left
+      alternativeOppositeDir = Up
     } else {
-      preferredDir = Left; preferredOppositeDir = Up
-      alternativeDir = Down; alternativeOppositeDir = Right
+      preferredDir = Left
+      preferredOppositeDir = Up
+      alternativeDir = Down
+      alternativeOppositeDir = Right
     }
   } else if (dirEquals(d, UpperLeft)) {
     if (graphDirection === 'LR') {
-      preferredDir = Down; preferredOppositeDir = Down
-      alternativeDir = Left; alternativeOppositeDir = Down
+      preferredDir = Down
+      preferredOppositeDir = Down
+      alternativeDir = Left
+      alternativeOppositeDir = Down
     } else {
-      preferredDir = Right; preferredOppositeDir = Right
-      alternativeDir = Up; alternativeOppositeDir = Right
+      preferredDir = Right
+      preferredOppositeDir = Right
+      alternativeDir = Up
+      alternativeOppositeDir = Right
     }
   } else if (isBackwards) {
     if (graphDirection === 'LR' && dirEquals(d, Left)) {
-      preferredDir = Down; preferredOppositeDir = Down
-      alternativeDir = Left; alternativeOppositeDir = Right
+      preferredDir = Down
+      preferredOppositeDir = Down
+      alternativeDir = Left
+      alternativeOppositeDir = Right
     } else if (graphDirection === 'TD' && dirEquals(d, Up)) {
-      preferredDir = Right; preferredOppositeDir = Right
-      alternativeDir = Up; alternativeOppositeDir = Down
+      preferredDir = Right
+      preferredOppositeDir = Right
+      alternativeDir = Up
+      alternativeOppositeDir = Down
     } else {
-      preferredDir = d; preferredOppositeDir = getOpposite(d)
-      alternativeDir = d; alternativeOppositeDir = getOpposite(d)
+      preferredDir = d
+      preferredOppositeDir = getOpposite(d)
+      alternativeDir = d
+      alternativeOppositeDir = getOpposite(d)
     }
   } else {
     // Default: go in the natural direction
-    preferredDir = d; preferredOppositeDir = getOpposite(d)
-    alternativeDir = d; alternativeOppositeDir = getOpposite(d)
+    preferredDir = d
+    preferredOppositeDir = getOpposite(d)
+    alternativeDir = d
+    alternativeOppositeDir = getOpposite(d)
   }
 
   return [preferredDir, preferredOppositeDir, alternativeDir, alternativeOppositeDir]
@@ -158,12 +191,13 @@ export function determinePath(graph: AsciiGraph, edge: AsciiEdge): void {
   // Otherwise, use the graph's direction (not source's effective direction)
   const sourceSg = getNodeSubgraph(graph, edge.from)
   const targetSg = getNodeSubgraph(graph, edge.to)
-  const effectiveDir = (sourceSg && sourceSg === targetSg && sourceSg.direction)
-    ? sourceSg.direction
-    : graph.config.graphDirection
+  const effectiveDir =
+    sourceSg && sourceSg === targetSg && sourceSg.direction ? sourceSg.direction : graph.config.graphDirection
 
-  const [preferredDir, preferredOppositeDir, alternativeDir, alternativeOppositeDir] =
-    determineStartAndEndDir(edge, effectiveDir)
+  const [preferredDir, preferredOppositeDir, alternativeDir, alternativeOppositeDir] = determineStartAndEndDir(
+    edge,
+    effectiveDir,
+  )
 
   // Try preferred path
   const prefFrom = gridCoordDirection(edge.from.gridCoord!, preferredDir)
@@ -229,7 +263,7 @@ export function determineLabelLine(graph: AsciiGraph, edge: AsciiEdge): void {
 
   const lenLabel = edge.text.length
   const pathLen = edge.path.length
-  const isVerticalFlow = graph.config.graphDirection === 'TD'
+  const _isVerticalFlow = graph.config.graphDirection === 'TD'
 
   // Collect all segments with their widths and orientation
   const segments: {

--- a/src/ascii/er-diagram.ts
+++ b/src/ascii/er-diagram.ts
@@ -10,11 +10,11 @@
 // ============================================================================
 
 import { parseErDiagram } from '../er/parser.ts'
-import type { ErDiagram, ErEntity, ErAttribute, Cardinality } from '../er/types.ts'
-import type { Canvas, AsciiConfig, RoleCanvas, CharRole, AsciiTheme, ColorMode } from './types.ts'
-import { mkCanvas, mkRoleCanvas, canvasToString, increaseSize, increaseRoleCanvasSize, setRole } from './canvas.ts'
+import type { Cardinality, ErAttribute, ErDiagram, ErEntity } from '../er/types.ts'
+import { canvasToString, increaseRoleCanvasSize, increaseSize, mkCanvas, mkRoleCanvas, setRole } from './canvas.ts'
 import { drawMultiBox } from './draw.ts'
 import { splitLines } from './multiline-utils.ts'
+import type { AsciiConfig, AsciiTheme, CharRole, ColorMode } from './types.ts'
 
 /** Classify a character from a box drawing as 'border' or 'text'. */
 function classifyBoxChar(ch: string): CharRole {
@@ -28,7 +28,7 @@ function classifyBoxChar(ch: string): CharRole {
 
 /** Format an attribute line: "PK type name" or "FK type name" etc. */
 function formatAttribute(attr: ErAttribute): string {
-  const keyStr = attr.keys.length > 0 ? attr.keys.join(',') + ' ' : '   '
+  const keyStr = attr.keys.length > 0 ? `${attr.keys.join(',')} ` : '   '
   return `${keyStr}${attr.type} ${attr.name}`
 }
 
@@ -62,18 +62,26 @@ function buildEntitySections(entity: ErEntity): string[][] {
 function getCrowsFootChars(card: Cardinality, useAscii: boolean, isRight = false): string {
   if (useAscii) {
     switch (card) {
-      case 'one':       return '|'
-      case 'zero-one':  return 'o|'
-      case 'many':      return isRight ? '<' : '>'
-      case 'zero-many': return isRight ? 'o<' : '>o'
+      case 'one':
+        return '|'
+      case 'zero-one':
+        return 'o|'
+      case 'many':
+        return isRight ? '<' : '>'
+      case 'zero-many':
+        return isRight ? 'o<' : '>o'
     }
   } else {
     // Use cleaner Unicode characters
     switch (card) {
-      case 'one':       return '│'
-      case 'zero-one':  return '○│'
-      case 'many':      return isRight ? '╟' : '╢'
-      case 'zero-many': return isRight ? '○╟' : '╢○'
+      case 'one':
+        return '│'
+      case 'zero-one':
+        return '○│'
+      case 'many':
+        return isRight ? '╟' : '╢'
+      case 'zero-many':
+        return isRight ? '○╟' : '╢○'
     }
   }
 }
@@ -157,15 +165,18 @@ function findConnectedComponents(diagram: ErDiagram): Set<string>[] {
  * Pipeline: parse → build boxes → component-aware layout → draw boxes → draw relationships → string.
  */
 export function renderErAscii(text: string, config: AsciiConfig, colorMode?: ColorMode, theme?: AsciiTheme): string {
-  const lines = text.split('\n').map(l => l.trim()).filter(l => l.length > 0 && !l.startsWith('%%'))
+  const lines = text
+    .split('\n')
+    .map(l => l.trim())
+    .filter(l => l.length > 0 && !l.startsWith('%%'))
   const diagram = parseErDiagram(lines)
 
   if (diagram.entities.length === 0) return ''
 
   const useAscii = config.useAscii
-  const hGap = 6  // horizontal gap between entity boxes
-  const vGap = 4  // vertical gap between rows (for relationship lines)
-  const componentGap = 6  // vertical gap between disconnected components
+  const hGap = 6 // horizontal gap between entity boxes
+  const vGap = 4 // vertical gap between rows (for relationship lines)
+  const componentGap = 6 // vertical gap between disconnected components
 
   // --- Build entity box dimensions ---
   const entitySections = new Map<string, string[][]>()
@@ -210,7 +221,7 @@ export function renderErAscii(text: string, config: AsciiConfig, colorMode?: Col
     let currentX = 0
     let maxRowH = 0
     let colCount = 0
-    const componentStartY = currentY
+    const _componentStartY = currentY
 
     for (const ent of componentEntities) {
       const w = entityBoxW.get(ent.id)!
@@ -308,9 +319,8 @@ export function renderErAscii(text: string, config: AsciiConfig, colorMode?: Col
     if (sameRow) {
       // Horizontal connection: right side of left entity → left side of right entity
       const [left, right] = e1CX < e2CX ? [e1, e2] : [e2, e1]
-      const [leftCard, rightCard] = e1CX < e2CX
-        ? [rel.cardinality1, rel.cardinality2]
-        : [rel.cardinality2, rel.cardinality1]
+      const [leftCard, rightCard] =
+        e1CX < e2CX ? [rel.cardinality1, rel.cardinality2] : [rel.cardinality2, rel.cardinality1]
 
       const startX = left.x + left.width
       const endX = right.x - 1
@@ -360,9 +370,8 @@ export function renderErAscii(text: string, config: AsciiConfig, colorMode?: Col
     } else {
       // Vertical connection: bottom of upper entity → top of lower entity
       const [upper, lower] = e1CY < e2CY ? [e1, e2] : [e2, e1]
-      const [upperCard, lowerCard] = e1CY < e2CY
-        ? [rel.cardinality1, rel.cardinality2]
-        : [rel.cardinality2, rel.cardinality1]
+      const [upperCard, lowerCard] =
+        e1CY < e2CY ? [rel.cardinality1, rel.cardinality2] : [rel.cardinality2, rel.cardinality1]
 
       const startY = upper.y + upper.height
       const endY = lower.y - 1

--- a/src/ascii/grid.ts
+++ b/src/ascii/grid.ts
@@ -7,16 +7,13 @@
 // and handles subgraph bounding boxes.
 // ============================================================================
 
-import type {
-  GridCoord, DrawingCoord, Direction, AsciiGraph, AsciiNode, AsciiSubgraph,
-} from './types.ts'
-import { gridKey } from './types.ts'
-import { mkCanvas, setCanvasSizeToGrid, setRoleCanvasSizeToGrid } from './canvas.ts'
-import { determinePath, determineLabelLine } from './edge-routing.ts'
-import { analyzeEdgeBundles, processBundles } from './edge-bundling.ts'
+import { setCanvasSizeToGrid, setRoleCanvasSizeToGrid } from './canvas.ts'
 import { drawBox } from './draw.ts'
-import { maxLineWidth, lineCount } from './multiline-utils.ts'
+import { analyzeEdgeBundles, processBundles } from './edge-bundling.ts'
+import { determineLabelLine, determinePath } from './edge-routing.ts'
 import { getShapeDimensions } from './shapes/index.ts'
+import type { AsciiGraph, AsciiNode, AsciiSubgraph, Direction, DrawingCoord, GridCoord } from './types.ts'
+import { gridKey } from './types.ts'
 
 // ============================================================================
 // Grid coordinate → drawing coordinate conversion
@@ -27,14 +24,8 @@ import { getShapeDimensions } from './shapes/index.ts'
  * Sums column widths up to the target column, and row heights up to the target row,
  * then centers within the cell.
  */
-export function gridToDrawingCoord(
-  graph: AsciiGraph,
-  c: GridCoord,
-  dir?: Direction,
-): DrawingCoord {
-  const target: GridCoord = dir
-    ? { x: c.x + dir.x, y: c.y + dir.y }
-    : c
+export function gridToDrawingCoord(graph: AsciiGraph, c: GridCoord, dir?: Direction): DrawingCoord {
+  const target: GridCoord = dir ? { x: c.x + dir.x, y: c.y + dir.y } : c
 
   let x = 0
   for (let col = 0; col < target.x; col++) {
@@ -414,14 +405,14 @@ export function createMapping(graph: AsciiGraph): void {
   // (e.g., `subgraph s; A-->B; end; X-->A` - A shouldn't be a root, X should).
   const rootNodes = initialRoots.filter(node => {
     const nodeSg = getNodeSubgraph(graph, node)
-    if (!nodeSg) return true  // external nodes: keep as roots
+    if (!nodeSg) return true // external nodes: keep as roots
 
     // Check if this subgraph node has incoming edges from outside its subgraph
     for (const edge of graph.edges) {
       if (edge.to === node) {
         const sourceSg = getNodeSubgraph(graph, edge.from)
         if (sourceSg !== nodeSg) {
-          return false  // has external incoming edge → not a root
+          return false // has external incoming edge → not a root
         }
       }
     }
@@ -453,9 +444,8 @@ export function createMapping(graph: AsciiGraph): void {
 
   // Place external root nodes
   for (const node of externalRootNodes) {
-    const requested: GridCoord = dir === 'LR'
-      ? { x: 0, y: highestPositionPerLevel[0]! }
-      : { x: highestPositionPerLevel[0]!, y: 0 }
+    const requested: GridCoord =
+      dir === 'LR' ? { x: 0, y: highestPositionPerLevel[0]! } : { x: highestPositionPerLevel[0]!, y: 0 }
     reserveSpotInGrid(graph, graph.nodes[node.index]!, requested)
     highestPositionPerLevel[0] = highestPositionPerLevel[0]! + 4
   }
@@ -464,9 +454,10 @@ export function createMapping(graph: AsciiGraph): void {
   if (shouldSeparate && subgraphRootNodes.length > 0) {
     const subgraphLevel = 4
     for (const node of subgraphRootNodes) {
-      const requested: GridCoord = dir === 'LR'
-        ? { x: subgraphLevel, y: highestPositionPerLevel[subgraphLevel]! }
-        : { x: highestPositionPerLevel[subgraphLevel]!, y: subgraphLevel }
+      const requested: GridCoord =
+        dir === 'LR'
+          ? { x: subgraphLevel, y: highestPositionPerLevel[subgraphLevel]! }
+          : { x: highestPositionPerLevel[subgraphLevel]!, y: subgraphLevel }
       reserveSpotInGrid(graph, graph.nodes[node.index]!, requested)
       highestPositionPerLevel[subgraphLevel] = highestPositionPerLevel[subgraphLevel]! + 4
     }
@@ -481,7 +472,7 @@ export function createMapping(graph: AsciiGraph): void {
   while (placedCount < graph.nodes.length) {
     const prevCount = placedCount
     for (const node of graph.nodes) {
-      if (node.gridCoord === null) continue  // skip unplaced nodes
+      if (node.gridCoord === null) continue // skip unplaced nodes
       const gc = node.gridCoord
 
       for (const child of getChildren(graph, node)) {
@@ -491,9 +482,8 @@ export function createMapping(graph: AsciiGraph): void {
         // Use subgraph direction only if both are in the same subgraph with override
         const parentSg = getNodeSubgraph(graph, node)
         const childSg = getNodeSubgraph(graph, child)
-        const edgeDir = (parentSg && parentSg === childSg && parentSg.direction)
-          ? parentSg.direction
-          : graph.config.graphDirection
+        const edgeDir =
+          parentSg && parentSg === childSg && parentSg.direction ? parentSg.direction : graph.config.graphDirection
 
         const childLevel = edgeDir === 'LR' ? gc.x + 4 : gc.y + 4
 
@@ -508,9 +498,8 @@ export function createMapping(graph: AsciiGraph): void {
           highestPosition = highestPositionPerLevel[childLevel]!
         }
 
-        const requested: GridCoord = edgeDir === 'LR'
-          ? { x: childLevel, y: highestPosition }
-          : { x: highestPosition, y: childLevel }
+        const requested: GridCoord =
+          edgeDir === 'LR' ? { x: childLevel, y: highestPosition } : { x: highestPosition, y: childLevel }
         reserveSpotInGrid(graph, graph.nodes[child.index]!, requested, edgeDir)
 
         // Only update level tracker for same-direction placements

--- a/src/ascii/index.ts
+++ b/src/ascii/index.ts
@@ -17,16 +17,16 @@
 // ============================================================================
 
 import { parseMermaid } from '../parser.ts'
-import { convertToAsciiGraph } from './converter.ts'
-import { createMapping } from './grid.ts'
-import { drawGraph } from './draw.ts'
+import { DEFAULT_ASCII_THEME, detectColorMode, diagramColorsToAsciiTheme } from './ansi.ts'
 import { canvasToString, flipCanvasVertically, flipRoleCanvasVertically } from './canvas.ts'
-import { renderSequenceAscii } from './sequence.ts'
 import { renderClassAscii } from './class-diagram.ts'
+import { convertToAsciiGraph } from './converter.ts'
+import { drawGraph } from './draw.ts'
 import { renderErAscii } from './er-diagram.ts'
-import { renderXYChartAscii } from './xychart.ts'
-import { detectColorMode, DEFAULT_ASCII_THEME, diagramColorsToAsciiTheme } from './ansi.ts'
+import { createMapping } from './grid.ts'
+import { renderSequenceAscii } from './sequence.ts'
 import type { AsciiConfig, AsciiTheme, ColorMode } from './types.ts'
+import { renderXYChartAscii } from './xychart.ts'
 
 // Re-export types for external use
 export type { AsciiTheme, ColorMode }
@@ -98,10 +98,7 @@ function detectDiagramType(text: string): 'flowchart' | 'sequence' | 'class' | '
  * // +---+     +---+     +---+
  * ```
  */
-export function renderMermaidASCII(
-  text: string,
-  options: AsciiRenderOptions = {},
-): string {
+export function renderMermaidASCII(text: string, options: AsciiRenderOptions = {}): string {
   const config: AsciiConfig = {
     useAscii: options.useAscii ?? false,
     paddingX: options.paddingX ?? 5,
@@ -111,9 +108,8 @@ export function renderMermaidASCII(
   }
 
   // Resolve color mode ('auto' or unset → detect environment, otherwise use specified mode)
-  const colorMode: ColorMode = options.colorMode === 'auto' || options.colorMode === undefined
-    ? detectColorMode()
-    : options.colorMode
+  const colorMode: ColorMode =
+    options.colorMode === 'auto' || options.colorMode === undefined ? detectColorMode() : options.colorMode
 
   // Merge user theme with defaults
   const theme: AsciiTheme = { ...DEFAULT_ASCII_THEME, ...options.theme }
@@ -132,8 +128,6 @@ export function renderMermaidASCII(
 
     case 'er':
       return renderErAscii(text, config, colorMode, theme)
-
-    case 'flowchart':
     default: {
       // Flowchart + state diagram pipeline (original)
       const parsed = parseMermaid(text)

--- a/src/ascii/multiline-utils.ts
+++ b/src/ascii/multiline-utils.ts
@@ -6,8 +6,8 @@
 // centered rendering across all diagram types.
 // ============================================================================
 
-import type { Canvas } from './types.ts'
 import { drawText } from './canvas.ts'
+import type { Canvas } from './types.ts'
 
 /**
  * Split a label into lines.
@@ -39,12 +39,7 @@ export function lineCount(label: string): number {
  * Expands vertically from the center point.
  * Each line is horizontally centered independently.
  */
-export function drawMultilineTextCentered(
-  canvas: Canvas,
-  label: string,
-  cx: number,
-  cy: number
-): void {
+export function drawMultilineTextCentered(canvas: Canvas, label: string, cx: number, cy: number): void {
   const lines = splitLines(label)
   const totalHeight = lines.length
   // Center vertically: start y positions lines evenly around cy
@@ -63,12 +58,7 @@ export function drawMultilineTextCentered(
  * Draw multi-line text left-aligned starting at (x, y).
  * Each subsequent line is placed one row below.
  */
-export function drawMultilineTextLeft(
-  canvas: Canvas,
-  label: string,
-  x: number,
-  y: number
-): void {
+export function drawMultilineTextLeft(canvas: Canvas, label: string, x: number, y: number): void {
   const lines = splitLines(label)
   for (let i = 0; i < lines.length; i++) {
     // Force overwrite for node labels (they take priority)

--- a/src/ascii/pathfinder.ts
+++ b/src/ascii/pathfinder.ts
@@ -6,8 +6,8 @@
 // paths between nodes on the grid. Prefers straight lines over zigzags.
 // ============================================================================
 
-import type { GridCoord, AsciiNode } from './types.ts'
-import { gridKey, gridCoordEquals } from './types.ts'
+import type { AsciiNode, GridCoord } from './types.ts'
+import { gridCoordEquals, gridKey } from './types.ts'
 
 // ============================================================================
 // Priority queue (min-heap) for A* open set
@@ -118,11 +118,7 @@ function isFreeInGrid(grid: Map<string, AsciiNode>, c: GridCoord): boolean {
  * Find a path from `from` to `to` on the grid using A*.
  * Returns the path as an array of GridCoords, or null if no path exists.
  */
-export function getPath(
-  grid: Map<string, AsciiNode>,
-  from: GridCoord,
-  to: GridCoord,
-): GridCoord[] | null {
+export function getPath(grid: Map<string, AsciiNode>, from: GridCoord, to: GridCoord): GridCoord[] | null {
   const pq = new MinHeap()
   pq.push({ coord: from, priority: 0 })
 

--- a/src/ascii/sequence.ts
+++ b/src/ascii/sequence.ts
@@ -10,13 +10,12 @@
 // ============================================================================
 
 import { parseSequenceDiagram } from '../sequence/parser.ts'
-import type { SequenceDiagram, Block } from '../sequence/types.ts'
-import type { Canvas, AsciiConfig, RoleCanvas, CharRole, AsciiTheme, ColorMode } from './types.ts'
-import { mkCanvas, mkRoleCanvas, canvasToString, increaseSize, increaseRoleCanvasSize, setRole } from './canvas.ts'
-import { splitLines, maxLineWidth, lineCount } from './multiline-utils.ts'
+import { canvasToString, increaseRoleCanvasSize, increaseSize, mkCanvas, mkRoleCanvas, setRole } from './canvas.ts'
+import { lineCount, maxLineWidth, splitLines } from './multiline-utils.ts'
+import type { AsciiConfig, AsciiTheme, CharRole, ColorMode } from './types.ts'
 
 /** Classify a box-drawing character as 'border' or 'text'. */
-function classifyBoxChar(ch: string): CharRole {
+function _classifyBoxChar(ch: string): CharRole {
   if (/^[┌┐└┘├┤┬┴┼│─╭╮╰╯+\-|]$/.test(ch)) return 'border'
   return 'text'
 }
@@ -26,8 +25,16 @@ function classifyBoxChar(ch: string): CharRole {
  *
  * Pipeline: parse → layout (columns + rows) → draw onto canvas → string.
  */
-export function renderSequenceAscii(text: string, config: AsciiConfig, colorMode?: ColorMode, theme?: AsciiTheme): string {
-  const lines = text.split('\n').map(l => l.trim()).filter(l => l.length > 0 && !l.startsWith('%%'))
+export function renderSequenceAscii(
+  text: string,
+  config: AsciiConfig,
+  colorMode?: ColorMode,
+  theme?: AsciiTheme,
+): string {
+  const lines = text
+    .split('\n')
+    .map(l => l.trim())
+    .filter(l => l.length > 0 && !l.startsWith('%%'))
   const diagram = parseSequenceDiagram(lines)
 
   if (diagram.actors.length === 0) return ''
@@ -49,7 +56,9 @@ export function renderSequenceAscii(text: string, config: AsciiConfig, colorMode
   // ---- LAYOUT: compute lifeline X positions ----
 
   const actorIdx = new Map<string, number>()
-  diagram.actors.forEach((a, i) => actorIdx.set(a.id, i))
+  diagram.actors.forEach((a, i) => {
+    actorIdx.set(a.id, i)
+  })
 
   const boxPad = 1
   // Use max line width for multi-line actor labels
@@ -81,11 +90,7 @@ export function renderSequenceAscii(text: string, config: AsciiConfig, colorMode
   // Compute lifeline x-positions (greedy left-to-right)
   const llX: number[] = [halfBox[0]!]
   for (let i = 1; i < diagram.actors.length; i++) {
-    const gap = Math.max(
-      halfBox[i - 1]! + halfBox[i]! + 2,
-      adjMaxWidth[i - 1]! + 2,
-      10,
-    )
+    const gap = Math.max(halfBox[i - 1]! + halfBox[i]! + 2, adjMaxWidth[i - 1]! + 2, 10)
     llX[i] = llX[i - 1]! + gap
   }
 
@@ -98,7 +103,13 @@ export function renderSequenceAscii(text: string, config: AsciiConfig, colorMode
   const blockStartY = new Map<number, number>()
   const blockEndY = new Map<number, number>()
   const divYMap = new Map<string, number>() // "blockIdx:divIdx" → y
-  const notePositions: Array<{ x: number; y: number; width: number; height: number; lines: string[] }> = []
+  const notePositions: Array<{
+    x: number
+    y: number
+    width: number
+    height: number
+    lines: string[]
+  }> = []
 
   let curY = actorBoxH // start right below header boxes
 
@@ -138,8 +149,8 @@ export function renderSequenceAscii(text: string, config: AsciiConfig, colorMode
     } else {
       // Normal message: label row(s) then arrow row
       msgLabelY[m] = curY
-      msgArrowY[m] = curY + msgLineCount  // arrow goes after all label lines
-      curY += msgLineCount + 1  // label lines + arrow row
+      msgArrowY[m] = curY + msgLineCount // arrow goes after all label lines
+      curY += msgLineCount + 1 // label lines + arrow row
     }
 
     // Notes after this message
@@ -169,7 +180,13 @@ export function renderSequenceAscii(text: string, config: AsciiConfig, colorMode
         }
         nx = Math.max(0, nx)
 
-        notePositions.push({ x: nx, y: curY, width: nWidth, height: nHeight, lines: nLines })
+        notePositions.push({
+          x: nx,
+          y: curY,
+          width: nWidth,
+          height: nHeight,
+          lines: nLines,
+        })
         curY += nHeight
       }
     }
@@ -223,7 +240,7 @@ export function renderSequenceAscii(text: string, config: AsciiConfig, colorMode
     const lines = splitLines(label)
     const maxW = maxLineWidth(label)
     const w = maxW + 2 * boxPad + 2
-    const h = lines.length + 2  // lines + top/bottom border
+    const h = lines.length + 2 // lines + top/bottom border
     const left = cx - Math.floor(w / 2)
 
     // Top border
@@ -310,7 +327,7 @@ export function renderSequenceAscii(text: string, config: AsciiConfig, colorMode
       }
 
       // Row 2: arrow-back + horizontal + bottom-right corner
-      const arrowChar = isFilled ? (useAscii ? '<' : '◀') : (useAscii ? '<' : '◁')
+      const arrowChar = isFilled ? (useAscii ? '<' : '◀') : useAscii ? '<' : '◁'
       setC(fromX, y0 + 2, arrowChar, 'arrow')
       for (let x = fromX + 1; x < fromX + loopW; x++) setC(x, y0 + 2, lineChar, 'line')
       setC(fromX + loopW, y0 + 2, useAscii ? '+' : '┘', 'corner')
@@ -338,11 +355,11 @@ export function renderSequenceAscii(text: string, config: AsciiConfig, colorMode
       if (leftToRight) {
         for (let x = fromX + 1; x < toX; x++) setC(x, arrowY, lineChar, 'line')
         // Arrowhead at destination
-        const ah = isFilled ? (useAscii ? '>' : '▶') : (useAscii ? '>' : '▷')
+        const ah = isFilled ? (useAscii ? '>' : '▶') : useAscii ? '>' : '▷'
         setC(toX, arrowY, ah, 'arrow')
       } else {
         for (let x = toX + 1; x < fromX; x++) setC(x, arrowY, lineChar, 'line')
-        const ah = isFilled ? (useAscii ? '<' : '◀') : (useAscii ? '<' : '◁')
+        const ah = isFilled ? (useAscii ? '<' : '◀') : useAscii ? '<' : '◁'
         setC(toX, arrowY, ah, 'arrow')
       }
     }

--- a/src/ascii/shapes/circle.ts
+++ b/src/ascii/shapes/circle.ts
@@ -2,9 +2,9 @@
 // Circle shape renderer — uses corner decorators instead of curves
 // ============================================================================
 
-import type { ShapeRenderer } from './types.ts'
-import { getBoxDimensions, renderBox, getBoxAttachmentPoint } from './rectangle.ts'
 import { getCorners } from './corners.ts'
+import { getBoxAttachmentPoint, getBoxDimensions, renderBox } from './rectangle.ts'
+import type { ShapeRenderer } from './types.ts'
 
 /**
  * Circle shape renderer.

--- a/src/ascii/shapes/diamond.ts
+++ b/src/ascii/shapes/diamond.ts
@@ -2,9 +2,9 @@
 // Diamond shape renderer — uses corner decorators instead of diagonals
 // ============================================================================
 
-import type { ShapeRenderer } from './types.ts'
-import { getBoxDimensions, renderBox, getBoxAttachmentPoint } from './rectangle.ts'
 import { getCorners } from './corners.ts'
+import { getBoxAttachmentPoint, getBoxDimensions, renderBox } from './rectangle.ts'
+import type { ShapeRenderer } from './types.ts'
 
 /**
  * Diamond shape renderer.

--- a/src/ascii/shapes/hexagon.ts
+++ b/src/ascii/shapes/hexagon.ts
@@ -2,9 +2,9 @@
 // Hexagon shape renderer — uses corner decorators instead of diagonals
 // ============================================================================
 
-import type { ShapeRenderer } from './types.ts'
-import { getBoxDimensions, renderBox, getBoxAttachmentPoint } from './rectangle.ts'
 import { getCorners } from './corners.ts'
+import { getBoxAttachmentPoint, getBoxDimensions, renderBox } from './rectangle.ts'
+import type { ShapeRenderer } from './types.ts'
 
 /**
  * Hexagon shape renderer.

--- a/src/ascii/shapes/index.ts
+++ b/src/ascii/shapes/index.ts
@@ -2,28 +2,27 @@
 // Shape registry — pluggable ASCII shape renderers
 // ============================================================================
 
-import type { AsciiNodeShape, Canvas, DrawingCoord, Direction } from '../types.ts'
-import type { ShapeRenderer, ShapeDimensions, ShapeRenderOptions, ShapeRegistry } from './types.ts'
-
+import type { AsciiNodeShape, Canvas, Direction, DrawingCoord } from '../types.ts'
+import { circleRenderer } from './circle.ts'
+import { diamondRenderer } from './diamond.ts'
+import { hexagonRenderer } from './hexagon.ts'
 // Import all shape renderers
 import { rectangleRenderer } from './rectangle.ts'
-import { diamondRenderer } from './diamond.ts'
-import { circleRenderer } from './circle.ts'
-import { stateStartRenderer, stateEndRenderer } from './state.ts'
 import { roundedRenderer } from './rounded.ts'
-import { stadiumRenderer } from './stadium.ts'
-import { hexagonRenderer } from './hexagon.ts'
 import {
-  subroutineRenderer,
-  doublecircleRenderer,
-  cylinderRenderer,
   asymmetricRenderer,
-  trapezoidRenderer,
+  cylinderRenderer,
+  doublecircleRenderer,
+  subroutineRenderer,
   trapezoidAltRenderer,
+  trapezoidRenderer,
 } from './special.ts'
+import { stadiumRenderer } from './stadium.ts'
+import { stateEndRenderer, stateStartRenderer } from './state.ts'
+import type { ShapeDimensions, ShapeRegistry, ShapeRenderer, ShapeRenderOptions } from './types.ts'
 
 // Re-export types
-export type { ShapeRenderer, ShapeDimensions, ShapeRenderOptions, ShapeRegistry }
+export type { ShapeDimensions, ShapeRegistry, ShapeRenderer, ShapeRenderOptions }
 
 /**
  * Global shape registry — maps shape types to their renderers.
@@ -64,11 +63,7 @@ export function getShapeRenderer(shape: AsciiNodeShape): ShapeRenderer {
  * Render a node shape to a canvas.
  * This is the main entry point for shape rendering.
  */
-export function renderShape(
-  shape: AsciiNodeShape,
-  label: string,
-  options: ShapeRenderOptions
-): Canvas {
+export function renderShape(shape: AsciiNodeShape, label: string, options: ShapeRenderOptions): Canvas {
   const renderer = getShapeRenderer(shape)
   const dimensions = renderer.getDimensions(label, options)
   return renderer.render(label, dimensions, options)
@@ -78,11 +73,7 @@ export function renderShape(
  * Get dimensions for a shape given a label.
  * Used during layout to determine node size.
  */
-export function getShapeDimensions(
-  shape: AsciiNodeShape,
-  label: string,
-  options: ShapeRenderOptions
-): ShapeDimensions {
+export function getShapeDimensions(shape: AsciiNodeShape, label: string, options: ShapeRenderOptions): ShapeDimensions {
   const renderer = getShapeRenderer(shape)
   return renderer.getDimensions(label, options)
 }
@@ -94,7 +85,7 @@ export function getShapeAttachmentPoint(
   shape: AsciiNodeShape,
   dir: Direction,
   dimensions: ShapeDimensions,
-  baseCoord: DrawingCoord
+  baseCoord: DrawingCoord,
 ): DrawingCoord {
   const renderer = getShapeRenderer(shape)
   return renderer.getAttachmentPoint(dir, dimensions, baseCoord)

--- a/src/ascii/shapes/rectangle.ts
+++ b/src/ascii/shapes/rectangle.ts
@@ -6,13 +6,13 @@
 // The renderBox() function accepts custom corner characters, allowing different
 // shapes to reuse the same rendering logic with different visual markers.
 
-import type { Canvas, DrawingCoord, Direction } from '../types.ts'
-import { Up, Down, Left, Right, UpperLeft, UpperRight, LowerLeft, LowerRight, Middle } from '../types.ts'
 import { mkCanvas } from '../canvas.ts'
-import { splitLines } from '../multiline-utils.ts'
-import type { ShapeRenderer, ShapeDimensions, ShapeRenderOptions } from './types.ts'
 import { dirEquals } from '../edge-routing.ts'
+import { splitLines } from '../multiline-utils.ts'
+import type { Canvas, Direction, DrawingCoord } from '../types.ts'
+import { Down, Left, LowerLeft, LowerRight, Right, Up, UpperLeft, UpperRight } from '../types.ts'
 import { type CornerChars, getCorners } from './corners.ts'
+import type { ShapeDimensions, ShapeRenderer, ShapeRenderOptions } from './types.ts'
 
 // ============================================================================
 // Shared dimension calculation
@@ -65,12 +65,7 @@ export function getBoxDimensions(label: string, options: ShapeRenderOptions): Sh
  * @param corners - Corner characters (tl, tr, bl, br)
  * @param useAscii - Whether to use ASCII or Unicode for lines
  */
-export function renderBox(
-  label: string,
-  dimensions: ShapeDimensions,
-  corners: CornerChars,
-  useAscii: boolean
-): Canvas {
+export function renderBox(label: string, dimensions: ShapeDimensions, corners: CornerChars, useAscii: boolean): Canvas {
   const { width, height } = dimensions
   const canvas = mkCanvas(width - 1, height - 1)
 
@@ -101,7 +96,7 @@ export function renderBox(
 
   // Center the multi-line label
   const lines = splitLines(label)
-  const w = width - 1  // Match original grid-based width calculation
+  const w = width - 1 // Match original grid-based width calculation
   const h = height - 1
   const centerY = Math.floor(h / 2)
   const startY = centerY - Math.floor((lines.length - 1) / 2)
@@ -132,7 +127,7 @@ export function renderBox(
 export function getBoxAttachmentPoint(
   dir: Direction,
   dimensions: ShapeDimensions,
-  baseCoord: DrawingCoord
+  baseCoord: DrawingCoord,
 ): DrawingCoord {
   const { width, height } = dimensions
   const centerX = baseCoord.x + Math.floor(width / 2)

--- a/src/ascii/shapes/rounded.ts
+++ b/src/ascii/shapes/rounded.ts
@@ -2,9 +2,9 @@
 // Rounded rectangle shape renderer — uses rounded corner decorators
 // ============================================================================
 
-import type { ShapeRenderer } from './types.ts'
-import { getBoxDimensions, renderBox, getBoxAttachmentPoint } from './rectangle.ts'
 import { getCorners } from './corners.ts'
+import { getBoxAttachmentPoint, getBoxDimensions, renderBox } from './rectangle.ts'
+import type { ShapeRenderer } from './types.ts'
 
 /**
  * Rounded rectangle shape renderer.

--- a/src/ascii/shapes/special.ts
+++ b/src/ascii/shapes/special.ts
@@ -5,14 +5,12 @@
 // Some shapes have unique internal structure (subroutine, cylinder) and keep
 // custom rendering. Others use the corner decorator pattern for simplicity.
 
-import type { Canvas, DrawingCoord, Direction } from '../types.ts'
-import { Up, Down, Left, Right } from '../types.ts'
 import { mkCanvas } from '../canvas.ts'
 import { splitLines } from '../multiline-utils.ts'
-import type { ShapeRenderer, ShapeDimensions, ShapeRenderOptions } from './types.ts'
-import { dirEquals } from '../edge-routing.ts'
-import { getBoxDimensions, renderBox, getBoxAttachmentPoint } from './rectangle.ts'
+import type { Canvas } from '../types.ts'
 import { getCorners } from './corners.ts'
+import { getBoxAttachmentPoint, getBoxDimensions, renderBox } from './rectangle.ts'
+import type { ShapeDimensions, ShapeRenderer, ShapeRenderOptions } from './types.ts'
 
 // ============================================================================
 // Subroutine — keeps custom double-border rendering
@@ -32,7 +30,7 @@ export const subroutineRenderer: ShapeRenderer = {
     const lineCount = lines.length
 
     const innerWidth = 2 * options.padding + maxLineWidth
-    const width = innerWidth + 4  // Double borders on each side
+    const width = innerWidth + 4 // Double borders on each side
     const innerHeight = lineCount + 2 * options.padding
     const height = innerHeight + 2
 
@@ -147,7 +145,7 @@ export const cylinderRenderer: ShapeRenderer = {
 
     const innerWidth = 2 * options.padding + maxLineWidth
     const width = innerWidth + 2
-    const innerHeight = lineCount + 2 * options.padding + 2  // Extra for curved top/bottom
+    const innerHeight = lineCount + 2 * options.padding + 2 // Extra for curved top/bottom
     const height = innerHeight + 2
 
     return {
@@ -193,9 +191,9 @@ export const cylinderRenderer: ShapeRenderer = {
     canvas[width - 1]![height - 2] = vChar
 
     // Bottom ellipse
-    canvas[0]![height - 1] = options.useAscii ? '\'' : '╰'
+    canvas[0]![height - 1] = options.useAscii ? "'" : '╰'
     for (let x = 1; x < width - 1; x++) canvas[x]![height - 1] = hChar
-    canvas[width - 1]![height - 1] = options.useAscii ? '\'' : '╯'
+    canvas[width - 1]![height - 1] = options.useAscii ? "'" : '╯'
 
     // Center the label
     const lines = splitLines(label)

--- a/src/ascii/shapes/stadium.ts
+++ b/src/ascii/shapes/stadium.ts
@@ -6,11 +6,11 @@
 // uses parentheses or rounded corners. This differs from other shapes that
 // use corner decorators with box lines.
 
-import type { Canvas, DrawingCoord, Direction } from '../types.ts'
 import { mkCanvas } from '../canvas.ts'
 import { splitLines } from '../multiline-utils.ts'
-import type { ShapeRenderer, ShapeDimensions, ShapeRenderOptions } from './types.ts'
+import type { Canvas } from '../types.ts'
 import { getBoxAttachmentPoint } from './rectangle.ts'
+import type { ShapeDimensions, ShapeRenderer, ShapeRenderOptions } from './types.ts'
 
 /**
  * Stadium (pill) shape renderer.
@@ -34,7 +34,7 @@ export const stadiumRenderer: ShapeRenderer = {
     const lineCount = lines.length
 
     const innerWidth = 2 * options.padding + maxLineWidth
-    const width = innerWidth + 4  // Extra for rounded ends
+    const width = innerWidth + 4 // Extra for rounded ends
     const innerHeight = lineCount + 2 * options.padding
     const height = Math.max(innerHeight + 2, 3)
 

--- a/src/ascii/shapes/state.ts
+++ b/src/ascii/shapes/state.ts
@@ -2,11 +2,11 @@
 // State pseudo-state renderers — UML start and end states
 // ============================================================================
 
-import type { Canvas, DrawingCoord, Direction } from '../types.ts'
-import { Up, Down, Left, Right, UpperLeft, UpperRight, LowerLeft, LowerRight } from '../types.ts'
 import { mkCanvas } from '../canvas.ts'
-import type { ShapeRenderer, ShapeDimensions, ShapeRenderOptions } from './types.ts'
 import { dirEquals } from '../edge-routing.ts'
+import type { Canvas, Direction, DrawingCoord } from '../types.ts'
+import { Down, Left, Right, Up } from '../types.ts'
+import type { ShapeDimensions, ShapeRenderer, ShapeRenderOptions } from './types.ts'
 
 /**
  * State start pseudo-state renderer — filled circle in rounded box.
@@ -40,7 +40,7 @@ export const stateStartRenderer: ShapeRenderer = {
     const { width, height } = dimensions
     const canvas = mkCanvas(width - 1, height - 1)
 
-    const centerX = Math.floor(width / 2)  // = 2
+    const centerX = Math.floor(width / 2) // = 2
 
     if (!options.useAscii) {
       // Unicode rounded box with filled circle: ╭───╮ │ ● │ ╰───╯
@@ -71,21 +71,17 @@ export const stateStartRenderer: ShapeRenderer = {
       canvas[centerX]![1] = '*'
       canvas[4]![1] = '|'
 
-      canvas[0]![2] = '\''
+      canvas[0]![2] = "'"
       canvas[1]![2] = '-'
       canvas[2]![2] = '-'
       canvas[3]![2] = '-'
-      canvas[4]![2] = '\''
+      canvas[4]![2] = "'"
     }
 
     return canvas
   },
 
-  getAttachmentPoint(
-    dir: Direction,
-    dimensions: ShapeDimensions,
-    baseCoord: DrawingCoord
-  ): DrawingCoord {
+  getAttachmentPoint(dir: Direction, dimensions: ShapeDimensions, baseCoord: DrawingCoord): DrawingCoord {
     const { width, height } = dimensions
     const centerX = baseCoord.x + Math.floor(width / 2)
     const centerY = baseCoord.y + Math.floor(height / 2)
@@ -132,7 +128,7 @@ export const stateEndRenderer: ShapeRenderer = {
     const { width, height } = dimensions
     const canvas = mkCanvas(width - 1, height - 1)
 
-    const centerX = Math.floor(width / 2)  // = 2
+    const centerX = Math.floor(width / 2) // = 2
 
     if (!options.useAscii) {
       // Unicode double-bordered box with bullseye: ╔═══╗ ║ ◎ ║ ╚═══╝
@@ -173,11 +169,7 @@ export const stateEndRenderer: ShapeRenderer = {
     return canvas
   },
 
-  getAttachmentPoint(
-    dir: Direction,
-    dimensions: ShapeDimensions,
-    baseCoord: DrawingCoord
-  ): DrawingCoord {
+  getAttachmentPoint(dir: Direction, dimensions: ShapeDimensions, baseCoord: DrawingCoord): DrawingCoord {
     const { width, height } = dimensions
     const centerX = baseCoord.x + Math.floor(width / 2)
     const centerY = baseCoord.y + Math.floor(height / 2)

--- a/src/ascii/shapes/types.ts
+++ b/src/ascii/shapes/types.ts
@@ -2,7 +2,7 @@
 // Shape renderer types — interface for pluggable ASCII shape renderers
 // ============================================================================
 
-import type { Canvas, DrawingCoord, Direction, AsciiNodeShape } from '../types.ts'
+import type { AsciiNodeShape, Canvas, Direction, DrawingCoord } from '../types.ts'
 
 /**
  * Dimensions calculated for a shape, used by layout and rendering.
@@ -50,21 +50,13 @@ export interface ShapeRenderer {
    * Render the shape to a canvas.
    * Returns a standalone canvas containing just the shape.
    */
-  render(
-    label: string,
-    dimensions: ShapeDimensions,
-    options: ShapeRenderOptions
-  ): Canvas
+  render(label: string, dimensions: ShapeDimensions, options: ShapeRenderOptions): Canvas
 
   /**
    * Get the edge attachment point for a given direction.
    * Used by edge routing to determine where edges connect.
    */
-  getAttachmentPoint(
-    dir: Direction,
-    dimensions: ShapeDimensions,
-    baseCoord: DrawingCoord
-  ): DrawingCoord
+  getAttachmentPoint(dir: Direction, dimensions: ShapeDimensions, baseCoord: DrawingCoord): DrawingCoord
 }
 
 /**

--- a/src/ascii/types.ts
+++ b/src/ascii/types.ts
@@ -43,19 +43,27 @@ export interface Direction {
   readonly y: number
 }
 
-export const Up: Direction         = { x: 1, y: 0 }
-export const Down: Direction       = { x: 1, y: 2 }
-export const Left: Direction       = { x: 0, y: 1 }
-export const Right: Direction      = { x: 2, y: 1 }
+export const Up: Direction = { x: 1, y: 0 }
+export const Down: Direction = { x: 1, y: 2 }
+export const Left: Direction = { x: 0, y: 1 }
+export const Right: Direction = { x: 2, y: 1 }
 export const UpperRight: Direction = { x: 2, y: 0 }
-export const UpperLeft: Direction  = { x: 0, y: 0 }
+export const UpperLeft: Direction = { x: 0, y: 0 }
 export const LowerRight: Direction = { x: 2, y: 2 }
-export const LowerLeft: Direction  = { x: 0, y: 2 }
-export const Middle: Direction     = { x: 1, y: 1 }
+export const LowerLeft: Direction = { x: 0, y: 2 }
+export const Middle: Direction = { x: 1, y: 1 }
 
 /** All named directions for iteration. */
 export const ALL_DIRECTIONS: readonly Direction[] = [
-  Up, Down, Left, Right, UpperRight, UpperLeft, LowerRight, LowerLeft, Middle,
+  Up,
+  Down,
+  Left,
+  Right,
+  UpperRight,
+  UpperLeft,
+  LowerRight,
+  LowerLeft,
+  Middle,
 ]
 
 /**
@@ -197,12 +205,12 @@ export const EMPTY_STYLE: AsciiStyleClass = { name: '', styles: {} }
  * Each role maps to a different color when colors are enabled.
  */
 export type CharRole =
-  | 'text'      // Node labels, edge labels
-  | 'border'    // Node box borders, subgraph borders
-  | 'line'      // Edge lines (paths between nodes)
-  | 'arrow'     // Arrowheads (▲▼◄► or ^v<>)
-  | 'corner'    // Corner characters at path bends
-  | 'junction'  // Junction characters (┬┴├┤ where edges meet boxes)
+  | 'text' // Node labels, edge labels
+  | 'border' // Node box borders, subgraph borders
+  | 'line' // Edge lines (paths between nodes)
+  | 'arrow' // Arrowheads (▲▼◄► or ^v<>)
+  | 'corner' // Corner characters at path bends
+  | 'junction' // Junction characters (┬┴├┤ where edges meet boxes)
 
 /**
  * Role canvas — parallel to Canvas, tracks the role of each character.
@@ -236,11 +244,11 @@ export interface AsciiTheme {
 
 /** Color mode for output. */
 export type ColorMode =
-  | 'none'      // No colors (plain text)
-  | 'ansi16'    // 16-color ANSI (basic terminals)
-  | 'ansi256'   // 256-color ANSI (xterm)
+  | 'none' // No colors (plain text)
+  | 'ansi16' // 16-color ANSI (basic terminals)
+  | 'ansi256' // 256-color ANSI (xterm)
   | 'truecolor' // 24-bit RGB (modern terminals)
-  | 'html'      // HTML <span> tags with inline color styles (browsers)
+  | 'html' // HTML <span> tags with inline color styles (browsers)
 
 // ============================================================================
 // Edge bundling types

--- a/src/ascii/validate.ts
+++ b/src/ascii/validate.ts
@@ -32,7 +32,7 @@ export interface DiagonalPosition {
  * @returns true if diagonal characters are present, false otherwise
  */
 export function hasDiagonalLines(asciiOutput: string): boolean {
-  return DIAGONAL_CHARS.all.some((char) => asciiOutput.includes(char))
+  return DIAGONAL_CHARS.all.some(char => asciiOutput.includes(char))
 }
 
 /**
@@ -108,13 +108,11 @@ export function assertNoDiagonals(asciiOutput: string, context?: string): void {
 
   const positions = findDiagonalLines(asciiOutput)
   const contextStr = context ? ` in "${context}"` : ''
-  const positionStr = positions
-    .map((p) => `  Line ${p.line}, Col ${p.col}: '${p.char}'`)
-    .join('\n')
+  const positionStr = positions.map(p => `  Line ${p.line}, Col ${p.col}: '${p.char}'`).join('\n')
 
   throw new Error(
     `Diagonal lines detected${contextStr}. ` +
       `Edges must use orthogonal Manhattan routing (90° bends only).\n` +
-      `Found ${positions.length} diagonal character(s):\n${positionStr}`
+      `Found ${positions.length} diagonal character(s):\n${positionStr}`,
   )
 }

--- a/src/ascii/xychart.ts
+++ b/src/ascii/xychart.ts
@@ -11,11 +11,11 @@
 // Multi-series support: each series gets a distinct color from a palette.
 // ============================================================================
 
+import { CHART_ACCENT_FALLBACK, getSeriesColor } from '../xychart/colors.ts'
 import { parseXYChart } from '../xychart/parser.ts'
 import type { XYChart } from '../xychart/types.ts'
-import type { AsciiConfig, AsciiTheme, ColorMode, CharRole, Canvas, RoleCanvas } from './types.ts'
 import { colorizeText } from './ansi.ts'
-import { getSeriesColor, CHART_ACCENT_FALLBACK } from '../xychart/colors.ts'
+import type { AsciiConfig, AsciiTheme, Canvas, CharRole, ColorMode, RoleCanvas } from './types.ts'
 
 // ============================================================================
 // Constants
@@ -33,10 +33,10 @@ const UNI = {
   xTick: '┬',
   bar: '█',
   grid: '·',
-  cornerTL: '╭',  // top-left: down+right
-  cornerTR: '╮',  // top-right: down+left
-  cornerBL: '╰',  // bottom-left: up+right
-  cornerBR: '╯',  // bottom-right: up+left
+  cornerTL: '╭', // top-left: down+right
+  cornerTR: '╮', // top-right: down+left
+  cornerBL: '╰', // bottom-left: up+right
+  cornerBR: '╯', // bottom-right: up+left
 } as const
 
 // ASCII fallback characters
@@ -71,13 +71,20 @@ function getSeriesColors(total: number, theme: AsciiTheme): string[] {
 /** Map a CharRole to its hex color from the theme (for canvasToString fallback). */
 function roleToHex(role: CharRole, theme: AsciiTheme): string {
   switch (role) {
-    case 'text': return theme.fg
-    case 'border': return theme.border
-    case 'line': return theme.line
-    case 'arrow': return theme.arrow
-    case 'corner': return theme.corner ?? theme.line
-    case 'junction': return theme.junction ?? theme.border
-    default: return theme.fg
+    case 'text':
+      return theme.fg
+    case 'border':
+      return theme.border
+    case 'line':
+      return theme.line
+    case 'arrow':
+      return theme.arrow
+    case 'corner':
+      return theme.corner ?? theme.line
+    case 'junction':
+      return theme.junction ?? theme.border
+    default:
+      return theme.fg
   }
 }
 
@@ -85,13 +92,11 @@ function roleToHex(role: CharRole, theme: AsciiTheme): string {
 // Public API
 // ============================================================================
 
-export function renderXYChartAscii(
-  text: string,
-  config: AsciiConfig,
-  colorMode: ColorMode,
-  theme: AsciiTheme,
-): string {
-  const lines = text.split('\n').map(l => l.trim()).filter(l => l.length > 0 && !l.startsWith('%%'))
+export function renderXYChartAscii(text: string, config: AsciiConfig, colorMode: ColorMode, theme: AsciiTheme): string {
+  const lines = text
+    .split('\n')
+    .map(l => l.trim())
+    .filter(l => l.length > 0 && !l.startsWith('%%'))
   const chart = parseXYChart(lines)
   const ch = config.useAscii ? ASC : UNI
 
@@ -105,12 +110,7 @@ export function renderXYChartAscii(
 // Vertical chart layout + rendering
 // ============================================================================
 
-function renderVertical(
-  chart: XYChart,
-  ch: typeof UNI | typeof ASC,
-  colorMode: ColorMode,
-  theme: AsciiTheme,
-): string {
+function renderVertical(chart: XYChart, ch: typeof UNI | typeof ASC, colorMode: ColorMode, theme: AsciiTheme): string {
   const dataCount = getDataCount(chart)
   if (dataCount === 0) return ''
 
@@ -257,7 +257,20 @@ function renderVertical(
   for (const entry of lineEntries) {
     if (entry.data.length === 0) continue
     const hexColor = seriesColors[entry.globalIdx]!
-    drawStaircaseLine(canvas, roles, entry.data, bandCenter, valueToRow, plotTop, plotH, plotLeft, bandW * dataCount, ch, hexColors, hexColor)
+    drawStaircaseLine(
+      canvas,
+      roles,
+      entry.data,
+      bandCenter,
+      valueToRow,
+      plotTop,
+      plotH,
+      plotLeft,
+      bandW * dataCount,
+      ch,
+      hexColors,
+      hexColor,
+    )
   }
 
   return canvasToString(canvas, roles, hexColors, colorMode, theme)
@@ -402,7 +415,20 @@ function renderHorizontal(
   for (const entry of lineEntries) {
     if (entry.data.length === 0) continue
     const hexColor = seriesColors[entry.globalIdx]!
-    drawHorizontalStaircaseLine(canvas, roles, entry.data, bandMid, valueToCol, plotTop, plotH, plotLeft, plotW, ch, hexColors, hexColor)
+    drawHorizontalStaircaseLine(
+      canvas,
+      roles,
+      entry.data,
+      bandMid,
+      valueToCol,
+      plotTop,
+      plotH,
+      plotLeft,
+      plotW,
+      ch,
+      hexColors,
+      hexColor,
+    )
   }
 
   return canvasToString(canvas, roles, hexColors, colorMode, theme)
@@ -630,14 +656,19 @@ function drawLegend(
   // Build legend items with global series indices
   type LegendItem = { symbol: string; label: string; globalIdx: number }
   const items: LegendItem[] = []
-  let barIdx = 0, lineIdx = 0
+  let barIdx = 0,
+    lineIdx = 0
   for (let si = 0; si < chart.series.length; si++) {
     const s = chart.series[si]!
     if (s.type === 'bar') {
       items.push({ symbol: ch.bar, label: `Bar ${barIdx + 1}`, globalIdx: si })
       barIdx++
     } else {
-      items.push({ symbol: ch.hLine, label: `Line ${lineIdx + 1}`, globalIdx: si })
+      items.push({
+        symbol: ch.hLine,
+        label: `Line ${lineIdx + 1}`,
+        globalIdx: si,
+      })
       lineIdx++
     }
   }
@@ -683,9 +714,14 @@ function createHexCanvas(width: number, height: number): HexCanvas {
 }
 
 function set(
-  canvas: Canvas, roles: RoleCanvas, row: number, col: number,
-  char: string, role: CharRole,
-  hexCanvas?: HexCanvas, hex?: string | null,
+  canvas: Canvas,
+  roles: RoleCanvas,
+  row: number,
+  col: number,
+  char: string,
+  role: CharRole,
+  hexCanvas?: HexCanvas,
+  hex?: string | null,
 ): void {
   if (col >= 0 && col < canvas.length && row >= 0 && row < canvas[0]!.length) {
     canvas[col]![row] = char
@@ -701,7 +737,14 @@ function get(canvas: Canvas, row: number, col: number): string {
   return ' '
 }
 
-function writeText(canvas: Canvas, roles: RoleCanvas, row: number, startCol: number, text: string, role: CharRole): void {
+function writeText(
+  canvas: Canvas,
+  roles: RoleCanvas,
+  row: number,
+  startCol: number,
+  text: string,
+  role: CharRole,
+): void {
   for (let i = 0; i < text.length; i++) {
     set(canvas, roles, row, startCol + i, text[i]!, role)
   }
@@ -738,13 +781,9 @@ function canvasToString(
     if (end < 0) {
       lines.push('')
     } else {
-      lines.push(colorizeRow(
-        chars.slice(0, end + 1),
-        rowRoles.slice(0, end + 1),
-        rowHex.slice(0, end + 1),
-        theme,
-        colorMode,
-      ))
+      lines.push(
+        colorizeRow(chars.slice(0, end + 1), rowRoles.slice(0, end + 1), rowHex.slice(0, end + 1), theme, colorMode),
+      )
     }
   }
 
@@ -841,7 +880,7 @@ function niceTickValues(min: number, max: number): number[] {
   if (range <= 0) return [min]
 
   const rawInterval = range / 6
-  const magnitude = Math.pow(10, Math.floor(Math.log10(rawInterval)))
+  const magnitude = 10 ** Math.floor(Math.log10(rawInterval))
   const residual = rawInterval / magnitude
   let niceInterval: number
   if (residual <= 1.5) niceInterval = magnitude

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -7,10 +7,10 @@
 // Bundled via `Bun.build({ target: 'browser' })` in index.ts.
 // ============================================================================
 
+import { diagramColorsToAsciiTheme, renderMermaidASCII } from './ascii/index.ts'
 import { renderMermaidSVGAsync } from './index.ts'
-import { renderMermaidASCII, diagramColorsToAsciiTheme } from './ascii/index.ts'
 import { THEMES } from './theme.ts'
-import { getSeriesColor, CHART_ACCENT_FALLBACK } from './xychart/colors.ts'
+import { CHART_ACCENT_FALLBACK, getSeriesColor } from './xychart/colors.ts'
 
 declare const window: unknown
 

--- a/src/class/layout.ts
+++ b/src/class/layout.ts
@@ -7,12 +7,19 @@
  *   3. Methods section
  */
 
-import type { ElkNode, ElkExtendedEdge } from 'elkjs'
-import type { ClassDiagram, ClassNode, ClassMember, PositionedClassDiagram, PositionedClassNode, PositionedClassRelationship } from './types.ts'
-import type { RenderOptions, Point } from '../types.ts'
-import { estimateTextWidth, estimateMonoTextWidth, FONT_SIZES, FONT_WEIGHTS } from '../styles.ts'
-import { measureMultilineText } from '../text-metrics.ts'
+import type { ElkExtendedEdge, ElkNode } from 'elkjs'
 import { elkLayoutSync } from '../elk-instance.ts'
+import { estimateMonoTextWidth, estimateTextWidth, FONT_SIZES, FONT_WEIGHTS } from '../styles.ts'
+import { measureMultilineText } from '../text-metrics.ts'
+import type { Point, RenderOptions } from '../types.ts'
+import type {
+  ClassDiagram,
+  ClassMember,
+  ClassNode,
+  PositionedClassDiagram,
+  PositionedClassNode,
+  PositionedClassRelationship,
+} from './types.ts'
 
 /** Layout constants for class diagrams */
 export const CLS = {
@@ -30,35 +37,51 @@ export const CLS = {
   layerSpacing: 60,
 } as const
 
-type ClassSizeMap = Map<string, { width: number; height: number; headerHeight: number; attrHeight: number; methodHeight: number }>
+type ClassSizeMap = Map<
+  string,
+  {
+    width: number
+    height: number
+    headerHeight: number
+    attrHeight: number
+    methodHeight: number
+  }
+>
 
 /** Build ELK graph and size map from a class diagram. */
 function buildClassElkGraph(
   diagram: ClassDiagram,
-  _options: RenderOptions
+  _options: RenderOptions,
 ): { elkGraph: ElkNode; classSizes: ClassSizeMap } {
   const classSizes: ClassSizeMap = new Map()
 
   for (const cls of diagram.classes) {
-    const headerHeight = cls.annotation
-      ? CLS.headerBaseHeight + CLS.annotationHeight
-      : CLS.headerBaseHeight
+    const headerHeight = cls.annotation ? CLS.headerBaseHeight + CLS.annotationHeight : CLS.headerBaseHeight
 
-    const attrHeight = cls.attributes.length > 0
-      ? cls.attributes.length * CLS.memberRowHeight + CLS.sectionPadY
-      : CLS.emptySectionHeight
+    const attrHeight =
+      cls.attributes.length > 0 ? cls.attributes.length * CLS.memberRowHeight + CLS.sectionPadY : CLS.emptySectionHeight
 
-    const methodHeight = cls.methods.length > 0
-      ? cls.methods.length * CLS.memberRowHeight + CLS.sectionPadY
-      : CLS.emptySectionHeight
+    const methodHeight =
+      cls.methods.length > 0 ? cls.methods.length * CLS.memberRowHeight + CLS.sectionPadY : CLS.emptySectionHeight
 
     const headerTextW = estimateTextWidth(cls.label, FONT_SIZES.nodeLabel, FONT_WEIGHTS.nodeLabel)
     const maxAttrW = maxMemberWidth(cls.attributes)
     const maxMethodW = maxMemberWidth(cls.methods)
-    const width = Math.max(CLS.minWidth, headerTextW + CLS.boxPadX * 2, maxAttrW + CLS.boxPadX * 2, maxMethodW + CLS.boxPadX * 2)
+    const width = Math.max(
+      CLS.minWidth,
+      headerTextW + CLS.boxPadX * 2,
+      maxAttrW + CLS.boxPadX * 2,
+      maxMethodW + CLS.boxPadX * 2,
+    )
     const height = headerHeight + attrHeight + methodHeight
 
-    classSizes.set(cls.id, { width, height, headerHeight, attrHeight, methodHeight })
+    classSizes.set(cls.id, {
+      width,
+      height,
+      headerHeight,
+      attrHeight,
+      methodHeight,
+    })
   }
 
   const elkGraph: ElkNode = {
@@ -78,15 +101,29 @@ function buildClassElkGraph(
 
   for (const cls of diagram.classes) {
     const size = classSizes.get(cls.id)!
-    elkGraph.children!.push({ id: cls.id, width: size.width, height: size.height })
+    elkGraph.children!.push({
+      id: cls.id,
+      width: size.width,
+      height: size.height,
+    })
   }
 
   for (let i = 0; i < diagram.relationships.length; i++) {
     const rel = diagram.relationships[i]!
-    const edge: ElkExtendedEdge = { id: `e${i}`, sources: [rel.from], targets: [rel.to] }
+    const edge: ElkExtendedEdge = {
+      id: `e${i}`,
+      sources: [rel.from],
+      targets: [rel.to],
+    }
     if (rel.label) {
       const metrics = measureMultilineText(rel.label, FONT_SIZES.edgeLabel, FONT_WEIGHTS.edgeLabel)
-      edge.labels = [{ text: rel.label, width: metrics.width + 8, height: metrics.height + 6 }]
+      edge.labels = [
+        {
+          text: rel.label,
+          width: metrics.width + 8,
+          height: metrics.height + 6,
+        },
+      ]
     }
     elkGraph.edges!.push(edge)
   }
@@ -95,11 +132,7 @@ function buildClassElkGraph(
 }
 
 /** Extract positioned classes and relationships from ELK result. */
-function extractClassLayout(
-  result: ElkNode,
-  diagram: ClassDiagram,
-  classSizes: ClassSizeMap
-): PositionedClassDiagram {
+function extractClassLayout(result: ElkNode, diagram: ClassDiagram, classSizes: ClassSizeMap): PositionedClassDiagram {
   const classLookup = new Map<string, ClassNode>()
   for (const cls of diagram.classes) classLookup.set(cls.id, cls)
 
@@ -177,10 +210,7 @@ function extractClassLayout(
 /**
  * Lay out a parsed class diagram using ELK.js (synchronous).
  */
-export function layoutClassDiagramSync(
-  diagram: ClassDiagram,
-  options: RenderOptions = {}
-): PositionedClassDiagram {
+export function layoutClassDiagramSync(diagram: ClassDiagram, options: RenderOptions = {}): PositionedClassDiagram {
   if (diagram.classes.length === 0) {
     return { width: 0, height: 0, classes: [], relationships: [] }
   }

--- a/src/class/parser.ts
+++ b/src/class/parser.ts
@@ -1,5 +1,12 @@
-import type { ClassDiagram, ClassNode, ClassRelationship, ClassMember, RelationshipType, ClassNamespace } from './types.ts'
 import { normalizeBrTags } from '../multiline-utils.ts'
+import type {
+  ClassDiagram,
+  ClassMember,
+  ClassNamespace,
+  ClassNode,
+  ClassRelationship,
+  RelationshipType,
+} from './types.ts'
 
 // ============================================================================
 // Class diagram parser
@@ -154,7 +161,6 @@ export function parseClassDiagram(lines: string[]): ClassDiagram {
       ensureClass(classMap, rel.from)
       ensureClass(classMap, rel.to)
       diagram.relationships.push(rel)
-      continue
     }
   }
 
@@ -243,7 +249,7 @@ function parseRelationship(line: string): ClassRelationship | null {
   // Relationship regex — handles all arrow types with optional cardinality and labels
   // Pattern: FROM ["card"] ARROW ["card"] TO [: label]
   const match = line.match(
-    /^(\S+?)\s+(?:"([^"]*?)"\s+)?(<\|--|<\|\.\.|\*--|o--|-->|--\*|--o|--\|>|\.\.>|\.\.\|>|<--|<\.\.?|--)\s+(?:"([^"]*?)"\s+)?(\S+?)(?:\s*:\s*(.+))?$/
+    /^(\S+?)\s+(?:"([^"]*?)"\s+)?(<\|--|<\|\.\.|\*--|o--|-->|--\*|--o|--\|>|\.\.>|\.\.\|>|<--|<\.\.?|--)\s+(?:"([^"]*?)"\s+)?(\S+?)(?:\s*:\s*(.+))?$/,
   )
   if (!match) return null
 
@@ -260,7 +266,15 @@ function parseRelationship(line: string): ClassRelationship | null {
   const parsed = parseArrow(arrow)
   if (!parsed) return null
 
-  return { from, to, type: parsed.type, markerAt: parsed.markerAt, label, fromCardinality, toCardinality }
+  return {
+    from,
+    to,
+    type: parsed.type,
+    markerAt: parsed.markerAt,
+    label,
+    fromCardinality,
+    toCardinality,
+  }
 }
 
 /**
@@ -272,19 +286,33 @@ function parseArrow(arrow: string): { type: RelationshipType; markerAt: 'from' |
   // Trim whitespace that might be captured by the regex
   const a = arrow.trim()
   switch (a) {
-    case '<|--': return { type: 'inheritance',  markerAt: 'from' }
-    case '--|>': return { type: 'inheritance',  markerAt: 'to' }
-    case '<|..': return { type: 'realization',  markerAt: 'from' }
-    case '..|>': return { type: 'realization',  markerAt: 'to' }
-    case '*--':  return { type: 'composition',  markerAt: 'from' }
-    case '--*':  return { type: 'composition',  markerAt: 'to' }
-    case 'o--':  return { type: 'aggregation',  markerAt: 'from' }
-    case '--o':  return { type: 'aggregation',  markerAt: 'to' }
-    case '-->':  return { type: 'association',  markerAt: 'to' }
-    case '<--':  return { type: 'association',  markerAt: 'from' }
-    case '..>':  return { type: 'dependency',   markerAt: 'to' }
-    case '<..':  return { type: 'dependency',   markerAt: 'from' }
-    case '--':   return { type: 'association',  markerAt: 'to' }
-    default:     return null
+    case '<|--':
+      return { type: 'inheritance', markerAt: 'from' }
+    case '--|>':
+      return { type: 'inheritance', markerAt: 'to' }
+    case '<|..':
+      return { type: 'realization', markerAt: 'from' }
+    case '..|>':
+      return { type: 'realization', markerAt: 'to' }
+    case '*--':
+      return { type: 'composition', markerAt: 'from' }
+    case '--*':
+      return { type: 'composition', markerAt: 'to' }
+    case 'o--':
+      return { type: 'aggregation', markerAt: 'from' }
+    case '--o':
+      return { type: 'aggregation', markerAt: 'to' }
+    case '-->':
+      return { type: 'association', markerAt: 'to' }
+    case '<--':
+      return { type: 'association', markerAt: 'from' }
+    case '..>':
+      return { type: 'dependency', markerAt: 'to' }
+    case '<..':
+      return { type: 'dependency', markerAt: 'from' }
+    case '--':
+      return { type: 'association', markerAt: 'to' }
+    default:
+      return null
   }
 }

--- a/src/class/renderer.ts
+++ b/src/class/renderer.ts
@@ -1,9 +1,15 @@
-import type { PositionedClassDiagram, PositionedClassNode, PositionedClassRelationship, ClassMember, RelationshipType } from './types.ts'
+import { escapeXml as escapeXmlUtil, renderMultilineText } from '../multiline-utils.ts'
+import { FONT_SIZES, FONT_WEIGHTS, STROKE_WIDTHS, TEXT_BASELINE_SHIFT } from '../styles.ts'
 import type { DiagramColors } from '../theme.ts'
-import { svgOpenTag, buildStyleBlock } from '../theme.ts'
-import { FONT_SIZES, FONT_WEIGHTS, STROKE_WIDTHS, estimateTextWidth, TEXT_BASELINE_SHIFT } from '../styles.ts'
+import { buildStyleBlock, svgOpenTag } from '../theme.ts'
 import { CLS } from './layout.ts'
-import { renderMultilineText, escapeXml as escapeXmlUtil } from '../multiline-utils.ts'
+import type {
+  ClassMember,
+  PositionedClassDiagram,
+  PositionedClassNode,
+  PositionedClassRelationship,
+  RelationshipType,
+} from './types.ts'
 
 // ============================================================================
 // Class diagram SVG renderer
@@ -36,7 +42,7 @@ export function renderClassSvg(
   diagram: PositionedClassDiagram,
   colors: DiagramColors,
   font: string = 'Inter',
-  transparent: boolean = false
+  transparent: boolean = false,
 ): string {
   const parts: string[] = []
 
@@ -112,7 +118,7 @@ function relationshipMarkerDefs(): string {
  * Wrapped in <g class="class-node"> with semantic data attributes.
  */
 function renderClassBox(cls: PositionedClassNode): string {
-  const { x, y, width, height, headerHeight, attrHeight, methodHeight } = cls
+  const { x, y, width, height, headerHeight, attrHeight } = cls
   const parts: string[] = []
 
   // Semantic wrapper with class metadata
@@ -121,19 +127,19 @@ function renderClassBox(cls: PositionedClassNode): string {
   // data-annotation: stereotype (interface, abstract, etc.)
   const annotationAttr = cls.annotation ? ` data-annotation="${escapeAttr(cls.annotation)}"` : ''
   parts.push(
-    `<g class="class-node" data-id="${escapeAttr(cls.id)}" data-label="${escapeAttr(cls.label)}"${annotationAttr}>`
+    `<g class="class-node" data-id="${escapeAttr(cls.id)}" data-label="${escapeAttr(cls.label)}"${annotationAttr}>`,
   )
 
   // Outer rectangle (full box)
   parts.push(
     `  <rect x="${x}" y="${y}" width="${width}" height="${height}" ` +
-    `rx="0" ry="0" fill="var(--_node-fill)" stroke="var(--_node-stroke)" stroke-width="${STROKE_WIDTHS.outerBox}" />`
+      `rx="0" ry="0" fill="var(--_node-fill)" stroke="var(--_node-stroke)" stroke-width="${STROKE_WIDTHS.outerBox}" />`,
   )
 
   // Header background
   parts.push(
     `  <rect x="${x}" y="${y}" width="${width}" height="${headerHeight}" ` +
-    `rx="0" ry="0" fill="var(--_group-hdr)" stroke="var(--_node-stroke)" stroke-width="${STROKE_WIDTHS.outerBox}" />`
+      `rx="0" ry="0" fill="var(--_group-hdr)" stroke="var(--_node-stroke)" stroke-width="${STROKE_WIDTHS.outerBox}" />`,
   )
 
   // Annotation (<<interface>>, <<abstract>>, etc.)
@@ -142,28 +148,29 @@ function renderClassBox(cls: PositionedClassNode): string {
     const annotY = y + 12
     parts.push(
       `  <text x="${x + width / 2}" y="${annotY}" text-anchor="middle" dy="${TEXT_BASELINE_SHIFT}" ` +
-      `font-size="${CLS_FONT.annotationSize}" font-weight="${CLS_FONT.annotationWeight}" ` +
-      `font-style="italic" fill="var(--_text-muted)">&lt;&lt;${escapeXml(cls.annotation)}&gt;&gt;</text>`
+        `font-size="${CLS_FONT.annotationSize}" font-weight="${CLS_FONT.annotationWeight}" ` +
+        `font-style="italic" fill="var(--_text-muted)">&lt;&lt;${escapeXml(cls.annotation)}&gt;&gt;</text>`,
     )
     nameY = y + headerHeight / 2 + 6
   }
 
   // Class name (supports multi-line via <br> tags)
   parts.push(
-    '  ' + renderMultilineText(
-      cls.label,
-      x + width / 2,
-      nameY,
-      FONT_SIZES.nodeLabel,
-      `text-anchor="middle" font-size="${FONT_SIZES.nodeLabel}" font-weight="700" fill="var(--_text)"`
-    )
+    '  ' +
+      renderMultilineText(
+        cls.label,
+        x + width / 2,
+        nameY,
+        FONT_SIZES.nodeLabel,
+        `text-anchor="middle" font-size="${FONT_SIZES.nodeLabel}" font-weight="700" fill="var(--_text)"`,
+      ),
   )
 
   // Divider line between header and attributes
   const attrTop = y + headerHeight
   parts.push(
     `  <line x1="${x}" y1="${attrTop}" x2="${x + width}" y2="${attrTop}" ` +
-    `stroke="var(--_node-stroke)" stroke-width="${STROKE_WIDTHS.innerBox}" />`
+      `stroke="var(--_node-stroke)" stroke-width="${STROKE_WIDTHS.innerBox}" />`,
   )
 
   // Attributes
@@ -171,21 +178,21 @@ function renderClassBox(cls: PositionedClassNode): string {
   for (let i = 0; i < cls.attributes.length; i++) {
     const member = cls.attributes[i]!
     const memberY = attrTop + 4 + i * memberRowH + memberRowH / 2
-    parts.push('  ' + renderMember(member, x + CLS.boxPadX, memberY))
+    parts.push(`  ${renderMember(member, x + CLS.boxPadX, memberY)}`)
   }
 
   // Divider line between attributes and methods
   const methodTop = attrTop + attrHeight
   parts.push(
     `  <line x1="${x}" y1="${methodTop}" x2="${x + width}" y2="${methodTop}" ` +
-    `stroke="var(--_node-stroke)" stroke-width="${STROKE_WIDTHS.innerBox}" />`
+      `stroke="var(--_node-stroke)" stroke-width="${STROKE_WIDTHS.innerBox}" />`,
   )
 
   // Methods
   for (let i = 0; i < cls.methods.length; i++) {
     const member = cls.methods[i]!
     const memberY = methodTop + 4 + i * memberRowH + memberRowH / 2
-    parts.push('  ' + renderMember(member, x + CLS.boxPadX, memberY))
+    parts.push(`  ${renderMember(member, x + CLS.boxPadX, memberY)}`)
   }
 
   parts.push('</g>')
@@ -213,9 +220,7 @@ function renderMember(member: ClassMember, x: number, y: number): string {
   }
 
   // Add parentheses for methods to distinguish from attributes, including parameters if present
-  const displayName = member.isMethod
-    ? `${member.name}(${member.params || ''})`
-    : member.name
+  const displayName = member.isMethod ? `${member.name}(${member.params || ''})` : member.name
   spans.push(`<tspan fill="var(--_text-sec)">${escapeXml(displayName)}</tspan>`)
 
   if (member.type) {
@@ -324,8 +329,13 @@ function renderRelationshipLabels(rel: PositionedClassRelationship): string {
   if (rel.label) {
     const pos = rel.labelPosition ?? midpoint(rel.points)
     parts.push(
-      renderMultilineText(rel.label, pos.x, pos.y - 8, FONT_SIZES.edgeLabel,
-        `font-size="${FONT_SIZES.edgeLabel}" text-anchor="middle" font-weight="${FONT_WEIGHTS.edgeLabel}" fill="var(--_text-muted)"`)
+      renderMultilineText(
+        rel.label,
+        pos.x,
+        pos.y - 8,
+        FONT_SIZES.edgeLabel,
+        `font-size="${FONT_SIZES.edgeLabel}" text-anchor="middle" font-weight="${FONT_WEIGHTS.edgeLabel}" fill="var(--_text-muted)"`,
+      ),
     )
   }
 
@@ -335,8 +345,13 @@ function renderRelationshipLabels(rel: PositionedClassRelationship): string {
     const next = rel.points[1]!
     const offset = cardinalityOffset(p, next)
     parts.push(
-      renderMultilineText(rel.fromCardinality, p.x + offset.x, p.y + offset.y, FONT_SIZES.edgeLabel,
-        `font-size="${FONT_SIZES.edgeLabel}" text-anchor="middle" font-weight="${FONT_WEIGHTS.edgeLabel}" fill="var(--_text-muted)"`)
+      renderMultilineText(
+        rel.fromCardinality,
+        p.x + offset.x,
+        p.y + offset.y,
+        FONT_SIZES.edgeLabel,
+        `font-size="${FONT_SIZES.edgeLabel}" text-anchor="middle" font-weight="${FONT_WEIGHTS.edgeLabel}" fill="var(--_text-muted)"`,
+      ),
     )
   }
 
@@ -346,8 +361,13 @@ function renderRelationshipLabels(rel: PositionedClassRelationship): string {
     const prev = rel.points[rel.points.length - 2]!
     const offset = cardinalityOffset(p, prev)
     parts.push(
-      renderMultilineText(rel.toCardinality, p.x + offset.x, p.y + offset.y, FONT_SIZES.edgeLabel,
-        `font-size="${FONT_SIZES.edgeLabel}" text-anchor="middle" font-weight="${FONT_WEIGHTS.edgeLabel}" fill="var(--_text-muted)"`)
+      renderMultilineText(
+        rel.toCardinality,
+        p.x + offset.x,
+        p.y + offset.y,
+        FONT_SIZES.edgeLabel,
+        `font-size="${FONT_SIZES.edgeLabel}" text-anchor="middle" font-weight="${FONT_WEIGHTS.edgeLabel}" fill="var(--_text-muted)"`,
+      ),
     )
   }
 
@@ -355,17 +375,17 @@ function renderRelationshipLabels(rel: PositionedClassRelationship): string {
 }
 
 /** Get the midpoint of a point array */
-function midpoint(points: Array<{ x: number; y: number }>): { x: number; y: number } {
+function midpoint(points: Array<{ x: number; y: number }>): {
+  x: number
+  y: number
+} {
   if (points.length === 0) return { x: 0, y: 0 }
   const mid = Math.floor(points.length / 2)
   return points[mid]!
 }
 
 /** Calculate offset for cardinality label perpendicular to edge direction */
-function cardinalityOffset(
-  from: { x: number; y: number },
-  to: { x: number; y: number }
-): { x: number; y: number } {
+function cardinalityOffset(from: { x: number; y: number }, to: { x: number; y: number }): { x: number; y: number } {
   const dx = to.x - from.x
   const dy = to.y - from.y
   // Place label perpendicular to the edge, 14px away
@@ -389,9 +409,5 @@ const escapeXml = escapeXmlUtil
  * Escapes quotes and ampersands to prevent attribute injection.
  */
 function escapeAttr(value: string): string {
-  return value
-    .replace(/&/g, '&amp;')
-    .replace(/"/g, '&quot;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
+  return value.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
 }

--- a/src/class/types.ts
+++ b/src/class/types.ts
@@ -45,12 +45,12 @@ export interface ClassMember {
 
 /** Relationship types following UML conventions */
 export type RelationshipType =
-  | 'inheritance'   // A <|-- B   (solid line, hollow triangle)
-  | 'composition'   // A *-- B    (solid line, filled diamond)
-  | 'aggregation'   // A o-- B    (solid line, hollow diamond)
-  | 'association'   // A --> B    (solid line, open arrow)
-  | 'dependency'    // A ..> B    (dashed line, open arrow)
-  | 'realization'   // A ..|> B   (dashed line, hollow triangle)
+  | 'inheritance' // A <|-- B   (solid line, hollow triangle)
+  | 'composition' // A *-- B    (solid line, filled diamond)
+  | 'aggregation' // A o-- B    (solid line, hollow diamond)
+  | 'association' // A --> B    (solid line, open arrow)
+  | 'dependency' // A ..> B    (dashed line, open arrow)
+  | 'realization' // A ..|> B   (dashed line, hollow triangle)
 
 export interface ClassRelationship {
   from: string

--- a/src/elk-instance.ts
+++ b/src/elk-instance.ts
@@ -14,7 +14,7 @@
  */
 
 import type { ElkNode } from 'elkjs'
-// @ts-ignore — static import of bundled ELK
+// @ts-expect-error — static import of bundled ELK
 import ELKBundled from 'elkjs/lib/elk.bundled.js'
 
 interface RawFakeWorker {
@@ -42,9 +42,12 @@ function ensureElk(): void {
   // Capture setTimeout(0) callbacks queued during ELK construction
   const pending: (() => void)[] = []
   const origSetTimeout = globalThis.setTimeout
-  // @ts-ignore — simplified signature for our interception
+  // @ts-expect-error — simplified signature for our interception
   globalThis.setTimeout = (fn: () => void, delay?: number) => {
-    if (delay === 0) { pending.push(fn); return 0 }
+    if (delay === 0) {
+      pending.push(fn)
+      return 0
+    }
     return origSetTimeout(fn, delay)
   }
 
@@ -67,7 +70,9 @@ function ensureElk(): void {
   globalThis.setTimeout = origSetTimeout
 
   // Flush captured callbacks synchronously — registers layout algorithms
-  pending.forEach(fn => fn())
+  pending.forEach(fn => {
+    fn()
+  })
 
   // Cache the raw FakeWorker for elkLayoutSync()
   rawWorker = (elk as unknown as { worker: { worker: RawFakeWorker } }).worker.worker
@@ -102,7 +107,9 @@ export function elkLayoutSync(graph: ElkNode): ElkNode {
   // Call dispatcher.saveDispatch directly — bypasses FakeWorker.postMessage's
   // setTimeout(0) wrapper. The dispatcher processes the layout synchronously
   // and calls rawWorker.onmessage with the result.
-  rawWorker!.dispatcher.saveDispatch({ data: { id: 0, cmd: 'layout', graph } as unknown as Record<string, unknown> })
+  rawWorker!.dispatcher.saveDispatch({
+    data: { id: 0, cmd: 'layout', graph } as unknown as Record<string, unknown>,
+  })
 
   // Restore original handler
   rawWorker!.onmessage = origOnmessage

--- a/src/er/layout.ts
+++ b/src/er/layout.ts
@@ -6,12 +6,12 @@
  *   2. Attribute rows (type, name, keys)
  */
 
-import type { ElkNode, ElkExtendedEdge } from 'elkjs'
-import type { ErDiagram, ErEntity, PositionedErDiagram, PositionedErEntity, PositionedErRelationship } from './types.ts'
-import type { RenderOptions, Point } from '../types.ts'
-import { estimateTextWidth, estimateMonoTextWidth, FONT_SIZES, FONT_WEIGHTS } from '../styles.ts'
-import { measureMultilineText } from '../text-metrics.ts'
+import type { ElkExtendedEdge, ElkNode } from 'elkjs'
 import { elkLayoutSync } from '../elk-instance.ts'
+import { estimateMonoTextWidth, estimateTextWidth, FONT_SIZES, FONT_WEIGHTS } from '../styles.ts'
+import { measureMultilineText } from '../text-metrics.ts'
+import type { Point, RenderOptions } from '../types.ts'
+import type { ErDiagram, ErEntity, PositionedErDiagram, PositionedErEntity, PositionedErRelationship } from './types.ts'
 
 /** Layout constants for ER diagrams */
 const ER = {
@@ -31,7 +31,7 @@ type EntitySizeMap = Map<string, { width: number; height: number }>
 /** Build ELK graph and size map from an ER diagram. */
 function buildErElkGraph(
   diagram: ErDiagram,
-  _options: RenderOptions
+  _options: RenderOptions,
 ): { elkGraph: ElkNode; entitySizes: EntitySizeMap } {
   const entitySizes: EntitySizeMap = new Map()
 
@@ -39,7 +39,7 @@ function buildErElkGraph(
     const headerTextW = estimateTextWidth(entity.label, FONT_SIZES.nodeLabel, FONT_WEIGHTS.nodeLabel)
     let maxAttrW = 0
     for (const attr of entity.attributes) {
-      const attrText = `${attr.type}  ${attr.name}${attr.keys.length > 0 ? '  ' + attr.keys.join(',') : ''}`
+      const attrText = `${attr.type}  ${attr.name}${attr.keys.length > 0 ? `  ${attr.keys.join(',')}` : ''}`
       const w = estimateMonoTextWidth(attrText, ER.attrFontSize)
       if (w > maxAttrW) maxAttrW = w
     }
@@ -65,15 +65,29 @@ function buildErElkGraph(
 
   for (const entity of diagram.entities) {
     const size = entitySizes.get(entity.id)!
-    elkGraph.children!.push({ id: entity.id, width: size.width, height: size.height })
+    elkGraph.children!.push({
+      id: entity.id,
+      width: size.width,
+      height: size.height,
+    })
   }
 
   for (let i = 0; i < diagram.relationships.length; i++) {
     const rel = diagram.relationships[i]!
     const metrics = measureMultilineText(rel.label, FONT_SIZES.edgeLabel, FONT_WEIGHTS.edgeLabel)
-    const edge: ElkExtendedEdge = { id: `e${i}`, sources: [rel.entity1], targets: [rel.entity2] }
+    const edge: ElkExtendedEdge = {
+      id: `e${i}`,
+      sources: [rel.entity1],
+      targets: [rel.entity2],
+    }
     if (rel.label) {
-      edge.labels = [{ text: rel.label, width: metrics.width + 8, height: metrics.height + 6 }]
+      edge.labels = [
+        {
+          text: rel.label,
+          width: metrics.width + 8,
+          height: metrics.height + 6,
+        },
+      ]
     }
     elkGraph.edges!.push(edge)
   }
@@ -82,11 +96,7 @@ function buildErElkGraph(
 }
 
 /** Extract positioned entities and relationships from ELK result. */
-function extractErLayout(
-  result: ElkNode,
-  diagram: ErDiagram,
-  entitySizes: EntitySizeMap
-): PositionedErDiagram {
+function extractErLayout(result: ElkNode, diagram: ErDiagram, entitySizes: EntitySizeMap): PositionedErDiagram {
   const entityLookup = new Map<string, ErEntity>()
   for (const entity of diagram.entities) entityLookup.set(entity.id, entity)
 
@@ -147,10 +157,7 @@ function extractErLayout(
 /**
  * Lay out a parsed ER diagram using ELK.js (synchronous).
  */
-export function layoutErDiagramSync(
-  diagram: ErDiagram,
-  options: RenderOptions = {}
-): PositionedErDiagram {
+export function layoutErDiagramSync(diagram: ErDiagram, options: RenderOptions = {}): PositionedErDiagram {
   if (diagram.entities.length === 0) {
     return { width: 0, height: 0, entities: [], relationships: [] }
   }

--- a/src/er/parser.ts
+++ b/src/er/parser.ts
@@ -1,5 +1,5 @@
-import type { ErDiagram, ErEntity, ErAttribute, ErRelationship, Cardinality } from './types.ts'
 import { normalizeBrTags } from '../multiline-utils.ts'
+import type { Cardinality, ErAttribute, ErDiagram, ErEntity, ErRelationship } from './types.ts'
 
 // ============================================================================
 // ER diagram parser
@@ -74,7 +74,6 @@ export function parseErDiagram(lines: string[]): ErDiagram {
       ensureEntity(entityMap, rel.entity1)
       ensureEntity(entityMap, rel.entity2)
       diagram.relationships.push(rel)
-      continue
     }
   }
 

--- a/src/er/renderer.ts
+++ b/src/er/renderer.ts
@@ -1,9 +1,15 @@
-import type { PositionedErDiagram, PositionedErEntity, PositionedErRelationship, ErAttribute, Cardinality } from './types.ts'
-import type { DiagramColors } from '../theme.ts'
-import { svgOpenTag, buildStyleBlock } from '../theme.ts'
-import { FONT_SIZES, FONT_WEIGHTS, STROKE_WIDTHS, estimateTextWidth, TEXT_BASELINE_SHIFT } from '../styles.ts'
-import { renderMultilineText, escapeXml as escapeXmlUtil } from '../multiline-utils.ts'
+import { escapeXml as escapeXmlUtil, renderMultilineText } from '../multiline-utils.ts'
+import { estimateTextWidth, FONT_SIZES, FONT_WEIGHTS, STROKE_WIDTHS, TEXT_BASELINE_SHIFT } from '../styles.ts'
 import { measureMultilineText } from '../text-metrics.ts'
+import type { DiagramColors } from '../theme.ts'
+import { buildStyleBlock, svgOpenTag } from '../theme.ts'
+import type {
+  Cardinality,
+  ErAttribute,
+  PositionedErDiagram,
+  PositionedErEntity,
+  PositionedErRelationship,
+} from './types.ts'
 
 // ============================================================================
 // ER diagram SVG renderer
@@ -36,7 +42,7 @@ export function renderErSvg(
   diagram: PositionedErDiagram,
   colors: DiagramColors,
   font: string = 'Inter',
-  transparent: boolean = false
+  transparent: boolean = false,
 ): string {
   const parts: string[] = []
 
@@ -83,52 +89,51 @@ function renderEntityBox(entity: PositionedErEntity): string {
   const parts: string[] = []
 
   // Semantic wrapper with entity metadata
-  parts.push(
-    `<g class="entity" data-id="${escapeAttr(id)}" data-label="${escapeAttr(label)}">`
-  )
+  parts.push(`<g class="entity" data-id="${escapeAttr(id)}" data-label="${escapeAttr(label)}">`)
 
   // Outer rectangle
   parts.push(
     `  <rect x="${x}" y="${y}" width="${width}" height="${height}" ` +
-    `rx="0" ry="0" fill="var(--_node-fill)" stroke="var(--_node-stroke)" stroke-width="${STROKE_WIDTHS.outerBox}" />`
+      `rx="0" ry="0" fill="var(--_node-fill)" stroke="var(--_node-stroke)" stroke-width="${STROKE_WIDTHS.outerBox}" />`,
   )
 
   // Header background
   parts.push(
     `  <rect x="${x}" y="${y}" width="${width}" height="${headerHeight}" ` +
-    `rx="0" ry="0" fill="var(--_group-hdr)" stroke="var(--_node-stroke)" stroke-width="${STROKE_WIDTHS.outerBox}" />`
+      `rx="0" ry="0" fill="var(--_group-hdr)" stroke="var(--_node-stroke)" stroke-width="${STROKE_WIDTHS.outerBox}" />`,
   )
 
   // Entity name (supports multi-line via <br> tags)
   parts.push(
-    '  ' + renderMultilineText(
-      label,
-      x + width / 2,
-      y + headerHeight / 2,
-      FONT_SIZES.nodeLabel,
-      `text-anchor="middle" font-size="${FONT_SIZES.nodeLabel}" font-weight="700" fill="var(--_text)"`
-    )
+    '  ' +
+      renderMultilineText(
+        label,
+        x + width / 2,
+        y + headerHeight / 2,
+        FONT_SIZES.nodeLabel,
+        `text-anchor="middle" font-size="${FONT_SIZES.nodeLabel}" font-weight="700" fill="var(--_text)"`,
+      ),
   )
 
   // Divider
   const attrTop = y + headerHeight
   parts.push(
     `  <line x1="${x}" y1="${attrTop}" x2="${x + width}" y2="${attrTop}" ` +
-    `stroke="var(--_node-stroke)" stroke-width="${STROKE_WIDTHS.innerBox}" />`
+      `stroke="var(--_node-stroke)" stroke-width="${STROKE_WIDTHS.innerBox}" />`,
   )
 
   // Attribute rows
   for (let i = 0; i < attributes.length; i++) {
     const attr = attributes[i]!
     const rowY = attrTop + i * rowHeight + rowHeight / 2
-    parts.push('  ' + renderAttribute(attr, x, rowY, width).replace(/\n/g, '\n  '))
+    parts.push(`  ${renderAttribute(attr, x, rowY, width).replace(/\n/g, '\n  ')}`)
   }
 
   // Empty row placeholder when no attributes
   if (attributes.length === 0) {
     parts.push(
       `  <text x="${x + width / 2}" y="${attrTop + rowHeight / 2}" text-anchor="middle" dy="${TEXT_BASELINE_SHIFT}" ` +
-      `font-size="${ER_FONT.attrSize}" fill="var(--_text-faint)" font-style="italic">(no attributes)</text>`
+        `font-size="${ER_FONT.attrSize}" fill="var(--_text-faint)" font-style="italic">(no attributes)</text>`,
     )
   }
 
@@ -162,11 +167,11 @@ function renderAttribute(attr: ErAttribute, boxX: number, y: number, boxWidth: n
     keyWidth = estimateTextWidth(keyText, ER_FONT.keySize, ER_FONT.keyWeight) + 8
     parts.push(
       `<rect x="${boxX + 6}" y="${y - 7}" width="${keyWidth}" height="14" rx="2" ry="2" ` +
-      `fill="var(--_key-badge)" />`
+        `fill="var(--_key-badge)" />`,
     )
     parts.push(
       `<text x="${boxX + 6 + keyWidth / 2}" y="${y}" text-anchor="middle" dy="${TEXT_BASELINE_SHIFT}" ` +
-      `font-size="${ER_FONT.keySize}" font-weight="${ER_FONT.keyWeight}" fill="var(--_text-sec)">${attr.keys.join(',')}</text>`
+        `font-size="${ER_FONT.keySize}" font-weight="${ER_FONT.keyWeight}" fill="var(--_text-sec)">${attr.keys.join(',')}</text>`,
     )
   }
 
@@ -174,16 +179,16 @@ function renderAttribute(attr: ErAttribute, boxX: number, y: number, boxWidth: n
   const typeX = boxX + 8 + (keyWidth > 0 ? keyWidth + 6 : 0)
   parts.push(
     `<text x="${typeX}" y="${y}" class="mono" dy="${TEXT_BASELINE_SHIFT}" ` +
-    `font-size="${ER_FONT.attrSize}" font-weight="${ER_FONT.attrWeight}">` +
-    `<tspan fill="var(--_text-muted)">${escapeXml(attr.type)}</tspan></text>`
+      `font-size="${ER_FONT.attrSize}" font-weight="${ER_FONT.attrWeight}">` +
+      `<tspan fill="var(--_text-muted)">${escapeXml(attr.type)}</tspan></text>`,
   )
 
   // Name (right-aligned, monospace with syntax highlighting)
   const nameX = boxX + boxWidth - 8
   parts.push(
     `<text x="${nameX}" y="${y}" class="mono" text-anchor="end" dy="${TEXT_BASELINE_SHIFT}" ` +
-    `font-size="${ER_FONT.attrSize}" font-weight="${ER_FONT.attrWeight}">` +
-    `<tspan fill="var(--_text-sec)">${escapeXml(attr.name)}</tspan></text>`
+      `font-size="${ER_FONT.attrSize}" font-weight="${ER_FONT.attrWeight}">` +
+      `<tspan fill="var(--_text-sec)">${escapeXml(attr.name)}</tspan></text>`,
   )
 
   // Close the group if we opened one
@@ -238,8 +243,13 @@ function renderRelationshipLabel(rel: PositionedErRelationship): string {
   return (
     `<rect x="${mid.x - bgW / 2}" y="${mid.y - bgH / 2}" width="${bgW}" height="${bgH}" rx="2" ry="2" ` +
     `fill="var(--bg)" stroke="var(--_inner-stroke)" stroke-width="0.5" />` +
-    `\n${renderMultilineText(rel.label, mid.x, mid.y, FONT_SIZES.edgeLabel,
-      `text-anchor="middle" font-size="${FONT_SIZES.edgeLabel}" font-weight="${FONT_WEIGHTS.edgeLabel}" fill="var(--_text-muted)"`)}`
+    `\n${renderMultilineText(
+      rel.label,
+      mid.x,
+      mid.y,
+      FONT_SIZES.edgeLabel,
+      `text-anchor="middle" font-size="${FONT_SIZES.edgeLabel}" font-weight="${FONT_WEIGHTS.edgeLabel}" fill="var(--_text-muted)"`,
+    )}`
   )
 }
 
@@ -276,7 +286,7 @@ function renderCardinality(rel: PositionedErRelationship): string {
 function renderCrowsFoot(
   point: { x: number; y: number },
   toward: { x: number; y: number },
-  cardinality: Cardinality
+  cardinality: Cardinality,
 ): string {
   const parts: string[] = []
   const sw = STROKE_WIDTHS.connector + 0.25
@@ -309,16 +319,16 @@ function renderCrowsFoot(
     const halfW = 6
     parts.push(
       `<line x1="${tipX + px * halfW}" y1="${tipY + py * halfW}" ` +
-      `x2="${tipX - px * halfW}" y2="${tipY - py * halfW}" ` +
-      `stroke="var(--_line)" stroke-width="${sw}" />`
+        `x2="${tipX - px * halfW}" y2="${tipY - py * halfW}" ` +
+        `stroke="var(--_line)" stroke-width="${sw}" />`,
     )
     // Second line slightly back for "exactly one" emphasis
     const line2X = tipX - ux * 4
     const line2Y = tipY - uy * 4
     parts.push(
       `<line x1="${line2X + px * halfW}" y1="${line2Y + py * halfW}" ` +
-      `x2="${line2X - px * halfW}" y2="${line2Y - py * halfW}" ` +
-      `stroke="var(--_line)" stroke-width="${sw}" />`
+        `x2="${line2X - px * halfW}" y2="${line2Y - py * halfW}" ` +
+        `stroke="var(--_line)" stroke-width="${sw}" />`,
     )
   }
 
@@ -332,20 +342,20 @@ function renderCrowsFoot(
     parts.push(
       // Top fan line
       `<line x1="${cfTipX + px * fanW}" y1="${cfTipY + py * fanW}" ` +
-      `x2="${backX}" y2="${backY}" ` +
-      `stroke="var(--_line)" stroke-width="${sw}" />`
+        `x2="${backX}" y2="${backY}" ` +
+        `stroke="var(--_line)" stroke-width="${sw}" />`,
     )
     parts.push(
       // Center line
       `<line x1="${cfTipX}" y1="${cfTipY}" ` +
-      `x2="${backX}" y2="${backY}" ` +
-      `stroke="var(--_line)" stroke-width="${sw}" />`
+        `x2="${backX}" y2="${backY}" ` +
+        `stroke="var(--_line)" stroke-width="${sw}" />`,
     )
     parts.push(
       // Bottom fan line
       `<line x1="${cfTipX - px * fanW}" y1="${cfTipY - py * fanW}" ` +
-      `x2="${backX}" y2="${backY}" ` +
-      `stroke="var(--_line)" stroke-width="${sw}" />`
+        `x2="${backX}" y2="${backY}" ` +
+        `stroke="var(--_line)" stroke-width="${sw}" />`,
     )
   }
 
@@ -356,7 +366,7 @@ function renderCrowsFoot(
     const circleY = point.y - uy * circleOffset
     parts.push(
       `<circle cx="${circleX}" cy="${circleY}" r="4" ` +
-      `fill="var(--bg)" stroke="var(--_line)" stroke-width="${sw}" />`
+        `fill="var(--bg)" stroke="var(--_line)" stroke-width="${sw}" />`,
     )
   }
 
@@ -367,7 +377,10 @@ function renderCrowsFoot(
  *  Walks along each segment, finds the point at exactly 50% of total path length.
  *  This ensures the label sits ON the path even for orthogonal routes with bends,
  *  unlike the naive first/last geometric center which floats in space for L/Z shapes. */
-function midpoint(points: Array<{ x: number; y: number }>): { x: number; y: number } {
+function midpoint(points: Array<{ x: number; y: number }>): {
+  x: number
+  y: number
+} {
   if (points.length === 0) return { x: 0, y: 0 }
   if (points.length === 1) return points[0]!
 
@@ -412,9 +425,5 @@ const escapeXml = escapeXmlUtil
  * Escape a string for use as an XML/HTML attribute value.
  */
 function escapeAttr(value: string): string {
-  return value
-    .replace(/&/g, '&amp;')
-    .replace(/"/g, '&quot;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
+  return value.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,32 +19,31 @@
 //   const svg = renderMermaidSVG('graph TD\n  A --> B')
 // ============================================================================
 
-export type { RenderOptions, MermaidGraph, PositionedGraph } from './types.ts'
-export type { DiagramColors, ThemeName } from './theme.ts'
-export { fromShikiTheme, THEMES, DEFAULTS } from './theme.ts'
-export { parseMermaid } from './parser.ts'
-export { renderMermaidASCII, renderMermaidAscii } from './ascii/index.ts'
 export type { AsciiRenderOptions } from './ascii/index.ts'
+export { renderMermaidASCII, renderMermaidAscii } from './ascii/index.ts'
+export { parseMermaid } from './parser.ts'
+export type { DiagramColors, ThemeName } from './theme.ts'
+export { DEFAULTS, fromShikiTheme, THEMES } from './theme.ts'
+export type { MermaidGraph, PositionedGraph, RenderOptions } from './types.ts'
 
 import { decodeXML } from 'entities'
-import { parseMermaid } from './parser.ts'
+import { layoutClassDiagramSync } from './class/layout.ts'
+import { parseClassDiagram } from './class/parser.ts'
+import { renderClassSvg } from './class/renderer.ts'
+import { layoutErDiagramSync } from './er/layout.ts'
+import { parseErDiagram } from './er/parser.ts'
+import { renderErSvg } from './er/renderer.ts'
 import { layoutGraphSync } from './layout.ts'
+import { parseMermaid } from './parser.ts'
 import { renderSvg } from './renderer.ts'
-import type { RenderOptions } from './types.ts'
+import { layoutSequenceDiagram } from './sequence/layout.ts'
+import { parseSequenceDiagram } from './sequence/parser.ts'
+import { renderSequenceSvg } from './sequence/renderer.ts'
 import type { DiagramColors } from './theme.ts'
 import { DEFAULTS } from './theme.ts'
-
-import { parseSequenceDiagram } from './sequence/parser.ts'
-import { layoutSequenceDiagram } from './sequence/layout.ts'
-import { renderSequenceSvg } from './sequence/renderer.ts'
-import { parseClassDiagram } from './class/parser.ts'
-import { layoutClassDiagramSync } from './class/layout.ts'
-import { renderClassSvg } from './class/renderer.ts'
-import { parseErDiagram } from './er/parser.ts'
-import { layoutErDiagramSync } from './er/layout.ts'
-import { renderErSvg } from './er/renderer.ts'
-import { parseXYChart } from './xychart/parser.ts'
+import type { RenderOptions } from './types.ts'
 import { layoutXYChart } from './xychart/layout.ts'
+import { parseXYChart } from './xychart/parser.ts'
 import { renderXYChartSvg } from './xychart/renderer.ts'
 
 /**
@@ -108,10 +107,7 @@ function buildColors(options: RenderOptions): DiagramColors {
  * })
  * ```
  */
-export function renderMermaidSVG(
-  text: string,
-  options: RenderOptions = {}
-): string {
+export function renderMermaidSVG(text: string, options: RenderOptions = {}): string {
   // Decode XML entities that may leak from markdown parsers (e.g. rehype-raw).
   // Without this, escapeXml() double-encodes them: &lt; → &amp;lt; → literal "&lt;" in SVG.
   text = decodeXML(text)
@@ -121,7 +117,10 @@ export function renderMermaidSVG(
   const transparent = options.transparent ?? false
   const diagramType = detectDiagramType(text)
 
-  const lines = text.split('\n').map(l => l.trim()).filter(l => l.length > 0 && !l.startsWith('%%'))
+  const lines = text
+    .split('\n')
+    .map(l => l.trim())
+    .filter(l => l.length > 0 && !l.startsWith('%%'))
 
   switch (diagramType) {
     case 'sequence': {
@@ -144,7 +143,6 @@ export function renderMermaidSVG(
       const positioned = layoutXYChart(chart, options)
       return renderXYChartSvg(positioned, colors, font, transparent, options.interactive ?? false)
     }
-    case 'flowchart':
     default: {
       const graph = parseMermaid(text)
       const positioned = layoutGraphSync(graph, options)
@@ -159,10 +157,7 @@ export function renderMermaidSVG(
  * Same result as renderMermaidSVG() but returns a Promise.
  * Useful in async contexts (server handlers, data loaders, etc.)
  */
-export async function renderMermaidSVGAsync(
-  text: string,
-  options: RenderOptions = {}
-): Promise<string> {
+export async function renderMermaidSVGAsync(text: string, options: RenderOptions = {}): Promise<string> {
   return renderMermaidSVG(text, options)
 }
 

--- a/src/layout-engine.ts
+++ b/src/layout-engine.ts
@@ -16,23 +16,23 @@
  * Safe for Electron, Node, and browser environments.
  */
 
-import type { ElkNode, ElkExtendedEdge, LayoutOptions } from 'elkjs'
-import type {
-  MermaidGraph,
-  MermaidSubgraph,
-  MermaidEdge,
-  Direction,
-  PositionedGraph,
-  PositionedNode,
-  PositionedEdge,
-  PositionedGroup,
-  Point,
-  RenderOptions,
-} from './types.ts'
-import { FONT_SIZES, FONT_WEIGHTS, NODE_PADDING, ARROW_HEAD } from './styles.ts'
-import { measureMultilineText } from './text-metrics.ts'
+import type { ElkExtendedEdge, ElkNode, LayoutOptions } from 'elkjs'
 import { elkLayoutSync } from './elk-instance.ts'
 import { clipEdgeToShape } from './shape-clipping.ts'
+import { ARROW_HEAD, FONT_SIZES, FONT_WEIGHTS, NODE_PADDING } from './styles.ts'
+import { measureMultilineText } from './text-metrics.ts'
+import type {
+  Direction,
+  MermaidEdge,
+  MermaidGraph,
+  MermaidSubgraph,
+  Point,
+  PositionedEdge,
+  PositionedGraph,
+  PositionedGroup,
+  PositionedNode,
+  RenderOptions,
+} from './types.ts'
 
 // ============================================================================
 // Layout options
@@ -51,12 +51,14 @@ const DEFAULTS = {
 /** Convert Mermaid direction to ELK direction */
 function directionToElk(dir: MermaidGraph['direction']): string {
   switch (dir) {
-    case 'LR': return 'RIGHT'
-    case 'RL': return 'LEFT'
-    case 'BT': return 'UP'
-    case 'TD':
-    case 'TB':
-    default: return 'DOWN'
+    case 'LR':
+      return 'RIGHT'
+    case 'RL':
+      return 'LEFT'
+    case 'BT':
+      return 'UP'
+    default:
+      return 'DOWN'
   }
 }
 
@@ -64,7 +66,7 @@ function directionToElk(dir: MermaidGraph['direction']): string {
 // Node sizing (same logic as Dagre adapter)
 // ============================================================================
 
-function estimateNodeSize(id: string, label: string, shape: string): { width: number; height: number } {
+function estimateNodeSize(_id: string, label: string, shape: string): { width: number; height: number } {
   const metrics = measureMultilineText(label, FONT_SIZES.nodeLabel, FONT_WEIGHTS.nodeLabel)
 
   let width = metrics.width + NODE_PADDING.horizontal * 2
@@ -118,18 +120,6 @@ interface ElkGraphNode extends ElkNode {
 }
 
 /**
- * Tracks port-to-edge mappings for hierarchical port edges.
- * Used to combine external and internal edge sections during extraction.
- */
-interface HierarchicalEdgeInfo {
-  originalIndex: number
-  externalEdgeId: string
-  internalEdgeId: string
-  subgraphId: string
-  direction: 'incoming' | 'outgoing'
-}
-
-/**
  * Convert a MermaidGraph to ELK's nested JSON input format.
  *
  * Uses SEPARATE hierarchy handling for proper subgraph direction override support.
@@ -137,7 +127,7 @@ interface HierarchicalEdgeInfo {
  */
 function mermaidToElk(
   graph: MermaidGraph,
-  opts: Required<Pick<RenderOptions, 'font' | 'padding' | 'nodeSpacing' | 'layerSpacing'>>
+  opts: Required<Pick<RenderOptions, 'font' | 'padding' | 'nodeSpacing' | 'layerSpacing'>>,
 ): ElkGraphNode {
   // Collect all node IDs that belong to subgraphs
   const subgraphNodeIds = new Set<string>()
@@ -154,13 +144,13 @@ function mermaidToElk(
   // 1. Internal edges (both endpoints in same subgraph)
   // 2. Root-level edges (neither endpoint in a subgraph)
   // 3. Cross-hierarchy edges (endpoints in different levels)
-  const edgesBySubgraph = new Map<string | null, Array<{ index: number; edge: typeof graph.edges[0] }>>()
+  const edgesBySubgraph = new Map<string | null, Array<{ index: number; edge: (typeof graph.edges)[0] }>>()
   edgesBySubgraph.set(null, []) // Root-level edges
 
   // Track cross-hierarchy edges for hierarchical port creation
   const crossHierarchyEdges: Array<{
     index: number
-    edge: typeof graph.edges[0]
+    edge: (typeof graph.edges)[0]
     sourceSubgraph: string | undefined
     targetSubgraph: string | undefined
   }> = []
@@ -181,7 +171,12 @@ function mermaidToElk(
       edgesBySubgraph.get(null)!.push({ index: i, edge })
     } else {
       // Cross-hierarchy edge: need hierarchical ports
-      crossHierarchyEdges.push({ index: i, edge, sourceSubgraph, targetSubgraph })
+      crossHierarchyEdges.push({
+        index: i,
+        edge,
+        sourceSubgraph,
+        targetSubgraph,
+      })
     }
   }
 
@@ -219,12 +214,15 @@ function mermaidToElk(
   }
 
   // Track hierarchical ports per subgraph for cross-hierarchy edges
-  const subgraphPorts = new Map<string, Array<{
-    portId: string
-    edgeIndex: number
-    direction: 'incoming' | 'outgoing'
-    internalNodeId: string
-  }>>()
+  const subgraphPorts = new Map<
+    string,
+    Array<{
+      portId: string
+      edgeIndex: number
+      direction: 'incoming' | 'outgoing'
+      internalNodeId: string
+    }>
+  >()
 
   // Process cross-hierarchy edges to create port entries
   if (hasDirectionOverride) {
@@ -286,15 +284,17 @@ function mermaidToElk(
     }
     if (edge.label) {
       const metrics = measureMultilineText(edge.label, FONT_SIZES.edgeLabel, FONT_WEIGHTS.edgeLabel)
-      elkEdge.labels = [{
-        text: edge.label,
-        width: metrics.width + 8,
-        height: metrics.height + 6,
-        layoutOptions: {
-          'elk.edgeLabels.inline': 'true',
-          'elk.edgeLabels.placement': 'CENTER',
+      elkEdge.labels = [
+        {
+          text: edge.label,
+          width: metrics.width + 8,
+          height: metrics.height + 6,
+          layoutOptions: {
+            'elk.edgeLabels.inline': 'true',
+            'elk.edgeLabels.placement': 'CENTER',
+          },
         },
-      }]
+      ]
     }
     elkGraph.edges!.push(elkEdge)
   }
@@ -308,15 +308,17 @@ function mermaidToElk(
     }
     if (edge.label) {
       const metrics = measureMultilineText(edge.label, FONT_SIZES.edgeLabel, FONT_WEIGHTS.edgeLabel)
-      elkEdge.labels = [{
-        text: edge.label,
-        width: metrics.width + 8,
-        height: metrics.height + 6,
-        layoutOptions: {
-          'elk.edgeLabels.inline': 'true',
-          'elk.edgeLabels.placement': 'CENTER',
+      elkEdge.labels = [
+        {
+          text: edge.label,
+          width: metrics.width + 8,
+          height: metrics.height + 6,
+          layoutOptions: {
+            'elk.edgeLabels.inline': 'true',
+            'elk.edgeLabels.placement': 'CENTER',
+          },
         },
-      }]
+      ]
     }
     elkGraph.edges!.push(elkEdge)
   }
@@ -337,12 +339,15 @@ function subgraphToElk(
   graph: MermaidGraph,
   opts: Required<Pick<RenderOptions, 'font' | 'padding' | 'nodeSpacing' | 'layerSpacing'>>,
   edgesBySubgraph: Map<string | null, Array<{ index: number; edge: MermaidEdge }>>,
-  subgraphPorts: Map<string, Array<{
-    portId: string
-    edgeIndex: number
-    direction: 'incoming' | 'outgoing'
-    internalNodeId: string
-  }>>
+  subgraphPorts: Map<
+    string,
+    Array<{
+      portId: string
+      edgeIndex: number
+      direction: 'incoming' | 'outgoing'
+      internalNodeId: string
+    }>
+  >,
 ): ElkGraphNode {
   const layoutOptions: LayoutOptions = {
     'elk.algorithm': 'layered',
@@ -374,7 +379,7 @@ function subgraphToElk(
   const ports = subgraphPorts.get(sg.id) ?? []
   if (ports.length > 0) {
     // ELK supports ports but types don't include it
-    (elkNode as unknown as Record<string, unknown>).ports = ports.map(p => ({
+    ;(elkNode as unknown as Record<string, unknown>).ports = ports.map(p => ({
       id: p.portId,
       // Port side is determined by ELK based on edge direction
     }))
@@ -409,15 +414,17 @@ function subgraphToElk(
     }
     if (edge.label) {
       const metrics = measureMultilineText(edge.label, FONT_SIZES.edgeLabel, FONT_WEIGHTS.edgeLabel)
-      elkEdge.labels = [{
-        text: edge.label,
-        width: metrics.width + 8,
-        height: metrics.height + 6,
-        layoutOptions: {
-          'elk.edgeLabels.inline': 'true',
-          'elk.edgeLabels.placement': 'CENTER',
+      elkEdge.labels = [
+        {
+          text: edge.label,
+          width: metrics.width + 8,
+          height: metrics.height + 6,
+          layoutOptions: {
+            'elk.edgeLabels.inline': 'true',
+            'elk.edgeLabels.placement': 'CENTER',
+          },
         },
-      }]
+      ]
     }
     elkNode.edges!.push(elkEdge)
   }
@@ -426,9 +433,18 @@ function subgraphToElk(
   // These connect the boundary ports to actual internal nodes
   for (const port of ports) {
     const internalEdgeId = `e${port.edgeIndex}_internal`
-    const elkEdge: ElkExtendedEdge = port.direction === 'incoming'
-      ? { id: internalEdgeId, sources: [port.portId], targets: [port.internalNodeId] }
-      : { id: internalEdgeId, sources: [port.internalNodeId], targets: [port.portId] }
+    const elkEdge: ElkExtendedEdge =
+      port.direction === 'incoming'
+        ? {
+            id: internalEdgeId,
+            sources: [port.portId],
+            targets: [port.internalNodeId],
+          }
+        : {
+            id: internalEdgeId,
+            sources: [port.internalNodeId],
+            targets: [port.portId],
+          }
     elkNode.edges!.push(elkEdge)
   }
 
@@ -489,17 +505,18 @@ interface MarginInfo {
 function flattenGroupBounds(groups: PositionedGroup[]): Array<{ x: number; y: number; right: number; bottom: number }> {
   const bounds: Array<{ x: number; y: number; right: number; bottom: number }> = []
   for (const g of groups) {
-    bounds.push({ x: g.x, y: g.y, right: g.x + g.width, bottom: g.y + g.height })
+    bounds.push({
+      x: g.x,
+      y: g.y,
+      right: g.x + g.width,
+      bottom: g.y + g.height,
+    })
     bounds.push(...flattenGroupBounds(g.children))
   }
   return bounds
 }
 
-function elkToPositioned(
-  elkResult: ElkNode,
-  graph: MermaidGraph,
-  mergeEdges: boolean = false
-): PositionedGraph {
+function elkToPositioned(elkResult: ElkNode, graph: MermaidGraph, mergeEdges: boolean = false): PositionedGraph {
   const nodes: PositionedNode[] = []
   const edges: PositionedEdge[] = []
   const groups: PositionedGroup[] = []
@@ -516,12 +533,13 @@ function elkToPositioned(
   // Compute margin positions for cross-hierarchy edge routing.
   // Margins sit outside all group bounding boxes so edges don't cross through subgraphs.
   const allBounds = flattenGroupBounds(groups)
-  const margins: MarginInfo | undefined = allBounds.length > 0
-    ? {
-        leftX: Math.min(...allBounds.map(b => b.x)) - 20,
-        rightX: Math.max(...allBounds.map(b => b.right)) + 20,
-      }
-    : undefined
+  const margins: MarginInfo | undefined =
+    allBounds.length > 0
+      ? {
+          leftX: Math.min(...allBounds.map(b => b.x)) - 20,
+          rightX: Math.max(...allBounds.map(b => b.right)) + 20,
+        }
+      : undefined
 
   // Extract edges recursively from all levels (root and subgraphs)
   // Edges are distributed to subgraphs for direction override to work,
@@ -592,7 +610,7 @@ function extractNodesAndGroups(
   nodes: PositionedNode[],
   groups: PositionedGroup[],
   offsetX: number,
-  offsetY: number
+  offsetY: number,
 ): void {
   if (!elkNode.children) return
 
@@ -652,7 +670,7 @@ function extractNodesAndGroups(
  */
 interface EdgeSegment {
   edgeIndex: number
-  isInternal: boolean  // true for port-to-node segments (e.g., "e3_internal")
+  isInternal: boolean // true for port-to-node segments (e.g., "e3_internal")
   points: Point[]
   labelPosition?: Point
 }
@@ -704,9 +722,9 @@ function extractEdgesRecursively(
   elkNode: ElkNode,
   graph: MermaidGraph,
   edges: PositionedEdge[],
-  offsetX: number,
-  offsetY: number,
-  margins?: MarginInfo
+  _offsetX: number,
+  _offsetY: number,
+  margins?: MarginInfo,
 ): void {
   // First pass: collect all edge segments
   const segments = new Map<number, { external?: EdgeSegment; incoming?: EdgeSegment; outgoing?: EdgeSegment }>()
@@ -805,11 +823,7 @@ function extractEdgesRecursively(
  * Returns the original array reference (identity) if no changes were needed,
  * so callers can detect whether routing was applied.
  */
-function orthogonalizeEdgePoints(
-  points: Point[],
-  margins?: MarginInfo,
-  edgeIndex: number = 0
-): Point[] {
+function orthogonalizeEdgePoints(points: Point[], margins?: MarginInfo, edgeIndex: number = 0): Point[] {
   if (points.length < 2) return points
 
   // Check if any segment needs orthogonalization
@@ -817,7 +831,10 @@ function orthogonalizeEdgePoints(
   for (let i = 1; i < points.length; i++) {
     const dx = Math.abs(points[i]!.x - points[i - 1]!.x)
     const dy = Math.abs(points[i]!.y - points[i - 1]!.y)
-    if (dx > 1 && dy > 1) { needsWork = true; break }
+    if (dx > 1 && dy > 1) {
+      needsWork = true
+      break
+    }
   }
   if (!needsWork) return points
 
@@ -836,9 +853,7 @@ function orthogonalizeEdgePoints(
         // Alternate left/right margins and offset for parallel edge spacing
         const useRight = edgeIndex % 2 === 0
         const offset = Math.floor(edgeIndex / 2) * EDGE_SPACING
-        const marginX = useRight
-          ? margins.rightX + offset
-          : margins.leftX - offset
+        const marginX = useRight ? margins.rightX + offset : margins.leftX - offset
 
         result.push({ x: marginX, y: prev.y })
         result.push({ x: marginX, y: curr.y })
@@ -863,14 +878,14 @@ function collectEdgeSegments(
   elkNode: ElkNode,
   segments: Map<number, { external?: EdgeSegment; incoming?: EdgeSegment; outgoing?: EdgeSegment }>,
   offsetX: number,
-  offsetY: number
+  offsetY: number,
 ): void {
   if (elkNode.edges) {
     for (const elkEdge of elkNode.edges) {
       // Parse edge ID: "e{index}" or "e{index}_internal"
       const isInternal = elkEdge.id.endsWith('_internal')
       const edgeIndex = parseInt(elkEdge.id.substring(1), 10)
-      if (isNaN(edgeIndex)) continue
+      if (Number.isNaN(edgeIndex)) continue
 
       // Extract points
       const points: Point[] = []
@@ -960,10 +975,7 @@ function collectAllSubgraphIds(sg: MermaidSubgraph, out: Set<string>): void {
  * Resolve inline styles for a node from classDefs and nodeStyles.
  * Class styles are applied first, then explicit style directives override.
  */
-function resolveNodeStyle(
-  nodeId: string,
-  graph: MermaidGraph
-): Record<string, string> | undefined {
+function resolveNodeStyle(nodeId: string, graph: MermaidGraph): Record<string, string> | undefined {
   let result: Record<string, string> | undefined
 
   // First, apply class styles (if node has a class assignment)
@@ -988,10 +1000,7 @@ function resolveNodeStyle(
  * Resolve inline styles for an edge from linkStyles map.
  * Default link style is applied first, then index-specific overrides.
  */
-function resolveEdgeStyle(
-  edgeIndex: number,
-  graph: MermaidGraph
-): Record<string, string> | undefined {
+function resolveEdgeStyle(edgeIndex: number, graph: MermaidGraph): Record<string, string> | undefined {
   let result: Record<string, string> | undefined
 
   const defaultStyle = graph.linkStyles.get('default')
@@ -1028,11 +1037,7 @@ function resolveEdgeStyle(
  * Intermediate bend points are left unchanged — edge bundling or clipping
  * will recalculate them afterwards.
  */
-function alignLayerNodes(
-  nodes: PositionedNode[],
-  edges: PositionedEdge[],
-  direction: Direction
-): void {
+function alignLayerNodes(nodes: PositionedNode[], edges: PositionedEdge[], direction: Direction): void {
   if (nodes.length === 0) return
 
   const isHorizontal = direction === 'LR' || direction === 'RL'
@@ -1054,9 +1059,7 @@ function alignLayerNodes(
   const THRESHOLD = DEFAULTS.layerSpacing * 0.6
 
   // Sort nodes by flow-axis position
-  const sorted = [...nodes].sort((a, b) =>
-    isHorizontal ? a.x - b.x : a.y - b.y
-  )
+  const sorted = [...nodes].sort((a, b) => (isHorizontal ? a.x - b.x : a.y - b.y))
 
   const layers: PositionedNode[][] = []
   let currentLayer: PositionedNode[] = [sorted[0]!]
@@ -1067,9 +1070,7 @@ function alignLayerNodes(
     // Single-linkage: compare with previous node, not layer start
     const gap = pos - prevPos
     // Check if this node is connected to any node already in the current layer
-    const hasEdgeToLayer = currentLayer.some(n =>
-      connectedPairs.has(`${n.id}:${sorted[i]!.id}`)
-    )
+    const hasEdgeToLayer = currentLayer.some(n => connectedPairs.has(`${n.id}:${sorted[i]!.id}`))
     if (gap <= THRESHOLD && !hasEdgeToLayer) {
       currentLayer.push(sorted[i]!)
     } else {
@@ -1085,7 +1086,7 @@ function alignLayerNodes(
   for (const layer of layers) {
     if (layer.length <= 1) continue
 
-    const positions = layer.map(n => isHorizontal ? n.x : n.y)
+    const positions = layer.map(n => (isHorizontal ? n.x : n.y))
     const min = Math.min(...positions)
     const max = Math.max(...positions)
     if (max - min <= 1) continue // Already aligned
@@ -1110,7 +1111,7 @@ function alignLayerNodes(
   if (deltas.size === 0) return
 
   // Build node lookup for edge adjustment
-  const nodeMap = new Map(nodes.map(n => [n.id, n]))
+  const _nodeMap = new Map(nodes.map(n => [n.id, n]))
 
   // Adjust edge endpoints to match shifted node positions
   for (const edge of edges) {
@@ -1162,10 +1163,7 @@ function alignLayerNodes(
 /**
  * Find all groups (outermost first) that geometrically contain the given point.
  */
-function findGroupsContainingPoint(
-  x: number, y: number,
-  groups: PositionedGroup[]
-): PositionedGroup[] {
+function findGroupsContainingPoint(x: number, y: number, groups: PositionedGroup[]): PositionedGroup[] {
   const result: PositionedGroup[] = []
   for (const g of groups) {
     if (x >= g.x && x <= g.x + g.width && y >= g.y && y <= g.y + g.height) {
@@ -1181,11 +1179,11 @@ function findGroupsContainingPoint(
  * move it just outside the outermost such group boundary.
  */
 function adjustJunctionForGroups(
-  junctionMain: number,  // the junction coordinate along the flow axis (Y for TD, X for LR)
-  refX: number,          // reference node center X (for finding its groups)
-  refY: number,          // reference node center Y
+  junctionMain: number, // the junction coordinate along the flow axis (Y for TD, X for LR)
+  refX: number, // reference node center X (for finding its groups)
+  refY: number, // reference node center Y
   groups: PositionedGroup[],
-  direction: Direction
+  direction: Direction,
 ): number {
   const GAP = 12
   const isLR = direction === 'LR'
@@ -1229,7 +1227,7 @@ function bundleEdgePaths(
   edges: PositionedEdge[],
   nodes: PositionedNode[],
   groups: PositionedGroup[],
-  direction: Direction
+  direction: Direction,
 ): void {
   const nodeMap = new Map(nodes.map(n => [n.id, n]))
   const processed = new Set<PositionedEdge>()
@@ -1267,7 +1265,10 @@ function bundleEdgePaths(
     })
     if (forward.length < 2) continue
 
-    const targets = forward.map(e => ({ edge: e, node: nodeMap.get(e.target)! }))
+    const targets = forward.map(e => ({
+      edge: e,
+      node: nodeMap.get(e.target)!,
+    }))
     const srcCX = source.x + source.width / 2
     const srcCY = source.y + source.height / 2
 
@@ -1343,7 +1344,10 @@ function bundleEdgePaths(
     })
     if (forward.length < 2) continue
 
-    const sources = forward.map(e => ({ edge: e, node: nodeMap.get(e.source)! }))
+    const sources = forward.map(e => ({
+      edge: e,
+      node: nodeMap.get(e.source)!,
+    }))
     const tgtCX = target.x + target.width / 2
     const tgtCY = target.y + target.height / 2
 
@@ -1399,10 +1403,7 @@ function bundleEdgePaths(
  * Lay out a parsed MermaidGraph using ELK.js (synchronous).
  * Returns a fully positioned graph ready for rendering.
  */
-export function layoutGraphSync(
-  graph: MermaidGraph,
-  options: RenderOptions = {}
-): PositionedGraph {
+export function layoutGraphSync(graph: MermaidGraph, options: RenderOptions = {}): PositionedGraph {
   const opts = { ...DEFAULTS, ...options }
   const elkGraph = mermaidToElk(graph, opts)
   const result = elkLayoutSync(elkGraph)
@@ -1412,10 +1413,7 @@ export function layoutGraphSync(
 /**
  * Convert MermaidGraph to ELK format (for benchmarking conversion overhead).
  */
-export function convertToElkFormat(
-  graph: MermaidGraph,
-  options: RenderOptions = {}
-): ElkNode {
+export function convertToElkFormat(graph: MermaidGraph, options: RenderOptions = {}): ElkNode {
   const opts = { ...DEFAULTS, ...options }
   return mermaidToElk(graph, opts)
 }

--- a/src/multiline-utils.ts
+++ b/src/multiline-utils.ts
@@ -16,14 +16,16 @@ import { LINE_HEIGHT_RATIO } from './text-metrics.ts'
 export function normalizeBrTags(label: string): string {
   // Strip surrounding double quotes (Mermaid uses them for special chars in labels)
   const unquoted = label.startsWith('"') && label.endsWith('"') ? label.slice(1, -1) : label
-  return unquoted
-    .replace(/<br\s*\/?>/gi, '\n')
-    .replace(/\\n/g, '\n')
-    .replace(/<\/?(?:sub|sup|small|mark)\s*>/gi, '')
-    // Markdown formatting → HTML tags (order matters: ** before *)
-    .replace(/\*\*(.+?)\*\*/g, '<b>$1</b>')
-    .replace(/(?<!\*)\*([^\s*](?:[^*]*[^\s*])?)\*(?!\*)/g, '<i>$1</i>')
-    .replace(/~~(.+?)~~/g, '<s>$1</s>')
+  return (
+    unquoted
+      .replace(/<br\s*\/?>/gi, '\n')
+      .replace(/\\n/g, '\n')
+      .replace(/<\/?(?:sub|sup|small|mark)\s*>/gi, '')
+      // Markdown formatting → HTML tags (order matters: ** before *)
+      .replace(/\*\*(.+?)\*\*/g, '<b>$1</b>')
+      .replace(/(?<!\*)\*([^\s*](?:[^*]*[^\s*])?)\*(?!\*)/g, '<i>$1</i>')
+      .replace(/~~(.+?)~~/g, '<s>$1</s>')
+  )
 }
 
 /**
@@ -67,7 +69,10 @@ const FORMAT_TAG_REGEX = /<(\/)?(?:(b|strong)|(i|em)|(u)|(s|del))\s*>/gi
  */
 function parseInlineFormatting(line: string): StyledSegment[] {
   const segments: StyledSegment[] = []
-  let bold = false, italic = false, underline = false, strikethrough = false
+  let bold = false,
+    italic = false,
+    underline = false,
+    strikethrough = false
   let lastIndex = 0
 
   // Reset lastIndex for global regex
@@ -77,7 +82,13 @@ function parseInlineFormatting(line: string): StyledSegment[] {
   while ((match = FORMAT_TAG_REGEX.exec(line)) !== null) {
     // Capture text before this tag
     if (match.index > lastIndex) {
-      segments.push({ text: line.slice(lastIndex, match.index), bold, italic, underline, strikethrough })
+      segments.push({
+        text: line.slice(lastIndex, match.index),
+        bold,
+        italic,
+        underline,
+        strikethrough,
+      })
     }
     lastIndex = match.index + match[0].length
 
@@ -91,7 +102,13 @@ function parseInlineFormatting(line: string): StyledSegment[] {
 
   // Remaining text after last tag
   if (lastIndex < line.length) {
-    segments.push({ text: line.slice(lastIndex), bold, italic, underline, strikethrough })
+    segments.push({
+      text: line.slice(lastIndex),
+      bold,
+      italic,
+      underline,
+      strikethrough,
+    })
   }
 
   return segments
@@ -115,21 +132,23 @@ function renderLineContent(line: string): string {
   const allPlain = segments.every(s => !s.bold && !s.italic && !s.underline && !s.strikethrough)
   if (allPlain) return segments.map(s => escapeXml(s.text)).join('')
 
-  return segments.map(seg => {
-    const escaped = escapeXml(seg.text)
-    if (!seg.bold && !seg.italic && !seg.underline && !seg.strikethrough) return escaped
+  return segments
+    .map(seg => {
+      const escaped = escapeXml(seg.text)
+      if (!seg.bold && !seg.italic && !seg.underline && !seg.strikethrough) return escaped
 
-    const attrs: string[] = []
-    if (seg.bold) attrs.push('font-weight="bold"')
-    if (seg.italic) attrs.push('font-style="italic"')
-    // SVG text-decoration can combine values
-    const deco: string[] = []
-    if (seg.underline) deco.push('underline')
-    if (seg.strikethrough) deco.push('line-through')
-    if (deco.length) attrs.push(`text-decoration="${deco.join(' ')}"`)
+      const attrs: string[] = []
+      if (seg.bold) attrs.push('font-weight="bold"')
+      if (seg.italic) attrs.push('font-style="italic"')
+      // SVG text-decoration can combine values
+      const deco: string[] = []
+      if (seg.underline) deco.push('underline')
+      if (seg.strikethrough) deco.push('line-through')
+      if (deco.length) attrs.push(`text-decoration="${deco.join(' ')}"`)
 
-    return `<tspan ${attrs.join(' ')}>${escaped}</tspan>`
-  }).join('')
+      return `<tspan ${attrs.join(' ')}>${escaped}</tspan>`
+    })
+    .join('')
 }
 
 // ============================================================================
@@ -157,7 +176,7 @@ export function renderMultilineText(
   cy: number,
   fontSize: number,
   attrs: string,
-  baselineShift: number = 0.35
+  baselineShift: number = 0.35,
 ): string {
   const lines = text.split('\n')
 
@@ -172,10 +191,12 @@ export function renderMultilineText(
   // First line dy: shift up by (n-1)/2 line heights, then add baseline shift
   const firstDy = -((lines.length - 1) / 2) * lineHeight + fontSize * baselineShift
 
-  const tspans = lines.map((line, i) => {
-    const dy = i === 0 ? firstDy : lineHeight
-    return `<tspan x="${cx}" dy="${dy}">${renderLineContent(line)}</tspan>`
-  }).join('')
+  const tspans = lines
+    .map((line, i) => {
+      const dy = i === 0 ? firstDy : lineHeight
+      return `<tspan x="${cx}" dy="${dy}">${renderLineContent(line)}</tspan>`
+    })
+    .join('')
 
   return `<text x="${cx}" y="${cy}" ${attrs}>${tspans}</text>`
 }
@@ -205,13 +226,13 @@ export function renderMultilineTextWithBackground(
   fontSize: number,
   padding: number,
   textAttrs: string,
-  bgAttrs: string
+  bgAttrs: string,
 ): string {
   const bgWidth = textWidth + padding * 2
   const bgHeight = textHeight + padding * 2
 
-  const rect = `<rect x="${cx - bgWidth / 2}" y="${cy - bgHeight / 2}" ` +
-    `width="${bgWidth}" height="${bgHeight}" ${bgAttrs} />`
+  const rect =
+    `<rect x="${cx - bgWidth / 2}" y="${cy - bgHeight / 2}" ` + `width="${bgWidth}" height="${bgHeight}" ${bgAttrs} />`
 
   const textEl = renderMultilineText(text, cx, cy, fontSize, textAttrs)
 

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1,5 +1,5 @@
-import type { MermaidGraph, MermaidNode, MermaidEdge, MermaidSubgraph, Direction, NodeShape, EdgeStyle } from './types.ts'
 import { normalizeBrTags } from './multiline-utils.ts'
+import type { Direction, EdgeStyle, MermaidGraph, MermaidNode, MermaidSubgraph, NodeShape } from './types.ts'
 
 // ============================================================================
 // Mermaid parser — flowcharts and state diagrams
@@ -18,7 +18,10 @@ import { normalizeBrTags } from './multiline-utils.ts'
  * Throws on invalid/unsupported input.
  */
 export function parseMermaid(text: string): MermaidGraph {
-  const lines = text.split('\n').map(l => l.trim()).filter(l => l.length > 0 && !l.startsWith('%%'))
+  const lines = text
+    .split('\n')
+    .map(l => l.trim())
+    .filter(l => l.length > 0 && !l.startsWith('%%'))
 
   if (lines.length === 0) {
     throw new Error('Empty mermaid diagram')
@@ -43,7 +46,9 @@ export function parseMermaid(text: string): MermaidGraph {
 function parseFlowchart(lines: string[]): MermaidGraph {
   const headerMatch = lines[0]!.match(/^(?:graph|flowchart)\s+(TD|TB|LR|BT|RL)\s*$/i)
   if (!headerMatch) {
-    throw new Error(`Invalid mermaid header: "${lines[0]}". Expected "graph TD", "flowchart LR", "stateDiagram-v2", etc.`)
+    throw new Error(
+      `Invalid mermaid header: "${lines[0]}". Expected "graph TD", "flowchart LR", "stateDiagram-v2", etc.`,
+    )
   }
 
   const direction = headerMatch[1]!.toUpperCase() as Direction
@@ -103,12 +108,18 @@ function parseFlowchart(lines: string[]): MermaidGraph {
       const target = linkStyleMatch[1]!.trim()
       const props = parseStyleProps(linkStyleMatch[2]!)
       if (target === 'default') {
-        graph.linkStyles.set('default', { ...graph.linkStyles.get('default'), ...props })
+        graph.linkStyles.set('default', {
+          ...graph.linkStyles.get('default'),
+          ...props,
+        })
       } else {
         const indices = target.split(',').map(s => parseInt(s.trim(), 10))
         for (const idx of indices) {
-          if (!isNaN(idx)) {
-            graph.linkStyles.set(idx, { ...graph.linkStyles.get(idx), ...props })
+          if (!Number.isNaN(idx)) {
+            graph.linkStyles.set(idx, {
+              ...graph.linkStyles.get(idx),
+              ...props,
+            })
           }
         }
       }
@@ -219,12 +230,18 @@ function parseStateDiagram(lines: string[]): MermaidGraph {
       const target = linkStyleMatch[1]!.trim()
       const props = parseStyleProps(linkStyleMatch[2]!)
       if (target === 'default') {
-        graph.linkStyles.set('default', { ...graph.linkStyles.get('default'), ...props })
+        graph.linkStyles.set('default', {
+          ...graph.linkStyles.get('default'),
+          ...props,
+        })
       } else {
         const indices = target.split(',').map(s => parseInt(s.trim(), 10))
         for (const idx of indices) {
-          if (!isNaN(idx)) {
-            graph.linkStyles.set(idx, { ...graph.linkStyles.get(idx), ...props })
+          if (!Number.isNaN(idx)) {
+            graph.linkStyles.set(idx, {
+              ...graph.linkStyles.get(idx),
+              ...props,
+            })
           }
         }
       }
@@ -280,7 +297,11 @@ function parseStateDiagram(lines: string[]): MermaidGraph {
       if (sourceId === '[*]') {
         startCount++
         sourceId = `_start${startCount > 1 ? startCount : ''}`
-        registerStateNode(graph, compositeStack, { id: sourceId, label: '', shape: 'state-start' })
+        registerStateNode(graph, compositeStack, {
+          id: sourceId,
+          label: '',
+          shape: 'state-start',
+        })
       } else if (!compositeStateIds.has(sourceId)) {
         // Only create a node if this isn't a composite state
         ensureStateNode(graph, compositeStack, sourceId)
@@ -289,7 +310,11 @@ function parseStateDiagram(lines: string[]): MermaidGraph {
       if (targetId === '[*]') {
         endCount++
         targetId = `_end${endCount > 1 ? endCount : ''}`
-        registerStateNode(graph, compositeStack, { id: targetId, label: '', shape: 'state-end' })
+        registerStateNode(graph, compositeStack, {
+          id: targetId,
+          label: '',
+          shape: 'state-end',
+        })
       } else if (!compositeStateIds.has(targetId)) {
         // Only create a node if this isn't a composite state
         ensureStateNode(graph, compositeStack, targetId)
@@ -312,7 +337,6 @@ function parseStateDiagram(lines: string[]): MermaidGraph {
       const id = stateDescMatch[1]!
       const label = normalizeBrTags(stateDescMatch[2]!.trim())
       registerStateNode(graph, compositeStack, { id, label, shape: 'rounded' })
-      continue
     }
   }
 
@@ -320,11 +344,7 @@ function parseStateDiagram(lines: string[]): MermaidGraph {
 }
 
 /** Register a state node and track in composite state if applicable */
-function registerStateNode(
-  graph: MermaidGraph,
-  compositeStack: MermaidSubgraph[],
-  node: MermaidNode
-): void {
+function registerStateNode(graph: MermaidGraph, compositeStack: MermaidSubgraph[], node: MermaidNode): void {
   const isNew = !graph.nodes.has(node.id)
   if (isNew) {
     graph.nodes.set(node.id, node)
@@ -338,13 +358,13 @@ function registerStateNode(
 }
 
 /** Ensure a state node exists with default rounded shape */
-function ensureStateNode(
-  graph: MermaidGraph,
-  compositeStack: MermaidSubgraph[],
-  id: string
-): void {
+function ensureStateNode(graph: MermaidGraph, compositeStack: MermaidSubgraph[], id: string): void {
   if (!graph.nodes.has(id)) {
-    registerStateNode(graph, compositeStack, { id, label: id, shape: 'rounded' })
+    registerStateNode(graph, compositeStack, {
+      id,
+      label: id,
+      shape: 'rounded',
+    })
   } else {
     // Track in composite if applicable
     if (compositeStack.length > 0) {
@@ -404,7 +424,7 @@ const ARROW_REGEX = /^(<)?(-->|-.->|==>|---|-\.-|===)(?:\|([^|]*)\|)?/
  *
  * Based on PR #36 by @liuxiaopai-ai (https://github.com/lukilabs/beautiful-mermaid/pull/36)
  */
-const TEXT_ARROW_REGEX = /^(<)?(--|-\.|==)\s+(.+?)\s+(-->|---|\.\->|-\.\-|==>|===)/
+const TEXT_ARROW_REGEX = /^(<)?(--|-\.|==)\s+(.+?)\s+(-->|---|\.->|-\.-|==>|===)/
 
 /**
  * Node shape patterns — ordered from most specific delimiters to least.
@@ -412,28 +432,28 @@ const TEXT_ARROW_REGEX = /^(<)?(--|-\.|==)\s+(.+?)\s+(-->|---|\.\->|-\.\-|==>|==
  */
 const NODE_PATTERNS: Array<{ regex: RegExp; shape: NodeShape }> = [
   // Triple delimiters (must be first)
-  { regex: /^([\w-]+)\(\(\((.+?)\)\)\)/, shape: 'doublecircle' },  // A(((text)))
+  { regex: /^([\w-]+)\(\(\((.+?)\)\)\)/, shape: 'doublecircle' }, // A(((text)))
 
   // Double delimiters with mixed brackets
-  { regex: /^([\w-]+)\(\[(.+?)\]\)/,     shape: 'stadium' },       // A([text])
-  { regex: /^([\w-]+)\(\((.+?)\)\)/,     shape: 'circle' },        // A((text))
-  { regex: /^([\w-]+)\[\[(.+?)\]\]/,     shape: 'subroutine' },    // A[[text]]
-  { regex: /^([\w-]+)\[\((.+?)\)\]/,     shape: 'cylinder' },      // A[(text)]
+  { regex: /^([\w-]+)\(\[(.+?)\]\)/, shape: 'stadium' }, // A([text])
+  { regex: /^([\w-]+)\(\((.+?)\)\)/, shape: 'circle' }, // A((text))
+  { regex: /^([\w-]+)\[\[(.+?)\]\]/, shape: 'subroutine' }, // A[[text]]
+  { regex: /^([\w-]+)\[\((.+?)\)\]/, shape: 'cylinder' }, // A[(text)]
 
   // Trapezoid variants — must come before plain [text]
-  { regex: /^([\w-]+)\[\/(.+?)\\\]/,     shape: 'trapezoid' },     // A[/text\]
-  { regex: /^([\w-]+)\[\\(.+?)\/\]/,     shape: 'trapezoid-alt' }, // A[\text/]
+  { regex: /^([\w-]+)\[\/(.+?)\\\]/, shape: 'trapezoid' }, // A[/text\]
+  { regex: /^([\w-]+)\[\\(.+?)\/\]/, shape: 'trapezoid-alt' }, // A[\text/]
 
   // Asymmetric flag shape
-  { regex: /^([\w-]+)>(.+?)\]/,          shape: 'asymmetric' },    // A>text]
+  { regex: /^([\w-]+)>(.+?)\]/, shape: 'asymmetric' }, // A>text]
 
   // Double curly braces (hexagon) — must come before single {text}
-  { regex: /^([\w-]+)\{\{(.+?)\}\}/,     shape: 'hexagon' },       // A{{text}}
+  { regex: /^([\w-]+)\{\{(.+?)\}\}/, shape: 'hexagon' }, // A{{text}}
 
   // Single-char delimiters (last — most common, least specific)
-  { regex: /^([\w-]+)\[(.+?)\]/,         shape: 'rectangle' },     // A[text]
-  { regex: /^([\w-]+)\((.+?)\)/,         shape: 'rounded' },       // A(text)
-  { regex: /^([\w-]+)\{(.+?)\}/,         shape: 'diamond' },       // A{text}
+  { regex: /^([\w-]+)\[(.+?)\]/, shape: 'rectangle' }, // A[text]
+  { regex: /^([\w-]+)\((.+?)\)/, shape: 'rounded' }, // A(text)
+  { regex: /^([\w-]+)\{(.+?)\}/, shape: 'diamond' }, // A{text}
 ]
 
 /** Regex for a bare node reference (just an ID, no shape brackets) */
@@ -447,11 +467,7 @@ const CLASS_SHORTHAND_REGEX = /^:::([\w][\w-]*)/
  * Handles chaining: A --> B --> C produces edges A→B and B→C.
  * Handles parallel links: A & B --> C & D produces 4 edges.
  */
-function parseEdgeLine(
-  line: string,
-  graph: MermaidGraph,
-  subgraphStack: MermaidSubgraph[]
-): void {
+function parseEdgeLine(line: string, graph: MermaidGraph, subgraphStack: MermaidSubgraph[]): void {
   let remaining = line.trim()
 
   // Parse the first node group (possibly with & separators)
@@ -527,7 +543,7 @@ interface ConsumedNodeGroup {
 function consumeNodeGroup(
   text: string,
   graph: MermaidGraph,
-  subgraphStack: MermaidSubgraph[]
+  subgraphStack: MermaidSubgraph[],
 ): ConsumedNodeGroup | null {
   const first = consumeNode(text, graph, subgraphStack)
   if (!first) return null
@@ -558,11 +574,7 @@ interface ConsumedNode {
  * If it's a bare reference (e.g. A), we look it up or create a default.
  * Also handles ::: class shorthand suffix.
  */
-function consumeNode(
-  text: string,
-  graph: MermaidGraph,
-  subgraphStack: MermaidSubgraph[]
-): ConsumedNode | null {
+function consumeNode(text: string, graph: MermaidGraph, subgraphStack: MermaidSubgraph[]): ConsumedNode | null {
   let id: string | null = null
   let remaining: string = text
 
@@ -586,7 +598,11 @@ function consumeNode(
     if (bareMatch) {
       id = bareMatch[1]!
       if (!graph.nodes.has(id)) {
-        registerNode(graph, subgraphStack, { id, label: id, shape: 'rectangle' })
+        registerNode(graph, subgraphStack, {
+          id,
+          label: id,
+          shape: 'rectangle',
+        })
       }
       remaining = text.slice(bareMatch[0].length)
     }
@@ -605,11 +621,7 @@ function consumeNode(
 }
 
 /** Register a node in the graph and track it in the current subgraph */
-function registerNode(
-  graph: MermaidGraph,
-  subgraphStack: MermaidSubgraph[],
-  node: MermaidNode
-): void {
+function registerNode(graph: MermaidGraph, subgraphStack: MermaidSubgraph[], node: MermaidNode): void {
   const isNew = !graph.nodes.has(node.id)
   if (isNew) {
     graph.nodes.set(node.id, node)

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -1,9 +1,9 @@
-import type { PositionedGraph, PositionedNode, PositionedEdge, PositionedGroup, Point } from './types.ts'
-import type { DiagramColors } from './theme.ts'
-import { svgOpenTag, buildStyleBlock } from './theme.ts'
-import { FONT_SIZES, FONT_WEIGHTS, STROKE_WIDTHS, ARROW_HEAD, estimateTextWidth, TEXT_BASELINE_SHIFT } from './styles.ts'
+import { renderMultilineText, renderMultilineTextWithBackground } from './multiline-utils.ts'
+import { ARROW_HEAD, FONT_SIZES, FONT_WEIGHTS, STROKE_WIDTHS } from './styles.ts'
 import { measureMultilineText } from './text-metrics.ts'
-import { renderMultilineText, renderMultilineTextWithBackground, escapeXml } from './multiline-utils.ts'
+import type { DiagramColors } from './theme.ts'
+import { buildStyleBlock, svgOpenTag } from './theme.ts'
+import type { Point, PositionedEdge, PositionedGraph, PositionedGroup, PositionedNode } from './types.ts'
 
 // ============================================================================
 // SVG renderer — converts a PositionedGraph into an SVG string.
@@ -36,7 +36,7 @@ export function renderSvg(
   graph: PositionedGraph,
   colors: DiagramColors,
   font: string = 'Inter',
-  transparent: boolean = false
+  transparent: boolean = false,
 ): string {
   const parts: string[] = []
 
@@ -139,7 +139,7 @@ function arrowMarkerDefsForColor(color: string): string {
  *  Non-alphanumeric chars are hex-encoded so distinct inputs never collapse
  *  (e.g. "var(--line-1)" → "var28--line2d129", "var(--line1)" → "var28--line129"). */
 function markerSuffix(color: string): string {
-  return color.replace(/[^a-zA-Z0-9]/g, (ch) => ch.charCodeAt(0).toString(16))
+  return color.replace(/[^a-zA-Z0-9]/g, ch => ch.charCodeAt(0).toString(16))
 }
 
 // ============================================================================
@@ -153,31 +153,30 @@ function renderGroup(group: PositionedGroup, font: string): string {
   // Opening <g> with semantic attributes for subgraph identification
   // data-id: original Mermaid subgraph ID
   // data-label: display label (may differ from ID)
-  parts.push(
-    `<g class="subgraph" data-id="${escapeAttr(group.id)}" data-label="${escapeAttr(group.label)}">`
-  )
+  parts.push(`<g class="subgraph" data-id="${escapeAttr(group.id)}" data-label="${escapeAttr(group.label)}">`)
 
   // Outer rectangle
   parts.push(
     `  <rect x="${group.x}" y="${group.y}" width="${group.width}" height="${group.height}" ` +
-    `rx="0" ry="0" fill="var(--_group-fill)" stroke="var(--_node-stroke)" stroke-width="${STROKE_WIDTHS.outerBox}" />`
+      `rx="0" ry="0" fill="var(--_group-fill)" stroke="var(--_node-stroke)" stroke-width="${STROKE_WIDTHS.outerBox}" />`,
   )
 
   // Header band
   parts.push(
     `  <rect x="${group.x}" y="${group.y}" width="${group.width}" height="${headerHeight}" ` +
-    `rx="0" ry="0" fill="var(--_group-hdr)" stroke="var(--_node-stroke)" stroke-width="${STROKE_WIDTHS.outerBox}" />`
+      `rx="0" ry="0" fill="var(--_group-hdr)" stroke="var(--_node-stroke)" stroke-width="${STROKE_WIDTHS.outerBox}" />`,
   )
 
   // Header label (supports multi-line via <br> tags)
   parts.push(
-    '  ' + renderMultilineText(
-      group.label,
-      group.x + 12,
-      group.y + headerHeight / 2,
-      FONT_SIZES.groupHeader,
-      `font-size="${FONT_SIZES.groupHeader}" font-weight="${FONT_WEIGHTS.groupHeader}" fill="var(--_text-sec)"`
-    )
+    '  ' +
+      renderMultilineText(
+        group.label,
+        group.x + 12,
+        group.y + headerHeight / 2,
+        FONT_SIZES.groupHeader,
+        `font-size="${FONT_SIZES.groupHeader}" font-weight="${FONT_WEIGHTS.groupHeader}" fill="var(--_text-sec)"`,
+      ),
   )
 
   // Render nested groups recursively (inside this group)
@@ -239,7 +238,7 @@ function pointsToPolylinePath(points: Point[]): string {
   return points.map(p => `${p.x},${p.y}`).join(' ')
 }
 
-function renderEdgeLabel(edge: PositionedEdge, font: string): string {
+function renderEdgeLabel(edge: PositionedEdge, _font: string): string {
   // Use layout-computed label position when available (layout-aware, avoids collisions).
   // Fall back to geometric midpoint of the edge polyline.
   const mid = edge.labelPosition ?? edgeMidpoint(edge.points)
@@ -261,7 +260,7 @@ function renderEdgeLabel(edge: PositionedEdge, font: string): string {
     // Use --_text-sec for better contrast (was --_text-muted)
     `text-anchor="middle" font-size="${FONT_SIZES.edgeLabel}" font-weight="${FONT_WEIGHTS.edgeLabel}" fill="var(--_text-sec)"`,
     // Increased stroke width from 0.5 to 1 for better label separation from edges
-    `rx="2" ry="2" fill="var(--bg)" stroke="var(--_inner-stroke)" stroke-width="1"`
+    `rx="2" ry="2" fill="var(--bg)" stroke="var(--_inner-stroke)" stroke-width="1"`,
   )
 
   // Semantic wrapper: links label to its edge via data-from/data-to
@@ -324,7 +323,7 @@ function renderNode(node: PositionedNode, font: string): string {
   // This enables reliable node identification without heuristics
   const parts: string[] = []
   parts.push(
-    `<g class="node" data-id="${escapeAttr(node.id)}" data-label="${escapeAttr(node.label)}" data-shape="${node.shape}">`
+    `<g class="node" data-id="${escapeAttr(node.id)}" data-label="${escapeAttr(node.label)}" data-shape="${node.shape}">`,
   )
   parts.push(`  ${shape.replace(/\n/g, '\n  ')}`)
   if (label) {
@@ -372,7 +371,6 @@ function renderNodeShape(node: PositionedNode): string {
       return renderStateStart(x, y, width, height)
     case 'state-end':
       return renderStateEnd(x, y, width, height)
-    case 'rectangle':
     default:
       return renderRect(x, y, width, height, fill, stroke, sw)
   }
@@ -387,7 +385,15 @@ function renderRect(x: number, y: number, w: number, h: number, fill: string, st
   )
 }
 
-function renderRoundedRect(x: number, y: number, w: number, h: number, fill: string, stroke: string, sw: string): string {
+function renderRoundedRect(
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+  fill: string,
+  stroke: string,
+  sw: string,
+): string {
   return (
     `<rect x="${x}" y="${y}" width="${w}" height="${h}" ` +
     `rx="6" ry="6" fill="${fill}" stroke="${stroke}" stroke-width="${sw}" />`
@@ -406,10 +412,7 @@ function renderCircle(x: number, y: number, w: number, h: number, fill: string, 
   const cx = x + w / 2
   const cy = y + h / 2
   const r = Math.min(w, h) / 2
-  return (
-    `<circle cx="${cx}" cy="${cy}" r="${r}" ` +
-    `fill="${fill}" stroke="${stroke}" stroke-width="${sw}" />`
-  )
+  return `<circle cx="${cx}" cy="${cy}" r="${r}" ` + `fill="${fill}" stroke="${stroke}" stroke-width="${sw}" />`
 }
 
 function renderDiamond(x: number, y: number, w: number, h: number, fill: string, stroke: string, sw: string): string {
@@ -418,21 +421,27 @@ function renderDiamond(x: number, y: number, w: number, h: number, fill: string,
   const hw = w / 2
   const hh = h / 2
   const points = [
-    `${cx},${cy - hh}`,   // top
-    `${cx + hw},${cy}`,   // right
-    `${cx},${cy + hh}`,   // bottom
-    `${cx - hw},${cy}`,   // left
+    `${cx},${cy - hh}`, // top
+    `${cx + hw},${cy}`, // right
+    `${cx},${cy + hh}`, // bottom
+    `${cx - hw},${cy}`, // left
   ].join(' ')
 
-  return (
-    `<polygon points="${points}" fill="${fill}" stroke="${stroke}" stroke-width="${sw}" />`
-  )
+  return `<polygon points="${points}" fill="${fill}" stroke="${stroke}" stroke-width="${sw}" />`
 }
 
 // --- Batch 1 shapes ---
 
 /** Subroutine: rectangle with double vertical borders on left and right */
-function renderSubroutine(x: number, y: number, w: number, h: number, fill: string, stroke: string, sw: string): string {
+function renderSubroutine(
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+  fill: string,
+  stroke: string,
+  sw: string,
+): string {
   const inset = 8 // distance from edge to inner vertical line
   return (
     `<rect x="${x}" y="${y}" width="${w}" height="${h}" ` +
@@ -445,7 +454,15 @@ function renderSubroutine(x: number, y: number, w: number, h: number, fill: stri
 }
 
 /** Double circle: two concentric circles with a gap between them */
-function renderDoubleCircle(x: number, y: number, w: number, h: number, fill: string, stroke: string, sw: string): string {
+function renderDoubleCircle(
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+  fill: string,
+  stroke: string,
+  sw: string,
+): string {
   const cx = x + w / 2
   const cy = y + h / 2
   const outerR = Math.min(w, h) / 2
@@ -462,12 +479,12 @@ function renderDoubleCircle(x: number, y: number, w: number, h: number, fill: st
 function renderHexagon(x: number, y: number, w: number, h: number, fill: string, stroke: string, sw: string): string {
   const inset = h / 4 // horizontal inset for the angled sides
   const points = [
-    `${x + inset},${y}`,           // top-left
-    `${x + w - inset},${y}`,       // top-right
-    `${x + w},${y + h / 2}`,       // mid-right
-    `${x + w - inset},${y + h}`,   // bottom-right
-    `${x + inset},${y + h}`,       // bottom-left
-    `${x},${y + h / 2}`,           // mid-left
+    `${x + inset},${y}`, // top-left
+    `${x + w - inset},${y}`, // top-right
+    `${x + w},${y + h / 2}`, // mid-right
+    `${x + w - inset},${y + h}`, // bottom-right
+    `${x + inset},${y + h}`, // bottom-left
+    `${x},${y + h / 2}`, // mid-left
   ].join(' ')
 
   return `<polygon points="${points}" fill="${fill}" stroke="${stroke}" stroke-width="${sw}" />`
@@ -499,14 +516,22 @@ function renderCylinder(x: number, y: number, w: number, h: number, fill: string
 }
 
 /** Asymmetric / flag: rectangle with a pointed left edge */
-function renderAsymmetric(x: number, y: number, w: number, h: number, fill: string, stroke: string, sw: string): string {
+function renderAsymmetric(
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+  fill: string,
+  stroke: string,
+  sw: string,
+): string {
   const indent = 12 // how far the point indents
   const points = [
-    `${x + indent},${y}`,       // top-left (indented)
-    `${x + w},${y}`,            // top-right
-    `${x + w},${y + h}`,        // bottom-right
-    `${x + indent},${y + h}`,   // bottom-left (indented)
-    `${x},${y + h / 2}`,        // left point
+    `${x + indent},${y}`, // top-left (indented)
+    `${x + w},${y}`, // top-right
+    `${x + w},${y + h}`, // bottom-right
+    `${x + indent},${y + h}`, // bottom-left (indented)
+    `${x},${y + h / 2}`, // left point
   ].join(' ')
 
   return `<polygon points="${points}" fill="${fill}" stroke="${stroke}" stroke-width="${sw}" />`
@@ -516,23 +541,31 @@ function renderAsymmetric(x: number, y: number, w: number, h: number, fill: stri
 function renderTrapezoid(x: number, y: number, w: number, h: number, fill: string, stroke: string, sw: string): string {
   const inset = w * 0.15 // top edge is narrower by this amount on each side
   const points = [
-    `${x + inset},${y}`,         // top-left (indented)
-    `${x + w - inset},${y}`,     // top-right (indented)
-    `${x + w},${y + h}`,         // bottom-right (full width)
-    `${x},${y + h}`,             // bottom-left (full width)
+    `${x + inset},${y}`, // top-left (indented)
+    `${x + w - inset},${y}`, // top-right (indented)
+    `${x + w},${y + h}`, // bottom-right (full width)
+    `${x},${y + h}`, // bottom-left (full width)
   ].join(' ')
 
   return `<polygon points="${points}" fill="${fill}" stroke="${stroke}" stroke-width="${sw}" />`
 }
 
 /** Trapezoid-alt [\text/]: wider top, narrower bottom */
-function renderTrapezoidAlt(x: number, y: number, w: number, h: number, fill: string, stroke: string, sw: string): string {
+function renderTrapezoidAlt(
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+  fill: string,
+  stroke: string,
+  sw: string,
+): string {
   const inset = w * 0.15 // bottom edge is narrower
   const points = [
-    `${x},${y}`,                     // top-left (full width)
-    `${x + w},${y}`,                 // top-right (full width)
-    `${x + w - inset},${y + h}`,     // bottom-right (indented)
-    `${x + inset},${y + h}`,         // bottom-left (indented)
+    `${x},${y}`, // top-left (full width)
+    `${x + w},${y}`, // top-right (full width)
+    `${x + w - inset},${y + h}`, // bottom-right (indented)
+    `${x + inset},${y + h}`, // bottom-left (indented)
   ].join(' ')
 
   return `<polygon points="${points}" fill="${fill}" stroke="${stroke}" stroke-width="${sw}" />`
@@ -565,7 +598,7 @@ function renderStateEnd(x: number, y: number, w: number, h: number): string {
 // Node label rendering
 // ============================================================================
 
-function renderNodeLabel(node: PositionedNode, font: string): string {
+function renderNodeLabel(node: PositionedNode, _font: string): string {
   // State pseudostates have no label
   if (node.shape === 'state-start' || node.shape === 'state-end') {
     if (!node.label) return ''
@@ -582,7 +615,7 @@ function renderNodeLabel(node: PositionedNode, font: string): string {
     cx,
     cy,
     FONT_SIZES.nodeLabel,
-    `text-anchor="middle" font-size="${FONT_SIZES.nodeLabel}" font-weight="${FONT_WEIGHTS.nodeLabel}" fill="${textColor}"`
+    `text-anchor="middle" font-size="${FONT_SIZES.nodeLabel}" font-weight="${FONT_WEIGHTS.nodeLabel}" fill="${textColor}"`,
   )
 }
 
@@ -595,9 +628,5 @@ function renderNodeLabel(node: PositionedNode, font: string): string {
  * Escapes quotes and ampersands to prevent attribute injection.
  */
 function escapeAttr(value: string): string {
-  return value
-    .replace(/&/g, '&amp;')
-    .replace(/"/g, '&quot;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
+  return value.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
 }

--- a/src/sequence/layout.ts
+++ b/src/sequence/layout.ts
@@ -1,6 +1,15 @@
-import type { SequenceDiagram, PositionedSequenceDiagram, PositionedActor, Lifeline, PositionedMessage, Activation, PositionedBlock, PositionedNote } from './types.ts'
-import type { RenderOptions } from '../types.ts'
 import { estimateTextWidth, FONT_SIZES, FONT_WEIGHTS } from '../styles.ts'
+import type { RenderOptions } from '../types.ts'
+import type {
+  Activation,
+  Lifeline,
+  PositionedActor,
+  PositionedBlock,
+  PositionedMessage,
+  PositionedNote,
+  PositionedSequenceDiagram,
+  SequenceDiagram,
+} from './types.ts'
 
 // ============================================================================
 // Sequence diagram layout engine
@@ -54,10 +63,19 @@ const SEQ = {
  */
 export function layoutSequenceDiagram(
   diagram: SequenceDiagram,
-  _options: RenderOptions = {}
+  _options: RenderOptions = {},
 ): PositionedSequenceDiagram {
   if (diagram.actors.length === 0) {
-    return { width: 0, height: 0, actors: [], lifelines: [], messages: [], activations: [], blocks: [], notes: [] }
+    return {
+      width: 0,
+      height: 0,
+      actors: [],
+      lifelines: [],
+      messages: [],
+      activations: [],
+      blocks: [],
+      notes: [],
+    }
   }
 
   // 1. Calculate actor widths and assign horizontal positions (center X)
@@ -151,7 +169,8 @@ export function layoutSequenceDiagram(
       label: msg.label,
       lineStyle: msg.lineStyle,
       arrowHead: msg.arrowHead,
-      x1, x2,
+      x1,
+      x2,
       y: messageY,
       isSelf,
     })
@@ -201,7 +220,7 @@ export function layoutSequenceDiagram(
       for (const note of notesForMsg) {
         const noteW = Math.max(
           SEQ.noteWidth,
-          estimateTextWidth(note.text, FONT_SIZES.edgeLabel, FONT_WEIGHTS.edgeLabel) + SEQ.notePadX * 2
+          estimateTextWidth(note.text, FONT_SIZES.edgeLabel, FONT_WEIGHTS.edgeLabel) + SEQ.notePadX * 2,
         )
         const noteH = FONT_SIZES.edgeLabel + SEQ.notePadY * 2
 
@@ -310,9 +329,7 @@ export function layoutSequenceDiagram(
         const msgLabelW = estimateTextWidth(msg.label, FONT_SIZES.edgeLabel, FONT_WEIGHTS.edgeLabel)
         // Self-messages render labels at x1 + 36 (left-aligned); normal
         // messages center the label between the two actor lifelines.
-        const msgLabelLeft = msg.isSelf
-          ? msg.x1 + 36
-          : (msg.x1 + msg.x2) / 2 - msgLabelW / 2
+        const msgLabelLeft = msg.isSelf ? msg.x1 + 36 : (msg.x1 + msg.x2) / 2 - msgLabelW / 2
         const msgLabelRight = msgLabelLeft + msgLabelW
 
         if (divLabelRight > msgLabelLeft && divLabelLeft < msgLabelRight) {
@@ -377,9 +394,14 @@ export function layoutSequenceDiagram(
   const shiftX = globalMinX < SEQ.padding ? SEQ.padding - globalMinX : 0
   if (shiftX > 0) {
     for (const a of actors) a.x += shiftX
-    for (const m of messages) { m.x1 += shiftX; m.x2 += shiftX }
+    for (const m of messages) {
+      m.x1 += shiftX
+      m.x2 += shiftX
+    }
     for (const act of activations) act.x += shiftX
-    for (const b of blocks) { b.x += shiftX; }
+    for (const b of blocks) {
+      b.x += shiftX
+    }
     for (const n of notes) n.x += shiftX
     // Also shift actor center X array (used for lifelines below)
     for (let i = 0; i < actorCenterX.length; i++) actorCenterX[i]! += shiftX

--- a/src/sequence/parser.ts
+++ b/src/sequence/parser.ts
@@ -1,5 +1,5 @@
-import type { SequenceDiagram, Actor, Message, Block, Note } from './types.ts'
 import { normalizeBrTags } from '../multiline-utils.ts'
+import type { Block, Message, SequenceDiagram } from './types.ts'
 
 // ============================================================================
 // Sequence diagram parser
@@ -39,7 +39,12 @@ export function parseSequenceDiagram(lines: string[]): SequenceDiagram {
   // Track actor IDs to auto-create actors referenced in messages
   const actorIds = new Set<string>()
   // Track block nesting with a stack
-  const blockStack: Array<{ type: Block['type']; label: string; startIndex: number; dividers: Block['dividers'] }> = []
+  const blockStack: Array<{
+    type: Block['type']
+    label: string
+    startIndex: number
+    dividers: Block['dividers']
+  }> = []
 
   for (let i = 1; i < lines.length; i++) {
     const line = lines[i]!
@@ -130,9 +135,7 @@ export function parseSequenceDiagram(lines: string[]): SequenceDiagram {
     // --- Message ---
     // Patterns: A->>B, A-->>B, A-)B, A--)B, with optional +/- activation
     // Format: FROM ARROW TO: LABEL
-    const msgMatch = line.match(
-      /^(\S+?)\s*(--?>?>|--?[)x]|--?>>|--?>)\s*([+-]?)(\S+?)\s*:\s*(.+)$/
-    )
+    const msgMatch = line.match(/^(\S+?)\s*(--?>?>|--?[)x]|--?>>|--?>)\s*([+-]?)(\S+?)\s*:\s*(.+)$/)
     if (msgMatch) {
       const from = msgMatch[1]!
       const arrow = msgMatch[2]!
@@ -166,9 +169,7 @@ export function parseSequenceDiagram(lines: string[]): SequenceDiagram {
     }
 
     // --- Simplified message format: A->>B: Label (fallback with more relaxed regex) ---
-    const simpleMsgMatch = line.match(
-      /^(\S+?)\s*(->>|-->>|-\)|--\)|-x|--x|->|-->)\s*([+-]?)(\S+?)\s*:\s*(.+)$/
-    )
+    const simpleMsgMatch = line.match(/^(\S+?)\s*(->>|-->>|-\)|--\)|-x|--x|->|-->)\s*([+-]?)(\S+?)\s*:\s*(.+)$/)
     if (simpleMsgMatch) {
       const from = simpleMsgMatch[1]!
       const arrow = simpleMsgMatch[2]!
@@ -187,7 +188,6 @@ export function parseSequenceDiagram(lines: string[]): SequenceDiagram {
       if (activationMark === '-') msg.deactivate = true
 
       diagram.messages.push(msg)
-      continue
     }
 
     // --- activate / deactivate explicit commands ---

--- a/src/sequence/renderer.ts
+++ b/src/sequence/renderer.ts
@@ -1,8 +1,16 @@
-import type { PositionedSequenceDiagram, PositionedActor, Lifeline, PositionedMessage, Activation, PositionedBlock, PositionedNote } from './types.ts'
+import { escapeXml as escapeXmlUtil, renderMultilineText } from '../multiline-utils.ts'
+import { ARROW_HEAD, estimateTextWidth, FONT_SIZES, FONT_WEIGHTS, STROKE_WIDTHS } from '../styles.ts'
 import type { DiagramColors } from '../theme.ts'
-import { svgOpenTag, buildStyleBlock } from '../theme.ts'
-import { FONT_SIZES, FONT_WEIGHTS, STROKE_WIDTHS, ARROW_HEAD, estimateTextWidth, TEXT_BASELINE_SHIFT } from '../styles.ts'
-import { renderMultilineText, escapeXml as escapeXmlUtil } from '../multiline-utils.ts'
+import { buildStyleBlock, svgOpenTag } from '../theme.ts'
+import type {
+  Activation,
+  Lifeline,
+  PositionedActor,
+  PositionedBlock,
+  PositionedMessage,
+  PositionedNote,
+  PositionedSequenceDiagram,
+} from './types.ts'
 
 // ============================================================================
 // Sequence diagram SVG renderer
@@ -29,7 +37,7 @@ export function renderSequenceSvg(
   diagram: PositionedSequenceDiagram,
   colors: DiagramColors,
   font: string = 'Inter',
-  transparent: boolean = false
+  transparent: boolean = false,
 ): string {
   const parts: string[] = []
 
@@ -107,9 +115,7 @@ function renderActor(actor: PositionedActor): string {
   const parts: string[] = []
 
   // Semantic wrapper with actor metadata
-  parts.push(
-    `<g class="actor" data-id="${escapeAttr(id)}" data-label="${escapeAttr(label)}" data-type="${type}">`
-  )
+  parts.push(`<g class="actor" data-id="${escapeAttr(id)}" data-label="${escapeAttr(label)}" data-type="${type}">`)
 
   if (type === 'actor') {
     // Circle-person icon: outer circle + head circle + shoulders arc.
@@ -117,36 +123,48 @@ function renderActor(actor: PositionedActor): string {
     // and centered both horizontally and vertically within the box.
     // Stroke width is inverse-scaled so the visual thickness matches STROKE_WIDTHS.outerBox.
     const s = (height / 24) * 0.9
-    const tx = x - 12 * s            // center icon horizontally on actor.x
-    const ty = y + (height - 24 * s) / 2  // center icon vertically in actor box
-    const sw = STROKE_WIDTHS.outerBox / s  // compensate for scale transform
-    const iconStroke = 'var(--_line)'      // use line color for actor icon strokes
+    const tx = x - 12 * s // center icon horizontally on actor.x
+    const ty = y + (height - 24 * s) / 2 // center icon vertically in actor box
+    const sw = STROKE_WIDTHS.outerBox / s // compensate for scale transform
+    const iconStroke = 'var(--_line)' // use line color for actor icon strokes
 
     parts.push(
       `  <g transform="translate(${tx},${ty}) scale(${s})">` +
-      // Outer circle
-      `\n    <path d="M21 12C21 16.9706 16.9706 21 12 21C7.02944 21 3 16.9706 3 12C3 7.02944 7.02944 3 12 3C16.9706 3 21 7.02944 21 12Z" fill="none" stroke="${iconStroke}" stroke-width="${sw}" />` +
-      // Head
-      `\n    <path d="M15 10C15 11.6569 13.6569 13 12 13C10.3431 13 9 11.6569 9 10C9 8.34315 10.3431 7 12 7C13.6569 7 15 8.34315 15 10Z" fill="none" stroke="${iconStroke}" stroke-width="${sw}" />` +
-      // Shoulders
-      `\n    <path d="M5.62842 18.3563C7.08963 17.0398 9.39997 16 12 16C14.6 16 16.9104 17.0398 18.3716 18.3563" fill="none" stroke="${iconStroke}" stroke-width="${sw}" />` +
-      `\n  </g>`
+        // Outer circle
+        `\n    <path d="M21 12C21 16.9706 16.9706 21 12 21C7.02944 21 3 16.9706 3 12C3 7.02944 7.02944 3 12 3C16.9706 3 21 7.02944 21 12Z" fill="none" stroke="${iconStroke}" stroke-width="${sw}" />` +
+        // Head
+        `\n    <path d="M15 10C15 11.6569 13.6569 13 12 13C10.3431 13 9 11.6569 9 10C9 8.34315 10.3431 7 12 7C13.6569 7 15 8.34315 15 10Z" fill="none" stroke="${iconStroke}" stroke-width="${sw}" />` +
+        // Shoulders
+        `\n    <path d="M5.62842 18.3563C7.08963 17.0398 9.39997 16 12 16C14.6 16 16.9104 17.0398 18.3716 18.3563" fill="none" stroke="${iconStroke}" stroke-width="${sw}" />` +
+        `\n  </g>`,
     )
     // Label below the icon (supports multi-line)
     parts.push(
-      '  ' + renderMultilineText(label, x, y + height + 14, FONT_SIZES.nodeLabel,
-        `font-size="${FONT_SIZES.nodeLabel}" text-anchor="middle" font-weight="${FONT_WEIGHTS.nodeLabel}" fill="var(--_text)"`)
+      '  ' +
+        renderMultilineText(
+          label,
+          x,
+          y + height + 14,
+          FONT_SIZES.nodeLabel,
+          `font-size="${FONT_SIZES.nodeLabel}" text-anchor="middle" font-weight="${FONT_WEIGHTS.nodeLabel}" fill="var(--_text)"`,
+        ),
     )
   } else {
     // Participant: rectangle box with label (supports multi-line)
     const boxX = x - width / 2
     parts.push(
       `  <rect x="${boxX}" y="${y}" width="${width}" height="${height}" rx="4" ry="4" ` +
-      `fill="var(--_node-fill)" stroke="var(--_node-stroke)" stroke-width="${STROKE_WIDTHS.outerBox}" />`
+        `fill="var(--_node-fill)" stroke="var(--_node-stroke)" stroke-width="${STROKE_WIDTHS.outerBox}" />`,
     )
     parts.push(
-      '  ' + renderMultilineText(label, x, y + height / 2, FONT_SIZES.nodeLabel,
-        `font-size="${FONT_SIZES.nodeLabel}" text-anchor="middle" font-weight="${FONT_WEIGHTS.nodeLabel}" fill="var(--_text)"`)
+      '  ' +
+        renderMultilineText(
+          label,
+          x,
+          y + height / 2,
+          FONT_SIZES.nodeLabel,
+          `font-size="${FONT_SIZES.nodeLabel}" text-anchor="middle" font-weight="${FONT_WEIGHTS.nodeLabel}" fill="var(--_text)"`,
+        ),
     )
   }
 
@@ -190,8 +208,8 @@ function renderMessage(msg: PositionedMessage): string {
   // Semantic wrapper with message metadata
   parts.push(
     `<g class="message" data-from="${escapeAttr(msg.from)}" data-to="${escapeAttr(msg.to)}" ` +
-    `data-label="${escapeAttr(msg.label)}" data-line-style="${msg.lineStyle}" ` +
-    `data-arrow-head="${msg.arrowHead}" data-self="${msg.isSelf}">`
+      `data-label="${escapeAttr(msg.label)}" data-line-style="${msg.lineStyle}" ` +
+      `data-arrow-head="${msg.arrowHead}" data-self="${msg.isSelf}">`,
   )
 
   if (msg.isSelf) {
@@ -202,24 +220,36 @@ function renderMessage(msg: PositionedMessage): string {
     const labelPadding = 8 // Space between loop and label
     parts.push(
       `  <polyline points="${msg.x1},${msg.y} ${msg.x1 + loopW},${msg.y} ${msg.x1 + loopW},${msg.y + loopH} ${msg.x2},${msg.y + loopH}" ` +
-      `fill="none" stroke="var(--_line)" stroke-width="${STROKE_WIDTHS.connector}"${dashArray} marker-end="url(#${markerId})" />`
+        `fill="none" stroke="var(--_line)" stroke-width="${STROKE_WIDTHS.connector}"${dashArray} marker-end="url(#${markerId})" />`,
     )
     // Label to the right of the loop (supports multi-line)
     parts.push(
-      '  ' + renderMultilineText(msg.label, msg.x1 + loopW + labelPadding, msg.y + loopH / 2, FONT_SIZES.edgeLabel,
-        `font-size="${FONT_SIZES.edgeLabel}" text-anchor="start" font-weight="${FONT_WEIGHTS.edgeLabel}" fill="var(--_text-muted)"`)
+      '  ' +
+        renderMultilineText(
+          msg.label,
+          msg.x1 + loopW + labelPadding,
+          msg.y + loopH / 2,
+          FONT_SIZES.edgeLabel,
+          `font-size="${FONT_SIZES.edgeLabel}" text-anchor="start" font-weight="${FONT_WEIGHTS.edgeLabel}" fill="var(--_text-muted)"`,
+        ),
     )
   } else {
     // Normal message: horizontal arrow
     parts.push(
       `  <line x1="${msg.x1}" y1="${msg.y}" x2="${msg.x2}" y2="${msg.y}" ` +
-      `stroke="var(--_line)" stroke-width="${STROKE_WIDTHS.connector}"${dashArray} marker-end="url(#${markerId})" />`
+        `stroke="var(--_line)" stroke-width="${STROKE_WIDTHS.connector}"${dashArray} marker-end="url(#${markerId})" />`,
     )
     // Label above the arrow, centered (supports multi-line)
     const midX = (msg.x1 + msg.x2) / 2
     parts.push(
-      '  ' + renderMultilineText(msg.label, midX, msg.y - 10, FONT_SIZES.edgeLabel,
-        `font-size="${FONT_SIZES.edgeLabel}" text-anchor="middle" font-weight="${FONT_WEIGHTS.edgeLabel}" fill="var(--_text-muted)"`)
+      '  ' +
+        renderMultilineText(
+          msg.label,
+          midX,
+          msg.y - 10,
+          FONT_SIZES.edgeLabel,
+          `font-size="${FONT_SIZES.edgeLabel}" text-anchor="middle" font-weight="${FONT_WEIGHTS.edgeLabel}" fill="var(--_text-muted)"`,
+        ),
     )
   }
 
@@ -236,14 +266,12 @@ function renderBlock(block: PositionedBlock): string {
 
   // Semantic wrapper with block metadata
   const labelAttr = block.label ? ` data-label="${escapeAttr(block.label)}"` : ''
-  parts.push(
-    `<g class="block" data-type="${escapeAttr(block.type)}"${labelAttr}>`
-  )
+  parts.push(`<g class="block" data-type="${escapeAttr(block.type)}"${labelAttr}>`)
 
   // Outer rectangle
   parts.push(
     `  <rect x="${block.x}" y="${block.y}" width="${block.width}" height="${block.height}" ` +
-    `rx="0" ry="0" fill="none" stroke="var(--_node-stroke)" stroke-width="${STROKE_WIDTHS.outerBox}" />`
+      `rx="0" ry="0" fill="none" stroke="var(--_node-stroke)" stroke-width="${STROKE_WIDTHS.outerBox}" />`,
   )
 
   // Type label tab (top-left corner)
@@ -255,30 +283,37 @@ function renderBlock(block: PositionedBlock): string {
 
   parts.push(
     `  <rect x="${block.x}" y="${block.y}" width="${tabWidth}" height="${tabHeight}" ` +
-    `fill="var(--_group-hdr)" stroke="var(--_node-stroke)" stroke-width="${STROKE_WIDTHS.outerBox}" />`
+      `fill="var(--_group-hdr)" stroke="var(--_node-stroke)" stroke-width="${STROKE_WIDTHS.outerBox}" />`,
   )
   // Block type label (supports multi-line via <br> tags)
   parts.push(
-    '  ' + renderMultilineText(
-      labelText,
-      block.x + 6,
-      block.y + tabHeight / 2,
-      FONT_SIZES.edgeLabel,
-      `font-size="${FONT_SIZES.edgeLabel}" font-weight="${FONT_WEIGHTS.groupHeader}" fill="var(--_text-sec)"`
-    )
+    '  ' +
+      renderMultilineText(
+        labelText,
+        block.x + 6,
+        block.y + tabHeight / 2,
+        FONT_SIZES.edgeLabel,
+        `font-size="${FONT_SIZES.edgeLabel}" font-weight="${FONT_WEIGHTS.groupHeader}" fill="var(--_text-sec)"`,
+      ),
   )
 
   // Divider lines (for alt/else, par/and)
   for (const divider of block.dividers) {
     parts.push(
       `  <line x1="${block.x}" y1="${divider.y}" x2="${block.x + block.width}" y2="${divider.y}" ` +
-      `stroke="var(--_line)" stroke-width="0.75" stroke-dasharray="6 4" />`
+        `stroke="var(--_line)" stroke-width="0.75" stroke-dasharray="6 4" />`,
     )
     if (divider.label) {
       // Divider label supports multi-line
       parts.push(
-        '  ' + renderMultilineText(`[${divider.label}]`, block.x + 8, divider.y + 14, FONT_SIZES.edgeLabel,
-          `font-size="${FONT_SIZES.edgeLabel}" text-anchor="start" font-weight="${FONT_WEIGHTS.edgeLabel}" fill="var(--_text-muted)"`)
+        '  ' +
+          renderMultilineText(
+            `[${divider.label}]`,
+            block.x + 8,
+            divider.y + 14,
+            FONT_SIZES.edgeLabel,
+            `font-size="${FONT_SIZES.edgeLabel}" text-anchor="start" font-weight="${FONT_WEIGHTS.edgeLabel}" fill="var(--_text-muted)"`,
+          ),
       )
     }
   }
@@ -297,9 +332,8 @@ function renderNote(note: PositionedNote): string {
   const { x, y, width: w, height: h } = note
 
   // Build actor reference attribute if present
-  const actorsAttr = note.actors && note.actors.length > 0
-    ? ` data-actors="${note.actors.map(escapeAttr).join(',')}"`
-    : ''
+  const actorsAttr =
+    note.actors && note.actors.length > 0 ? ` data-actors="${note.actors.map(escapeAttr).join(',')}"` : ''
   const positionAttr = note.position ? ` data-position="${escapeAttr(note.position)}"` : ''
 
   // Note body: polygon with top-right corner cut off
@@ -321,8 +355,13 @@ function renderNote(note: PositionedNote): string {
     `\n  <polygon points="${x + w - foldSize},${y} ${x + w},${y + foldSize} ${x + w - foldSize},${y + foldSize}" ` +
     `fill="var(--_inner-stroke)" stroke="var(--_node-stroke)" stroke-width="${STROKE_WIDTHS.innerBox}" />` +
     // Note text (supports multi-line)
-    `\n  ${renderMultilineText(note.text, x + w / 2, y + h / 2, FONT_SIZES.edgeLabel,
-      `font-size="${FONT_SIZES.edgeLabel}" text-anchor="middle" font-weight="${FONT_WEIGHTS.edgeLabel}" fill="var(--_text-muted)"`)}` +
+    `\n  ${renderMultilineText(
+      note.text,
+      x + w / 2,
+      y + h / 2,
+      FONT_SIZES.edgeLabel,
+      `font-size="${FONT_SIZES.edgeLabel}" text-anchor="middle" font-weight="${FONT_WEIGHTS.edgeLabel}" fill="var(--_text-muted)"`,
+    )}` +
     `\n</g>`
   )
 }
@@ -332,15 +371,11 @@ function renderNote(note: PositionedNote): string {
 // ============================================================================
 
 // Use shared escapeXml from multiline-utils
-const escapeXml = escapeXmlUtil
+const _escapeXml = escapeXmlUtil
 
 /**
  * Escape a string for use as an XML/HTML attribute value.
  */
 function escapeAttr(value: string): string {
-  return value
-    .replace(/&/g, '&amp;')
-    .replace(/"/g, '&quot;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
+  return value.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
 }

--- a/src/shape-clipping.ts
+++ b/src/shape-clipping.ts
@@ -19,11 +19,7 @@ import type { Point, PositionedNode } from './types.ts'
  * @param isStart - True if clipping the start point (source), false for end (target)
  * @returns New points array with clipped endpoint
  */
-export function clipEdgeToShape(
-  points: Point[],
-  node: PositionedNode,
-  isStart: boolean
-): Point[] {
+export function clipEdgeToShape(points: Point[], node: PositionedNode, isStart: boolean): Point[] {
   if (points.length < 2) return points
 
   // Only clip non-rectangular shapes
@@ -67,8 +63,8 @@ export function clipEdgeToShape(
 function clipToDiamond(endpoint: Point, adjacent: Point, node: PositionedNode): Point {
   const cx = node.x + node.width / 2
   const cy = node.y + node.height / 2
-  const halfW = node.width / 2
-  const halfH = node.height / 2
+  const _halfW = node.width / 2
+  const _halfH = node.height / 2
 
   // Diamond vertices
   const top: Point = { x: cx, y: node.y }

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -93,4 +93,3 @@ export const ARROW_HEAD = {
   width: 8,
   height: 5,
 } as const
-

--- a/src/text-metrics.ts
+++ b/src/text-metrics.ts
@@ -176,7 +176,7 @@ export function measureTextWidth(text: string, fontSize: number, fontWeight: num
   // Base ratio calibrated for Inter font family
   // Heavier weights are slightly wider
   // Added +0.02 buffer to prevent edge truncation of characters like 's' at line ends
-  const baseRatio = fontWeight >= 600 ? 0.60 : fontWeight >= 500 ? 0.57 : 0.54
+  const baseRatio = fontWeight >= 600 ? 0.6 : fontWeight >= 500 ? 0.57 : 0.54
 
   let totalWidth = 0
 
@@ -221,11 +221,7 @@ export interface MultilineMetrics {
  * @param fontWeight - Font weight (affects width slightly)
  * @returns Metrics including width, height, lines array, and lineHeight
  */
-export function measureMultilineText(
-  text: string,
-  fontSize: number,
-  fontWeight: number
-): MultilineMetrics {
+export function measureMultilineText(text: string, fontSize: number, fontWeight: number): MultilineMetrics {
   const lines = text.split('\n')
   const lineHeight = fontSize * LINE_HEIGHT_RATIO
 

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -63,27 +63,27 @@ export const DEFAULTS: Readonly<{ bg: string; fg: string }> = {
 
 export const MIX = {
   /** Primary text: near-full fg */
-  text:         100, // just use --fg directly
+  text: 100, // just use --fg directly
   /** Secondary text (group headers): fg mixed at 60% */
-  textSec:      60,
+  textSec: 60,
   /** Muted text (edge labels, notes): fg mixed at 40% */
-  textMuted:    40,
+  textMuted: 40,
   /** Faint text (de-emphasized): fg mixed at 25% */
-  textFaint:    25,
+  textFaint: 25,
   /** Edge/connector lines: fg mixed at 50% for clear visibility */
-  line:         50,
+  line: 50,
   /** Arrow head fill: fg mixed at 85% for clear visibility */
-  arrow:        85,
+  arrow: 85,
   /** Node fill tint: fg mixed at 3% */
-  nodeFill:     3,
+  nodeFill: 3,
   /** Node/group stroke: fg mixed at 20% */
-  nodeStroke:   20,
+  nodeStroke: 20,
   /** Group header band tint: fg mixed at 5% */
-  groupHeader:  5,
+  groupHeader: 5,
   /** Inner divider strokes: fg mixed at 12% */
-  innerStroke:  12,
+  innerStroke: 12,
   /** Key badge background opacity (ER diagrams) */
-  keyBadge:     10,
+  keyBadge: 10,
 } as const
 
 // ============================================================================
@@ -95,62 +95,103 @@ export const MIX = {
 
 export const THEMES: Record<string, DiagramColors> = {
   'zinc-light': {
-    bg: '#FFFFFF', fg: '#27272A',
+    bg: '#FFFFFF',
+    fg: '#27272A',
   },
   'zinc-dark': {
-    bg: '#18181B', fg: '#FAFAFA',
+    bg: '#18181B',
+    fg: '#FAFAFA',
   },
   'tokyo-night': {
-    bg: '#1a1b26', fg: '#a9b1d6',
-    line: '#3d59a1', accent: '#7aa2f7', muted: '#565f89',
+    bg: '#1a1b26',
+    fg: '#a9b1d6',
+    line: '#3d59a1',
+    accent: '#7aa2f7',
+    muted: '#565f89',
   },
   'tokyo-night-storm': {
-    bg: '#24283b', fg: '#a9b1d6',
-    line: '#3d59a1', accent: '#7aa2f7', muted: '#565f89',
+    bg: '#24283b',
+    fg: '#a9b1d6',
+    line: '#3d59a1',
+    accent: '#7aa2f7',
+    muted: '#565f89',
   },
   'tokyo-night-light': {
-    bg: '#d5d6db', fg: '#343b58',
-    line: '#34548a', accent: '#34548a', muted: '#9699a3',
+    bg: '#d5d6db',
+    fg: '#343b58',
+    line: '#34548a',
+    accent: '#34548a',
+    muted: '#9699a3',
   },
   'catppuccin-mocha': {
-    bg: '#1e1e2e', fg: '#cdd6f4',
-    line: '#585b70', accent: '#cba6f7', muted: '#6c7086',
+    bg: '#1e1e2e',
+    fg: '#cdd6f4',
+    line: '#585b70',
+    accent: '#cba6f7',
+    muted: '#6c7086',
   },
   'catppuccin-latte': {
-    bg: '#eff1f5', fg: '#4c4f69',
-    line: '#9ca0b0', accent: '#8839ef', muted: '#9ca0b0',
+    bg: '#eff1f5',
+    fg: '#4c4f69',
+    line: '#9ca0b0',
+    accent: '#8839ef',
+    muted: '#9ca0b0',
   },
-  'nord': {
-    bg: '#2e3440', fg: '#d8dee9',
-    line: '#4c566a', accent: '#88c0d0', muted: '#616e88',
+  nord: {
+    bg: '#2e3440',
+    fg: '#d8dee9',
+    line: '#4c566a',
+    accent: '#88c0d0',
+    muted: '#616e88',
   },
   'nord-light': {
-    bg: '#eceff4', fg: '#2e3440',
-    line: '#aab1c0', accent: '#5e81ac', muted: '#7b88a1',
+    bg: '#eceff4',
+    fg: '#2e3440',
+    line: '#aab1c0',
+    accent: '#5e81ac',
+    muted: '#7b88a1',
   },
-  'dracula': {
-    bg: '#282a36', fg: '#f8f8f2',
-    line: '#6272a4', accent: '#bd93f9', muted: '#6272a4',
+  dracula: {
+    bg: '#282a36',
+    fg: '#f8f8f2',
+    line: '#6272a4',
+    accent: '#bd93f9',
+    muted: '#6272a4',
   },
   'github-light': {
-    bg: '#ffffff', fg: '#1f2328',
-    line: '#d1d9e0', accent: '#0969da', muted: '#59636e',
+    bg: '#ffffff',
+    fg: '#1f2328',
+    line: '#d1d9e0',
+    accent: '#0969da',
+    muted: '#59636e',
   },
   'github-dark': {
-    bg: '#0d1117', fg: '#e6edf3',
-    line: '#3d444d', accent: '#4493f8', muted: '#9198a1',
+    bg: '#0d1117',
+    fg: '#e6edf3',
+    line: '#3d444d',
+    accent: '#4493f8',
+    muted: '#9198a1',
   },
   'solarized-light': {
-    bg: '#fdf6e3', fg: '#657b83',
-    line: '#93a1a1', accent: '#268bd2', muted: '#93a1a1',
+    bg: '#fdf6e3',
+    fg: '#657b83',
+    line: '#93a1a1',
+    accent: '#268bd2',
+    muted: '#93a1a1',
   },
   'solarized-dark': {
-    bg: '#002b36', fg: '#839496',
-    line: '#586e75', accent: '#268bd2', muted: '#586e75',
+    bg: '#002b36',
+    fg: '#839496',
+    line: '#586e75',
+    accent: '#268bd2',
+    muted: '#586e75',
   },
   'one-dark': {
-    bg: '#282c34', fg: '#abb2bf',
-    line: '#4b5263', accent: '#c678dd', muted: '#5c6370',
+    bg: '#282c34',
+    fg: '#abb2bf',
+    line: '#4b5263',
+    accent: '#c678dd',
+    muted: '#5c6370',
   },
 } as const
 
@@ -205,18 +246,17 @@ export function fromShikiTheme(theme: ShikiThemeLike): DiagramColors {
 
   // Helper: find a token color by scope name
   const tokenColor = (scope: string): string | undefined =>
-    theme.tokenColors?.find(t =>
-      Array.isArray(t.scope) ? t.scope.includes(scope) : t.scope === scope
-    )?.settings?.foreground
+    theme.tokenColors?.find(t => (Array.isArray(t.scope) ? t.scope.includes(scope) : t.scope === scope))?.settings
+      ?.foreground
 
   return {
     bg: c['editor.background'] ?? (dark ? '#1e1e1e' : '#ffffff'),
     fg: c['editor.foreground'] ?? (dark ? '#d4d4d4' : '#333333'),
-    line:    c['editorLineNumber.foreground'] ?? undefined,
-    accent:  c['focusBorder'] ?? tokenColor('keyword') ?? undefined,
-    muted:   tokenColor('comment') ?? c['editorLineNumber.foreground'] ?? undefined,
+    line: c['editorLineNumber.foreground'] ?? undefined,
+    accent: c.focusBorder ?? tokenColor('keyword') ?? undefined,
+    muted: tokenColor('comment') ?? c['editorLineNumber.foreground'] ?? undefined,
     surface: c['editor.selectionBackground'] ?? undefined,
-    border:  c['editorWidget.border'] ?? undefined,
+    border: c['editorWidget.border'] ?? undefined,
   }
 }
 
@@ -264,7 +304,9 @@ export function buildStyleBlock(font: string, hasMonoFont: boolean): string {
     '<style>',
     `  ${fontImports.join('\n  ')}`,
     `  text { font-family: '${font}', system-ui, sans-serif; }`,
-    ...(hasMonoFont ? [`  .mono { font-family: 'JetBrains Mono', 'SF Mono', 'Fira Code', ui-monospace, monospace; }`] : []),
+    ...(hasMonoFont
+      ? [`  .mono { font-family: 'JetBrains Mono', 'SF Mono', 'Fira Code', ui-monospace, monospace; }`]
+      : []),
     `  svg {${derivedVars}`,
     `  }`,
     '</style>',
@@ -278,22 +320,19 @@ export function buildStyleBlock(font: string, hasMonoFont: boolean): string {
  *
  * @param transparent - If true, omits the background style for transparent SVGs
  */
-export function svgOpenTag(
-  width: number,
-  height: number,
-  colors: DiagramColors,
-  transparent?: boolean,
-): string {
+export function svgOpenTag(width: number, height: number, colors: DiagramColors, transparent?: boolean): string {
   // Build the style string with only the provided color variables
   const vars = [
     `--bg:${colors.bg}`,
     `--fg:${colors.fg}`,
-    colors.line    ? `--line:${colors.line}` : '',
-    colors.accent  ? `--accent:${colors.accent}` : '',
-    colors.muted   ? `--muted:${colors.muted}` : '',
+    colors.line ? `--line:${colors.line}` : '',
+    colors.accent ? `--accent:${colors.accent}` : '',
+    colors.muted ? `--muted:${colors.muted}` : '',
     colors.surface ? `--surface:${colors.surface}` : '',
-    colors.border  ? `--border:${colors.border}` : '',
-  ].filter(Boolean).join(';')
+    colors.border ? `--border:${colors.border}` : '',
+  ]
+    .filter(Boolean)
+    .join(';')
 
   const bgStyle = transparent ? '' : ';background:var(--bg)'
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -31,17 +31,17 @@ export type NodeShape =
   | 'stadium'
   | 'circle'
   // Batch 1 additions
-  | 'subroutine'     // [[text]]  — double-bordered rectangle
-  | 'doublecircle'   // (((text))) — concentric circles
-  | 'hexagon'        // {{text}}  — six-sided polygon
+  | 'subroutine' // [[text]]  — double-bordered rectangle
+  | 'doublecircle' // (((text))) — concentric circles
+  | 'hexagon' // {{text}}  — six-sided polygon
   // Batch 2 additions
-  | 'cylinder'       // [(text)]  — database cylinder
-  | 'asymmetric'     // >text]    — flag/banner shape
-  | 'trapezoid'      // [/text\]  — wider bottom
-  | 'trapezoid-alt'  // [\text/]  — wider top
+  | 'cylinder' // [(text)]  — database cylinder
+  | 'asymmetric' // >text]    — flag/banner shape
+  | 'trapezoid' // [/text\]  — wider bottom
+  | 'trapezoid-alt' // [\text/]  — wider top
   // Batch 3 state diagram pseudostates
-  | 'state-start'    // filled circle (start pseudostate)
-  | 'state-end'      // bullseye circle (end pseudostate)
+  | 'state-start' // filled circle (start pseudostate)
+  | 'state-end' // bullseye circle (end pseudostate)
 
 export interface MermaidEdge {
   source: string

--- a/src/xychart/colors.ts
+++ b/src/xychart/colors.ts
@@ -48,14 +48,36 @@ function hslToHex(h: number, s: number, l: number): string {
   const m = li - c / 2
 
   let r: number, g: number, b: number
-  if (h < 60) { r = c; g = x; b = 0 }
-  else if (h < 120) { r = x; g = c; b = 0 }
-  else if (h < 180) { r = 0; g = c; b = x }
-  else if (h < 240) { r = 0; g = x; b = c }
-  else if (h < 300) { r = x; g = 0; b = c }
-  else { r = c; g = 0; b = x }
+  if (h < 60) {
+    r = c
+    g = x
+    b = 0
+  } else if (h < 120) {
+    r = x
+    g = c
+    b = 0
+  } else if (h < 180) {
+    r = 0
+    g = c
+    b = x
+  } else if (h < 240) {
+    r = 0
+    g = x
+    b = c
+  } else if (h < 300) {
+    r = x
+    g = 0
+    b = c
+  } else {
+    r = c
+    g = 0
+    b = x
+  }
 
-  const toHex = (v: number) => Math.round((v + m) * 255).toString(16).padStart(2, '0')
+  const toHex = (v: number) =>
+    Math.round((v + m) * 255)
+      .toString(16)
+      .padStart(2, '0')
   return `#${toHex(r)}${toHex(g)}${toHex(b)}`
 }
 
@@ -65,15 +87,14 @@ function hslToHex(h: number, s: number, l: number): string {
 
 function hexToRgb(hex: string): [number, number, number] {
   const h = hex.replace('#', '')
-  return [
-    parseInt(h.substring(0, 2), 16),
-    parseInt(h.substring(2, 4), 16),
-    parseInt(h.substring(4, 6), 16),
-  ]
+  return [parseInt(h.substring(0, 2), 16), parseInt(h.substring(2, 4), 16), parseInt(h.substring(4, 6), 16)]
 }
 
 function rgbToHex(r: number, g: number, b: number): string {
-  const toHex = (v: number) => Math.round(Math.max(0, Math.min(255, v))).toString(16).padStart(2, '0')
+  const toHex = (v: number) =>
+    Math.round(Math.max(0, Math.min(255, v)))
+      .toString(16)
+      .padStart(2, '0')
   return `#${toHex(r)}${toHex(g)}${toHex(b)}`
 }
 
@@ -128,13 +149,11 @@ export function getSeriesColor(index: number, accentColor: string, bgColor?: str
 
   // On dark backgrounds, flip: odd = lighter, even = darker
   const dark = safeBg && isDarkBackground(safeBg) ? !oddIndex : oddIndex
-  const l = dark
-    ? Math.max(25, 48 - tier * 13)
-    : Math.min(78, 55 + tier * 11)
+  const l = dark ? Math.max(25, 48 - tier * 13) : Math.min(78, 55 + tier * 11)
 
   // Subtle hue drift: darker shades shift slightly negative, lighter shift positive
   const hShift = (dark ? -8 : 12) * tier
-  const newH = ((h + hShift) % 360 + 360) % 360
+  const newH = (((h + hShift) % 360) + 360) % 360
 
   return hslToHex(newH, chartS, l)
 }

--- a/src/xychart/layout.ts
+++ b/src/xychart/layout.ts
@@ -1,9 +1,16 @@
-import type {
-  XYChart, PositionedXYChart, PositionedAxis, AxisTick,
-  PositionedBar, PositionedLine, GridLine, PlotArea, LegendItem,
-} from './types.ts'
-import type { RenderOptions } from '../types.ts'
 import { estimateTextWidth } from '../styles.ts'
+import type { RenderOptions } from '../types.ts'
+import type {
+  AxisTick,
+  GridLine,
+  LegendItem,
+  PlotArea,
+  PositionedAxis,
+  PositionedBar,
+  PositionedLine,
+  PositionedXYChart,
+  XYChart,
+} from './types.ts'
 
 // ============================================================================
 // XY Chart layout engine
@@ -44,10 +51,7 @@ const XY = {
 /**
  * Lay out a parsed XY chart by computing pixel coordinates.
  */
-export function layoutXYChart(
-  chart: XYChart,
-  _options: RenderOptions = {}
-): PositionedXYChart {
+export function layoutXYChart(chart: XYChart, _options: RenderOptions = {}): PositionedXYChart {
   if (chart.horizontal) return layoutHorizontal(chart)
   return layoutVertical(chart)
 }
@@ -67,7 +71,7 @@ function layoutVertical(chart: XYChart): PositionedXYChart {
   const yTicks = niceTickValues(yRange.min, yRange.max)
   const maxYLabelWidth = Math.max(
     ...yTicks.map(v => estimateTextWidth(formatTickValue(v), XY.axisLabelFontSize, XY.axisLabelFontWeight)),
-    XY.yLabelWidth
+    XY.yLabelWidth,
   )
 
   // Margins
@@ -98,15 +102,21 @@ function layoutVertical(chart: XYChart): PositionedXYChart {
   // Y-axis ticks
   const yAxisTicks: AxisTick[] = yTicks.map(v => ({
     label: formatTickValue(v),
-    x: left, y: yScale(v),
-    tx: left - XY.tickLength, ty: yScale(v),
-    labelX: left - XY.yLabelGap, labelY: yScale(v),
+    x: left,
+    y: yScale(v),
+    tx: left - XY.tickLength,
+    ty: yScale(v),
+    labelX: left - XY.yLabelGap,
+    labelY: yScale(v),
     textAnchor: 'end' as const,
   }))
 
   // Grid lines (horizontal at each y tick)
   const gridLines: GridLine[] = yTicks.map(v => ({
-    x1: left, y1: yScale(v), x2: left + plotW, y2: yScale(v),
+    x1: left,
+    y1: yScale(v),
+    x2: left + plotW,
+    y2: yScale(v),
   }))
 
   // Category labels for data attributes
@@ -126,25 +136,58 @@ function layoutVertical(chart: XYChart): PositionedXYChart {
   const legend = hasLegend ? buildLegendItems(chart, totalW / 2, legendY, colorMap) : []
 
   // Axis lines
-  const xAxisLine = { x1: left, y1: top + plotH, x2: left + plotW, y2: top + plotH }
+  const xAxisLine = {
+    x1: left,
+    y1: top + plotH,
+    x2: left + plotW,
+    y2: top + plotH,
+  }
   const yAxisLine = { x1: left, y1: top, x2: left, y2: top + plotH }
 
   // Axis titles
   const xAxisObj: PositionedAxis = {
     ticks: xTicks,
     line: xAxisLine,
-    ...(hasXTitle ? { title: { text: chart.xAxis.title!, x: left + plotW / 2, y: totalH - XY.padding } } : {}),
+    ...(hasXTitle
+      ? {
+          title: {
+            text: chart.xAxis.title!,
+            x: left + plotW / 2,
+            y: totalH - XY.padding,
+          },
+        }
+      : {}),
   }
   const yAxisObj: PositionedAxis = {
     ticks: yAxisTicks,
     line: yAxisLine,
-    ...(hasYTitle ? { title: { text: chart.yAxis.title!, x: XY.padding + 4, y: top + plotH / 2, rotate: -90 } } : {}),
+    ...(hasYTitle
+      ? {
+          title: {
+            text: chart.yAxis.title!,
+            x: XY.padding + 4,
+            y: top + plotH / 2,
+            rotate: -90,
+          },
+        }
+      : {}),
   }
 
   // Title
   const titleObj = hasTitle ? { text: chart.title!, x: totalW / 2, y: XY.padding + XY.titleFontSize } : undefined
 
-  return { width: totalW, height: totalH, title: titleObj, xAxis: xAxisObj, yAxis: yAxisObj, plotArea, bars, lines, gridLines, legend }
+  return {
+    width: totalW,
+    height: totalH,
+    title: titleObj,
+    xAxis: xAxisObj,
+    yAxis: yAxisObj,
+    plotArea,
+    bars,
+    lines,
+    gridLines,
+    legend,
+  }
 }
 
 // ============================================================================
@@ -166,7 +209,7 @@ function layoutHorizontal(chart: XYChart): PositionedXYChart {
   const catLabels = getCategoryLabels(chart, dataCount)
   const maxCatLabelWidth = Math.max(
     ...catLabels.map(l => estimateTextWidth(l, XY.axisLabelFontSize, XY.axisLabelFontWeight)),
-    40
+    40,
   )
 
   const top = XY.padding + (hasTitle ? XY.titleHeight : 0) + (hasLegend ? XY.legendHeight : 0)
@@ -194,24 +237,33 @@ function layoutHorizontal(chart: XYChart): PositionedXYChart {
   // X-axis (bottom): value ticks
   const xTicks: AxisTick[] = valueTicks.map(v => ({
     label: formatTickValue(v),
-    x: valueScale(v), y: top + plotH,
-    tx: valueScale(v), ty: top + plotH + XY.tickLength,
-    labelX: valueScale(v), labelY: top + plotH + 18,
+    x: valueScale(v),
+    y: top + plotH,
+    tx: valueScale(v),
+    ty: top + plotH + XY.tickLength,
+    labelX: valueScale(v),
+    labelY: top + plotH + 18,
     textAnchor: 'middle' as const,
   }))
 
   // Y-axis (left): category ticks
   const yTicks: AxisTick[] = catLabels.map((label, i) => ({
     label,
-    x: left, y: catScale(i),
-    tx: left - XY.tickLength, ty: catScale(i),
-    labelX: left - XY.yLabelGap, labelY: catScale(i),
+    x: left,
+    y: catScale(i),
+    tx: left - XY.tickLength,
+    ty: catScale(i),
+    labelX: left - XY.yLabelGap,
+    labelY: catScale(i),
     textAnchor: 'end' as const,
   }))
 
   // Grid lines (vertical at each value tick)
   const gridLines: GridLine[] = valueTicks.map(v => ({
-    x1: valueScale(v), y1: top, x2: valueScale(v), y2: top + plotH,
+    x1: valueScale(v),
+    y1: top,
+    x2: valueScale(v),
+    y2: top + plotH,
   }))
 
   // Global color index map
@@ -225,13 +277,14 @@ function layoutHorizontal(chart: XYChart): PositionedXYChart {
     const usable = bandHeight * (1 - XY.barPadRatio)
     const rawBarH = barCount > 1 ? (usable - (barCount - 1) * XY.barGroupGap) / barCount : usable
     const singleBarH = Math.min(rawBarH, XY.maxBarWidth)
-    const groupH = barCount > 1
-      ? singleBarH * barCount + XY.barGroupGap * (barCount - 1)
-      : singleBarH
+    const groupH = barCount > 1 ? singleBarH * barCount + XY.barGroupGap * (barCount - 1) : singleBarH
     let bIdx = 0
     let seriesArrayIdx = 0
     for (const s of chart.series) {
-      if (s.type !== 'bar') { seriesArrayIdx++; continue }
+      if (s.type !== 'bar') {
+        seriesArrayIdx++
+        continue
+      }
       for (let i = 0; i < s.data.length; i++) {
         const cy = catScale(i)
         const groupTop = cy - groupH / 2
@@ -259,26 +312,60 @@ function layoutHorizontal(chart: XYChart): PositionedXYChart {
   let lineIdx = 0
   let lineSeriesIdx = 0
   for (const s of chart.series) {
-    if (s.type !== 'line') { lineSeriesIdx++; continue }
-    const points = s.data.map((v, i) => ({ x: valueScale(v), y: catScale(i), value: v, label: catLabels[i]! }))
-    lines.push({ points, seriesIndex: lineIdx, colorIndex: colorMap[lineSeriesIdx]! })
+    if (s.type !== 'line') {
+      lineSeriesIdx++
+      continue
+    }
+    const points = s.data.map((v, i) => ({
+      x: valueScale(v),
+      y: catScale(i),
+      value: v,
+      label: catLabels[i]!,
+    }))
+    lines.push({
+      points,
+      seriesIndex: lineIdx,
+      colorIndex: colorMap[lineSeriesIdx]!,
+    })
     lineIdx++
     lineSeriesIdx++
   }
 
-  const xAxisLine = { x1: left, y1: top + plotH, x2: left + plotW, y2: top + plotH }
+  const xAxisLine = {
+    x1: left,
+    y1: top + plotH,
+    x2: left + plotW,
+    y2: top + plotH,
+  }
   const yAxisLine = { x1: left, y1: top, x2: left, y2: top + plotH }
 
   // In horizontal mode, the "y-axis" title describes values (bottom) and "x-axis" title describes categories (left)
   const xAxisObj: PositionedAxis = {
     ticks: xTicks,
     line: xAxisLine,
-    ...(hasYTitle ? { title: { text: chart.yAxis.title!, x: left + plotW / 2, y: totalH - XY.padding } } : {}),
+    ...(hasYTitle
+      ? {
+          title: {
+            text: chart.yAxis.title!,
+            x: left + plotW / 2,
+            y: totalH - XY.padding,
+          },
+        }
+      : {}),
   }
   const yAxisObj: PositionedAxis = {
     ticks: yTicks,
     line: yAxisLine,
-    ...(hasXTitle ? { title: { text: chart.xAxis.title!, x: XY.padding + 4, y: top + plotH / 2, rotate: -90 } } : {}),
+    ...(hasXTitle
+      ? {
+          title: {
+            text: chart.xAxis.title!,
+            x: XY.padding + 4,
+            y: top + plotH / 2,
+            rotate: -90,
+          },
+        }
+      : {}),
   }
 
   const titleObj = hasTitle ? { text: chart.title!, x: totalW / 2, y: XY.padding + XY.titleFontSize } : undefined
@@ -287,7 +374,19 @@ function layoutHorizontal(chart: XYChart): PositionedXYChart {
   const legendY = XY.padding + (hasTitle ? XY.titleHeight : 0) + XY.legendHeight / 2
   const legend = hasLegend ? buildLegendItems(chart, totalW / 2, legendY, colorMap) : []
 
-  return { width: totalW, height: totalH, horizontal: true, title: titleObj, xAxis: xAxisObj, yAxis: yAxisObj, plotArea, bars, lines, gridLines, legend }
+  return {
+    width: totalW,
+    height: totalH,
+    horizontal: true,
+    title: titleObj,
+    xAxis: xAxisObj,
+    yAxis: yAxisObj,
+    plotArea,
+    bars,
+    lines,
+    gridLines,
+    legend,
+  }
 }
 
 // ============================================================================
@@ -318,16 +417,24 @@ function buildXTicks(chart: XYChart, xScale: (i: number) => number, axisY: numbe
   const labels = getCategoryLabels(chart, count)
   return labels.map((label, i) => ({
     label,
-    x: xScale(i), y: axisY,
-    tx: xScale(i), ty: axisY + XY.tickLength,
-    labelX: xScale(i), labelY: axisY + 18,
+    x: xScale(i),
+    y: axisY,
+    tx: xScale(i),
+    ty: axisY + XY.tickLength,
+    labelX: xScale(i),
+    labelY: axisY + 18,
     textAnchor: 'middle' as const,
   }))
 }
 
 function layoutBars(
-  chart: XYChart, xScale: (i: number) => number, yScale: (v: number) => number,
-  bandWidth: number, yMin: number, catLabels: string[], colorMap: number[],
+  chart: XYChart,
+  xScale: (i: number) => number,
+  yScale: (v: number) => number,
+  bandWidth: number,
+  yMin: number,
+  catLabels: string[],
+  colorMap: number[],
 ): PositionedBar[] {
   const barSeries = chart.series.filter(s => s.type === 'bar')
   const barCount = barSeries.length
@@ -336,15 +443,16 @@ function layoutBars(
   const usable = bandWidth * (1 - XY.barPadRatio)
   const rawBarW = barCount > 1 ? (usable - (barCount - 1) * XY.barGroupGap) / barCount : usable
   const singleBarW = Math.min(rawBarW, XY.maxBarWidth)
-  const groupW = barCount > 1
-    ? singleBarW * barCount + XY.barGroupGap * (barCount - 1)
-    : singleBarW
+  const groupW = barCount > 1 ? singleBarW * barCount + XY.barGroupGap * (barCount - 1) : singleBarW
   const bars: PositionedBar[] = []
 
   let bIdx = 0
   let seriesArrayIdx = 0
   for (const s of chart.series) {
-    if (s.type !== 'bar') { seriesArrayIdx++; continue }
+    if (s.type !== 'bar') {
+      seriesArrayIdx++
+      continue
+    }
     for (let i = 0; i < s.data.length; i++) {
       const cx = xScale(i)
       const groupLeft = cx - groupW / 2
@@ -368,14 +476,32 @@ function layoutBars(
   return bars
 }
 
-function layoutLines(chart: XYChart, xScale: (i: number) => number, yScale: (v: number) => number, catLabels: string[], colorMap: number[]): PositionedLine[] {
+function layoutLines(
+  chart: XYChart,
+  xScale: (i: number) => number,
+  yScale: (v: number) => number,
+  catLabels: string[],
+  colorMap: number[],
+): PositionedLine[] {
   const lines: PositionedLine[] = []
   let lineIdx = 0
   let seriesArrayIdx = 0
   for (const s of chart.series) {
-    if (s.type !== 'line') { seriesArrayIdx++; continue }
-    const points = s.data.map((v, i) => ({ x: xScale(i), y: yScale(v), value: v, label: catLabels[i]! }))
-    lines.push({ points, seriesIndex: lineIdx, colorIndex: colorMap[seriesArrayIdx]! })
+    if (s.type !== 'line') {
+      seriesArrayIdx++
+      continue
+    }
+    const points = s.data.map((v, i) => ({
+      x: xScale(i),
+      y: yScale(v),
+      value: v,
+      label: catLabels[i]!,
+    }))
+    lines.push({
+      points,
+      seriesIndex: lineIdx,
+      colorIndex: colorMap[seriesArrayIdx]!,
+    })
     lineIdx++
     seriesArrayIdx++
   }
@@ -389,7 +515,7 @@ function niceTickValues(min: number, max: number): number[] {
 
   // Find nice interval
   const rawInterval = range / 6
-  const magnitude = Math.pow(10, Math.floor(Math.log10(rawInterval)))
+  const magnitude = 10 ** Math.floor(Math.log10(rawInterval))
   const residual = rawInterval / magnitude
   let niceInterval: number
   if (residual <= 1.5) niceInterval = magnitude
@@ -414,11 +540,19 @@ function formatTickValue(v: number): string {
 /** Build centered legend items for multi-series charts */
 function buildLegendItems(chart: XYChart, centerX: number, y: number, colorMap: number[]): LegendItem[] {
   const items: LegendItem[] = []
-  let barIdx = 0, lineIdx = 0
+  let barIdx = 0,
+    lineIdx = 0
   for (let si = 0; si < chart.series.length; si++) {
     const s = chart.series[si]!
     const label = s.type === 'bar' ? `Bar ${barIdx + 1}` : `Line ${lineIdx + 1}`
-    items.push({ label, x: 0, y, type: s.type, seriesIndex: s.type === 'bar' ? barIdx : lineIdx, colorIndex: colorMap[si]! })
+    items.push({
+      label,
+      x: 0,
+      y,
+      type: s.type,
+      seriesIndex: s.type === 'bar' ? barIdx : lineIdx,
+      colorIndex: colorMap[si]!,
+    })
     if (s.type === 'bar') barIdx++
     else lineIdx++
   }

--- a/src/xychart/parser.ts
+++ b/src/xychart/parser.ts
@@ -1,4 +1,4 @@
-import type { XYChart, XYAxis, XYChartSeries } from './types.ts'
+import type { XYAxis, XYChart, XYChartSeries } from './types.ts'
 
 // ============================================================================
 // XY Chart parser
@@ -54,7 +54,10 @@ export function parseXYChart(lines: string[]): XYChart {
     const xRangeMatch = line.match(/^x-axis\s+(?:"([^"]*)"\s+)?(-?\d+(?:\.\d+)?)\s*-->\s*(-?\d+(?:\.\d+)?)/)
     if (xRangeMatch) {
       if (xRangeMatch[1]) xAxis.title = xRangeMatch[1]
-      xAxis.range = { min: parseFloat(xRangeMatch[2]!), max: parseFloat(xRangeMatch[3]!) }
+      xAxis.range = {
+        min: parseFloat(xRangeMatch[2]!),
+        max: parseFloat(xRangeMatch[3]!),
+      }
       continue
     }
 
@@ -62,7 +65,10 @@ export function parseXYChart(lines: string[]): XYChart {
     const yRangeMatch = line.match(/^y-axis\s+(?:"([^"]*)"\s+)?(-?\d+(?:\.\d+)?)\s*-->\s*(-?\d+(?:\.\d+)?)/)
     if (yRangeMatch) {
       if (yRangeMatch[1]) yAxis.title = yRangeMatch[1]
-      yAxis.range = { min: parseFloat(yRangeMatch[2]!), max: parseFloat(yRangeMatch[3]!) }
+      yAxis.range = {
+        min: parseFloat(yRangeMatch[2]!),
+        max: parseFloat(yRangeMatch[3]!),
+      }
       continue
     }
 
@@ -84,7 +90,6 @@ export function parseXYChart(lines: string[]): XYChart {
     const lineMatch = line.match(/^line\s+\[([^\]]+)\]/)
     if (lineMatch) {
       series.push({ type: 'line', data: parseNumericArray(lineMatch[1]!) })
-      continue
     }
   }
 

--- a/src/xychart/renderer.ts
+++ b/src/xychart/renderer.ts
@@ -1,8 +1,8 @@
-import type { PositionedXYChart } from './types.ts'
+import { estimateTextWidth, TEXT_BASELINE_SHIFT } from '../styles.ts'
 import type { DiagramColors } from '../theme.ts'
-import { svgOpenTag, buildStyleBlock } from '../theme.ts'
-import { TEXT_BASELINE_SHIFT, estimateTextWidth } from '../styles.ts'
-import { getSeriesColor, CHART_ACCENT_FALLBACK } from './colors.ts'
+import { buildStyleBlock, svgOpenTag } from '../theme.ts'
+import { CHART_ACCENT_FALLBACK, getSeriesColor } from './colors.ts'
+import type { PositionedXYChart } from './types.ts'
 
 // ============================================================================
 // XY Chart SVG renderer
@@ -67,8 +67,10 @@ export function renderXYChartSvg(
   // SVG root + base styles
   // Stamp data-xychart-colors so theme-switching JS knows how many series color vars to update
   const maxColorIdx = Math.max(0, ...chart.bars.map(b => b.colorIndex), ...chart.lines.map(l => l.colorIndex))
-  const svgTag = svgOpenTag(chart.width, chart.height, colors, transparent)
-    .replace('<svg ', `<svg data-xychart-colors="${maxColorIdx}" `)
+  const svgTag = svgOpenTag(chart.width, chart.height, colors, transparent).replace(
+    '<svg ',
+    `<svg data-xychart-colors="${maxColorIdx}" `,
+  )
   parts.push(svgTag)
   parts.push(buildStyleBlock(font, false))
 
@@ -84,9 +86,7 @@ export function renderXYChartSvg(
   // 1. Dot grid (dense dots across plot area, aligned to tick spacing)
   const { plotArea } = chart
   const xTicks = chart.xAxis.ticks.map(t => t.x)
-  const yVals = chart.horizontal
-    ? chart.yAxis.ticks.map(t => t.y)
-    : chart.gridLines.map(g => g.y1)
+  const yVals = chart.horizontal ? chart.yAxis.ticks.map(t => t.y) : chart.gridLines.map(g => g.y1)
   const xBase = xTicks.length > 1 ? Math.abs(xTicks[1]! - xTicks[0]!) : plotArea.width / 6
   const yBase = yVals.length > 1 ? Math.abs(yVals[1]! - yVals[0]!) : plotArea.height / 6
   const xGap = xBase / Math.max(1, Math.round(xBase / 20))
@@ -109,19 +109,17 @@ export function renderXYChartSvg(
     const barPath = chart.horizontal
       ? roundedRightBarPath(bar.x, bar.y, bar.width, bar.height, CHART_FONT.barRadius)
       : roundedTopBarPath(bar.x, bar.y, bar.width, bar.height, CHART_FONT.barRadius)
-    parts.push(
-      `<path d="${barPath}" class="xychart-bar xychart-color-${bar.colorIndex}"${dataAttrs}/>`
-    )
+    parts.push(`<path d="${barPath}" class="xychart-bar xychart-color-${bar.colorIndex}"${dataAttrs}/>`)
     if (interactive) {
       const tipText = formatTipValue(bar.value)
       const tipTitle = bar.label ? `${bar.label}: ${tipText}` : tipText
       const tip = tooltipAbove(bar.x + bar.width / 2, bar.y, tipText)
       barOverlay.push(
         `<g class="xychart-bar-group">` +
-        `<rect x="${r(bar.x)}" y="${r(bar.y)}" width="${r(bar.width)}" height="${r(bar.height)}" fill="transparent"/>` +
-        `<title>${escapeXml(tipTitle)}</title>` +
-        tip +
-        `</g>`
+          `<rect x="${r(bar.x)}" y="${r(bar.y)}" width="${r(bar.width)}" height="${r(bar.height)}" fill="transparent"/>` +
+          `<title>${escapeXml(tipTitle)}</title>` +
+          tip +
+          `</g>`,
       )
     }
   }
@@ -130,7 +128,9 @@ export function renderXYChartSvg(
   for (const line of chart.lines) {
     if (line.points.length === 0) continue
     const d = smoothCurvePath(line.points)
-    parts.push(`<path d="${d}" class="xychart-line-shadow xychart-color-${line.colorIndex}" transform="translate(0,2)"/>`)
+    parts.push(
+      `<path d="${d}" class="xychart-line-shadow xychart-color-${line.colorIndex}" transform="translate(0,2)"/>`,
+    )
     parts.push(`<path d="${d}" class="xychart-line xychart-color-${line.colorIndex}"/>`)
   }
 
@@ -143,14 +143,28 @@ export function renderXYChartSvg(
       if (item.type === 'line') lineLegendLabels.set(item.seriesIndex, item.label)
     }
 
-    type DotEntry = { x: number; y: number; value: number; label?: string; seriesIndex: number; colorIndex: number }
+    type DotEntry = {
+      x: number
+      y: number
+      value: number
+      label?: string
+      seriesIndex: number
+      colorIndex: number
+    }
     const columns = new Map<string, DotEntry[]>()
 
     for (const line of chart.lines) {
       for (const p of line.points) {
         const key = r(p.x)
         if (!columns.has(key)) columns.set(key, [])
-        columns.get(key)!.push({ x: p.x, y: p.y, value: p.value, label: p.label, seriesIndex: line.seriesIndex, colorIndex: line.colorIndex })
+        columns.get(key)!.push({
+          x: p.x,
+          y: p.y,
+          value: p.value,
+          label: p.label,
+          seriesIndex: line.seriesIndex,
+          colorIndex: line.colorIndex,
+        })
       }
     }
 
@@ -178,7 +192,6 @@ export function renderXYChartSvg(
         }
         group += `<title>${escapeXml(titleText)}</title>${tip}</g>`
         dotOverlay.push(group)
-
       } else if (interactive) {
         const e = entries[0]!
         const dataAttrs = ` data-value="${e.value}"${e.label ? ` data-label="${escapeXml(e.label)}"` : ''}`
@@ -190,16 +203,15 @@ export function renderXYChartSvg(
           : ''
         dotOverlay.push(
           `<g class="xychart-dot-group">${hitArea}` +
-          `<circle cx="${r(e.x)}" cy="${r(e.y)}" r="${CHART_FONT.dotRadius}" class="xychart-dot xychart-color-${e.colorIndex}"${dataAttrs}/>` +
-          `<title>${escapeXml(tipTitle)}</title>${tip}</g>`
+            `<circle cx="${r(e.x)}" cy="${r(e.y)}" r="${CHART_FONT.dotRadius}" class="xychart-dot xychart-color-${e.colorIndex}"${dataAttrs}/>` +
+            `<title>${escapeXml(tipTitle)}</title>${tip}</g>`,
         )
-
       } else {
         // Sparse, not interactive: static dots render inline
         for (const e of entries) {
           const dataAttrs = ` data-value="${e.value}"${e.label ? ` data-label="${escapeXml(e.label)}"` : ''}`
           parts.push(
-            `<circle cx="${r(e.x)}" cy="${r(e.y)}" r="${CHART_FONT.dotRadius}" class="xychart-dot xychart-color-${e.colorIndex}"${dataAttrs}/>`
+            `<circle cx="${r(e.x)}" cy="${r(e.y)}" r="${CHART_FONT.dotRadius}" class="xychart-dot xychart-color-${e.colorIndex}"${dataAttrs}/>`,
           )
         }
       }
@@ -210,15 +222,15 @@ export function renderXYChartSvg(
   for (const tick of chart.xAxis.ticks) {
     parts.push(
       `<text x="${tick.labelX}" y="${tick.labelY}" text-anchor="${tick.textAnchor}" ` +
-      `font-size="${CHART_FONT.labelSize}" font-weight="${CHART_FONT.labelWeight}" ` +
-      `dy="${TEXT_BASELINE_SHIFT}" class="xychart-label">${escapeXml(tick.label)}</text>`
+        `font-size="${CHART_FONT.labelSize}" font-weight="${CHART_FONT.labelWeight}" ` +
+        `dy="${TEXT_BASELINE_SHIFT}" class="xychart-label">${escapeXml(tick.label)}</text>`,
     )
   }
   for (const tick of chart.yAxis.ticks) {
     parts.push(
       `<text x="${tick.labelX}" y="${tick.labelY}" text-anchor="${tick.textAnchor}" ` +
-      `font-size="${CHART_FONT.labelSize}" font-weight="${CHART_FONT.labelWeight}" ` +
-      `dy="${TEXT_BASELINE_SHIFT}" class="xychart-label">${escapeXml(tick.label)}</text>`
+        `font-size="${CHART_FONT.labelSize}" font-weight="${CHART_FONT.labelWeight}" ` +
+        `dy="${TEXT_BASELINE_SHIFT}" class="xychart-label">${escapeXml(tick.label)}</text>`,
     )
   }
 
@@ -228,8 +240,8 @@ export function renderXYChartSvg(
     const transform = t.rotate ? ` transform="rotate(${t.rotate},${t.x},${t.y})"` : ''
     parts.push(
       `<text x="${t.x}" y="${t.y}" text-anchor="middle"${transform} ` +
-      `font-size="${CHART_FONT.axisTitleSize}" font-weight="${CHART_FONT.axisTitleWeight}" ` +
-      `dy="${TEXT_BASELINE_SHIFT}" class="xychart-axis-title">${escapeXml(t.text)}</text>`
+        `font-size="${CHART_FONT.axisTitleSize}" font-weight="${CHART_FONT.axisTitleWeight}" ` +
+        `dy="${TEXT_BASELINE_SHIFT}" class="xychart-axis-title">${escapeXml(t.text)}</text>`,
     )
   }
   if (chart.yAxis.title) {
@@ -237,8 +249,8 @@ export function renderXYChartSvg(
     const transform = t.rotate ? ` transform="rotate(${t.rotate},${t.x},${t.y})"` : ''
     parts.push(
       `<text x="${t.x}" y="${t.y}" text-anchor="middle"${transform} ` +
-      `font-size="${CHART_FONT.axisTitleSize}" font-weight="${CHART_FONT.axisTitleWeight}" ` +
-      `dy="${TEXT_BASELINE_SHIFT}" class="xychart-axis-title">${escapeXml(t.text)}</text>`
+        `font-size="${CHART_FONT.axisTitleSize}" font-weight="${CHART_FONT.axisTitleWeight}" ` +
+        `dy="${TEXT_BASELINE_SHIFT}" class="xychart-axis-title">${escapeXml(t.text)}</text>`,
     )
   }
 
@@ -246,31 +258,32 @@ export function renderXYChartSvg(
   if (chart.title) {
     parts.push(
       `<text x="${chart.title.x}" y="${chart.title.y}" text-anchor="middle" ` +
-      `font-size="${CHART_FONT.titleSize}" font-weight="${CHART_FONT.titleWeight}" ` +
-      `dy="${TEXT_BASELINE_SHIFT}" class="xychart-title">${escapeXml(chart.title.text)}</text>`
+        `font-size="${CHART_FONT.titleSize}" font-weight="${CHART_FONT.titleWeight}" ` +
+        `dy="${TEXT_BASELINE_SHIFT}" class="xychart-title">${escapeXml(chart.title.text)}</text>`,
     )
   }
 
   // 8. Legend
   for (const item of chart.legend) {
-    const swatchW = 14, swatchH = 14
+    const swatchW = 14,
+      swatchH = 14
     const gap = 6
     if (item.type === 'bar') {
       parts.push(
         `<rect x="${item.x}" y="${item.y - swatchH / 2}" width="${swatchW}" height="${swatchH}" rx="3" ` +
-        `class="xychart-bar xychart-color-${item.colorIndex}"/>`
+          `class="xychart-bar xychart-color-${item.colorIndex}"/>`,
       )
     } else {
       const ly = item.y
       parts.push(
         `<line x1="${item.x}" y1="${ly}" x2="${item.x + swatchW}" y2="${ly}" ` +
-        `stroke-width="${CHART_FONT.lineWidth}" stroke-linecap="round" class="xychart-legend-line xychart-color-${item.colorIndex}"/>`
+          `stroke-width="${CHART_FONT.lineWidth}" stroke-linecap="round" class="xychart-legend-line xychart-color-${item.colorIndex}"/>`,
       )
     }
     parts.push(
       `<text x="${item.x + swatchW + gap}" y="${item.y}" text-anchor="start" ` +
-      `font-size="${CHART_FONT.legendSize}" font-weight="${CHART_FONT.legendWeight}" ` +
-      `dy="${TEXT_BASELINE_SHIFT}" class="xychart-label">${escapeXml(item.label)}</text>`
+        `font-size="${CHART_FONT.legendSize}" font-weight="${CHART_FONT.legendWeight}" ` +
+        `dy="${TEXT_BASELINE_SHIFT}" class="xychart-label">${escapeXml(item.label)}</text>`,
     )
   }
 
@@ -286,7 +299,13 @@ export function renderXYChartSvg(
 // Chart-specific CSS styles
 // ============================================================================
 
-function chartStyles(chart: PositionedXYChart, interactive: boolean, sparse: boolean, themeAccent?: string, bgColor?: string): { style: string; defs: string } {
+function chartStyles(
+  chart: PositionedXYChart,
+  interactive: boolean,
+  _sparse: boolean,
+  themeAccent?: string,
+  bgColor?: string,
+): { style: string; defs: string } {
   const accentHex = themeAccent ?? CHART_ACCENT_FALLBACK
 
   // Collect all unique global color indices from bars + lines
@@ -298,11 +317,11 @@ function chartStyles(chart: PositionedXYChart, interactive: boolean, sparse: boo
   // Also define --xychart-bar-fill-N via color-mix() so it stays dynamic on theme change
   const colorVarDefs: string[] = []
   for (const idx of [...colorIndices].sort((a, b) => a - b)) {
-    const value = idx === 0
-      ? `var(--accent, ${CHART_ACCENT_FALLBACK})`
-      : getSeriesColor(idx, accentHex, bgColor)
+    const value = idx === 0 ? `var(--accent, ${CHART_ACCENT_FALLBACK})` : getSeriesColor(idx, accentHex, bgColor)
     colorVarDefs.push(`    --xychart-color-${idx}: ${value};`)
-    colorVarDefs.push(`    --xychart-bar-fill-${idx}: color-mix(in srgb, var(--bg) 75%, var(--xychart-color-${idx}) 25%);`)
+    colorVarDefs.push(
+      `    --xychart-bar-fill-${idx}: color-mix(in srgb, var(--bg) 75%, var(--xychart-color-${idx}) 25%);`,
+    )
   }
 
   // Generate unified color rules — one per global index, referencing the CSS vars
@@ -316,13 +335,15 @@ function chartStyles(chart: PositionedXYChart, interactive: boolean, sparse: boo
     seriesRules.push(`  circle.xychart-color-${idx} { fill: ${color}; }`)
   }
 
-  const tipRules = interactive ? `
+  const tipRules = interactive
+    ? `
   .xychart-tip { opacity: 0; pointer-events: none; }
   .xychart-tip-bg { fill: var(--_text); filter: drop-shadow(0 1px 3px color-mix(in srgb, var(--fg) 20%, transparent)); }
   .xychart-tip-text { fill: var(--bg); font-size: ${TIP.fontSize}px; font-weight: ${TIP.fontWeight}; }
   .xychart-tip-ptr { fill: var(--_text); }
   .xychart-bar-group:hover .xychart-tip,
-  .xychart-dot-group:hover .xychart-tip { opacity: 1; }` : ''
+  .xychart-dot-group:hover .xychart-tip { opacity: 1; }`
+    : ''
 
   const colorVarsBlock = colorVarDefs.length > 0 ? `\n  svg {\n${colorVarDefs.join('\n')}\n  }` : ''
 
@@ -341,7 +362,6 @@ ${seriesRules.join('\n')}${tipRules}
   return { style, defs: '' }
 }
 
-
 // ============================================================================
 // Bar path with all corners rounded
 // ============================================================================
@@ -352,14 +372,14 @@ function roundedTopBarPath(x: number, y: number, w: number, h: number, radius: n
     return `M${r(x)},${r(y)} h${r(w)} v${r(h)} h${r(-w)} Z`
   }
   return [
-    `M${r(x)},${r(y + rr)}`,                                   // start below top-left
-    `Q${r(x)},${r(y)} ${r(x + rr)},${r(y)}`,                   // top-left
-    `L${r(x + w - rr)},${r(y)}`,                                // top edge
-    `Q${r(x + w)},${r(y)} ${r(x + w)},${r(y + rr)}`,           // top-right
-    `L${r(x + w)},${r(y + h - rr)}`,                            // right edge
-    `Q${r(x + w)},${r(y + h)} ${r(x + w - rr)},${r(y + h)}`,   // bottom-right
-    `L${r(x + rr)},${r(y + h)}`,                                // bottom edge
-    `Q${r(x)},${r(y + h)} ${r(x)},${r(y + h - rr)}`,           // bottom-left
+    `M${r(x)},${r(y + rr)}`, // start below top-left
+    `Q${r(x)},${r(y)} ${r(x + rr)},${r(y)}`, // top-left
+    `L${r(x + w - rr)},${r(y)}`, // top edge
+    `Q${r(x + w)},${r(y)} ${r(x + w)},${r(y + rr)}`, // top-right
+    `L${r(x + w)},${r(y + h - rr)}`, // right edge
+    `Q${r(x + w)},${r(y + h)} ${r(x + w - rr)},${r(y + h)}`, // bottom-right
+    `L${r(x + rr)},${r(y + h)}`, // bottom edge
+    `Q${r(x)},${r(y + h)} ${r(x)},${r(y + h - rr)}`, // bottom-left
     'Z',
   ].join(' ')
 }
@@ -374,15 +394,15 @@ function roundedRightBarPath(x: number, y: number, w: number, h: number, radius:
     return `M${r(x)},${r(y)} h${r(w)} v${r(h)} h${r(-w)} Z`
   }
   return [
-    `M${r(x + rr)},${r(y)}`,                                    // start after top-left
-    `L${r(x + w - rr)},${r(y)}`,                                // top edge
-    `Q${r(x + w)},${r(y)} ${r(x + w)},${r(y + rr)}`,           // top-right
-    `L${r(x + w)},${r(y + h - rr)}`,                            // right edge
-    `Q${r(x + w)},${r(y + h)} ${r(x + w - rr)},${r(y + h)}`,   // bottom-right
-    `L${r(x + rr)},${r(y + h)}`,                                // bottom edge
-    `Q${r(x)},${r(y + h)} ${r(x)},${r(y + h - rr)}`,           // bottom-left
-    `L${r(x)},${r(y + rr)}`,                                    // left edge
-    `Q${r(x)},${r(y)} ${r(x + rr)},${r(y)}`,                   // top-left
+    `M${r(x + rr)},${r(y)}`, // start after top-left
+    `L${r(x + w - rr)},${r(y)}`, // top edge
+    `Q${r(x + w)},${r(y)} ${r(x + w)},${r(y + rr)}`, // top-right
+    `L${r(x + w)},${r(y + h - rr)}`, // right edge
+    `Q${r(x + w)},${r(y + h)} ${r(x + w - rr)},${r(y + h)}`, // bottom-right
+    `L${r(x + rr)},${r(y + h)}`, // bottom edge
+    `Q${r(x)},${r(y + h)} ${r(x)},${r(y + h - rr)}`, // bottom-left
+    `L${r(x)},${r(y + rr)}`, // left edge
+    `Q${r(x)},${r(y)} ${r(x + rr)},${r(y)}`, // top-left
     'Z',
   ].join(' ')
 }
@@ -442,10 +462,10 @@ function smoothCurvePath(points: Array<{ x: number; y: number }>): string {
   // 3. Compute first derivatives (slopes) at each knot
   const slopes = new Array<number>(n).fill(0)
   for (let i = 0; i < n - 1; i++) {
-    slopes[i] = delta[i]! - h[i]! * (2 * c[i]! + c[i + 1]!) / 3
+    slopes[i] = delta[i]! - (h[i]! * (2 * c[i]! + c[i + 1]!)) / 3
   }
   // Slope at last point: derivative of last segment at its end
-  slopes[n - 1] = delta[n - 2]! + h[n - 2]! * (c[n - 2]!) / 3
+  slopes[n - 1] = delta[n - 2]! + (h[n - 2]! * c[n - 2]!) / 3
 
   // 4. Convert to cubic Bezier — control points strictly between endpoints in x
   let path = `M${r(points[0]!.x)},${r(points[0]!.y)}`
@@ -468,16 +488,23 @@ function smoothCurvePath(points: Array<{ x: number; y: number }>): string {
 /**
  * Multi-value tooltip: category label on top, each series value below with legend text label.
  */
-function multiTooltipAbove(cx: number, topY: number, label: string, entries: Array<{ text: string; legendLabel: string }>): string {
+function multiTooltipAbove(
+  cx: number,
+  topY: number,
+  label: string,
+  entries: Array<{ text: string; legendLabel: string }>,
+): string {
   const lineH = 20
   const padY = 6
   const labelGap = 10
   const headingW = estimateTextWidth(label, TIP.fontSize, 600)
-  const maxRowW = Math.max(...entries.map(e => {
-    const legendW = estimateTextWidth(e.legendLabel, TIP.fontSize, TIP.fontWeight)
-    const valW = estimateTextWidth(e.text, TIP.fontSize, TIP.fontWeight)
-    return legendW + labelGap + valW
-  }))
+  const maxRowW = Math.max(
+    ...entries.map(e => {
+      const legendW = estimateTextWidth(e.legendLabel, TIP.fontSize, TIP.fontWeight)
+      const valW = estimateTextWidth(e.text, TIP.fontSize, TIP.fontWeight)
+      return legendW + labelGap + valW
+    }),
+  )
   const bgW = Math.max(headingW, maxRowW) + TIP.padX * 2
   const bgH = padY + lineH + entries.length * lineH + padY
 
@@ -539,11 +566,5 @@ function r(n: number): string {
 }
 
 function escapeXml(text: string): string {
-  return text
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
+  return text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;')
 }
-
-


### PR DESCRIPTION
- Add @biomejs/biome 2.x as dev dependency
- Add biome.json config (single quotes, no semicolons, 2-space indent)
- Add lint, lint:fix, and format scripts to package.json
- Auto-fix: import ordering, let→const, template literals, unused imports
- Manual fix: unused vars, implicit any lets, forEach return values
- Remove unused HierarchicalEdgeInfo interface
- All 711 tests pass, 79 files lint clean