### PR TITLE
fix(package): define fallback entrypoint to exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     ".": {
       "bun": "./src/index.ts",
       "import": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
     }
   },
   "repository": {


### PR DESCRIPTION
Fix #73.

This change just adds `default` entry to `exports` field. This is expected to act as a fallback when no matched import rules.

By this change, `require("beautiful-mermaid")` will get to work on Node.js that supports `require(esm)` (Node.js v20.19+, v22.12+, v24).