### PR TITLE
Round all floats to 2 decimal places in SVG output

### DIFF
--- a/src/__tests__/render-utils.test.ts
+++ b/src/__tests__/render-utils.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'bun:test';
+import { f } from '../render-utils';
+
+describe('f tagged template literal', () => {
+  it('rounds floats to 2 decimal places', () => {
+    expect(f`${3.14159}`).toBe('3.14');
+    expect(f`${0.1 + 0.2}`).toBe('0.3');
+    expect(f`${1.005}`).toBe('1');
+    expect(f`${1.1}`).toBe('1.1');
+    expect(f`${2.0}`).toBe('2');
+    expect(f`M ${'A'} ${3.14159} L ${10.5} ${-20.999}`).toBe('M A 3.14 L 10.5 -21');
+  });
+
+  it('keeps integers unchanged', () => {
+    expect(f`${42}`).toBe('42');
+    expect(f`${0}`).toBe('0');
+    expect(f`${-7}`).toBe('-7');
+  });
+
+  it('passes other values strings as-is', () => {
+    expect(f`hello ${'world'}`).toBe('hello world');
+    expect(f`${'foo'}bar`).toBe('foobar');
+    expect(f`just text`).toBe('just text');
+    expect(f`${true}`).toBe('true');
+    expect(f`${null}`).toBe('null');
+    expect(f`${undefined}`).toBe('undefined');
+  });
+});

--- a/src/class/renderer.ts
+++ b/src/class/renderer.ts
@@ -1,9 +1,22 @@
-import type { PositionedClassDiagram, PositionedClassNode, PositionedClassRelationship, ClassMember, RelationshipType } from './types.ts'
-import type { DiagramColors } from '../theme.ts'
-import { svgOpenTag, buildStyleBlock } from '../theme.ts'
-import { FONT_SIZES, FONT_WEIGHTS, STROKE_WIDTHS, estimateTextWidth, TEXT_BASELINE_SHIFT } from '../styles.ts'
-import { CLS } from './layout.ts'
-import { renderMultilineText, escapeXml as escapeXmlUtil } from '../multiline-utils.ts'
+import type {
+  PositionedClassDiagram,
+  PositionedClassNode,
+  PositionedClassRelationship,
+  ClassMember,
+  RelationshipType,
+} from './types.ts';
+import type { DiagramColors } from '../theme.ts';
+import { svgOpenTag, buildStyleBlock } from '../theme.ts';
+import {
+  FONT_SIZES,
+  FONT_WEIGHTS,
+  STROKE_WIDTHS,
+  estimateTextWidth,
+  TEXT_BASELINE_SHIFT,
+} from '../styles.ts';
+import { CLS } from './layout.ts';
+import { renderMultilineText, escapeXml as escapeXmlUtil } from '../multiline-utils.ts';
+import { f } from '../render-utils.ts';
 
 // ============================================================================
 // Class diagram SVG renderer
@@ -24,7 +37,7 @@ const CLS_FONT = {
   memberWeight: 400,
   annotationSize: 10,
   annotationWeight: 500,
-} as const
+} as const;
 
 /**
  * Render a positioned class diagram as an SVG string.
@@ -36,34 +49,34 @@ export function renderClassSvg(
   diagram: PositionedClassDiagram,
   colors: DiagramColors,
   font: string = 'Inter',
-  transparent: boolean = false
+  transparent: boolean = false,
 ): string {
-  const parts: string[] = []
+  const parts: string[] = [];
 
   // SVG root with CSS variables + style block (with mono font) + defs
-  parts.push(svgOpenTag(diagram.width, diagram.height, colors, transparent))
-  parts.push(buildStyleBlock(font, true))
-  parts.push('<defs>')
-  parts.push(relationshipMarkerDefs())
-  parts.push('</defs>')
+  parts.push(svgOpenTag(diagram.width, diagram.height, colors, transparent));
+  parts.push(buildStyleBlock(font, true));
+  parts.push('<defs>');
+  parts.push(relationshipMarkerDefs());
+  parts.push('</defs>');
 
   // 1. Relationship lines (rendered behind boxes)
   for (const rel of diagram.relationships) {
-    parts.push(renderRelationship(rel))
+    parts.push(renderRelationship(rel));
   }
 
   // 2. Class boxes
   for (const cls of diagram.classes) {
-    parts.push(renderClassBox(cls))
+    parts.push(renderClassBox(cls));
   }
 
   // 3. Relationship labels and cardinality
   for (const rel of diagram.relationships) {
-    parts.push(renderRelationshipLabels(rel))
+    parts.push(renderRelationshipLabels(rel));
   }
 
-  parts.push('</svg>')
-  return parts.join('\n')
+  parts.push('</svg>');
+  return parts.join('\n');
 }
 
 // ============================================================================
@@ -100,7 +113,7 @@ function relationshipMarkerDefs(): string {
     `\n  <marker id="cls-arrow" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto-start-reverse">` +
     `\n    <polyline points="0 0, 8 3, 0 6" fill="none" stroke="var(--_arrow)" stroke-width="1.5" />` +
     `\n  </marker>`
-  )
+  );
 }
 
 // ============================================================================
@@ -112,85 +125,86 @@ function relationshipMarkerDefs(): string {
  * Wrapped in <g class="class-node"> with semantic data attributes.
  */
 function renderClassBox(cls: PositionedClassNode): string {
-  const { x, y, width, height, headerHeight, attrHeight, methodHeight } = cls
-  const parts: string[] = []
+  const { x, y, width, height, headerHeight, attrHeight, methodHeight } = cls;
+  const parts: string[] = [];
 
   // Semantic wrapper with class metadata
   // data-id: class identifier
   // data-label: class name
   // data-annotation: stereotype (interface, abstract, etc.)
-  const annotationAttr = cls.annotation ? ` data-annotation="${escapeAttr(cls.annotation)}"` : ''
+  const annotationAttr = cls.annotation ? ` data-annotation="${escapeAttr(cls.annotation)}"` : '';
   parts.push(
-    `<g class="class-node" data-id="${escapeAttr(cls.id)}" data-label="${escapeAttr(cls.label)}"${annotationAttr}>`
-  )
+    `<g class="class-node" data-id="${escapeAttr(cls.id)}" data-label="${escapeAttr(cls.label)}"${annotationAttr}>`,
+  );
 
   // Outer rectangle (full box)
   parts.push(
-    `  <rect x="${x}" y="${y}" width="${width}" height="${height}" ` +
-    `rx="0" ry="0" fill="var(--_node-fill)" stroke="var(--_node-stroke)" stroke-width="${STROKE_WIDTHS.outerBox}" />`
-  )
+    f`  <rect x="${x}" y="${y}" width="${width}" height="${height}" ` +
+      `rx="0" ry="0" fill="var(--_node-fill)" stroke="var(--_node-stroke)" stroke-width="${STROKE_WIDTHS.outerBox}" />`,
+  );
 
   // Header background
   parts.push(
-    `  <rect x="${x}" y="${y}" width="${width}" height="${headerHeight}" ` +
-    `rx="0" ry="0" fill="var(--_group-hdr)" stroke="var(--_node-stroke)" stroke-width="${STROKE_WIDTHS.outerBox}" />`
-  )
+    f`  <rect x="${x}" y="${y}" width="${width}" height="${headerHeight}" ` +
+      `rx="0" ry="0" fill="var(--_group-hdr)" stroke="var(--_node-stroke)" stroke-width="${STROKE_WIDTHS.outerBox}" />`,
+  );
 
   // Annotation (<<interface>>, <<abstract>>, etc.)
-  let nameY = y + headerHeight / 2
+  let nameY = y + headerHeight / 2;
   if (cls.annotation) {
-    const annotY = y + 12
+    const annotY = y + 12;
     parts.push(
-      `  <text x="${x + width / 2}" y="${annotY}" text-anchor="middle" dy="${TEXT_BASELINE_SHIFT}" ` +
-      `font-size="${CLS_FONT.annotationSize}" font-weight="${CLS_FONT.annotationWeight}" ` +
-      `font-style="italic" fill="var(--_text-muted)">&lt;&lt;${escapeXml(cls.annotation)}&gt;&gt;</text>`
-    )
-    nameY = y + headerHeight / 2 + 6
+      f`  <text x="${x + width / 2}" y="${annotY}" text-anchor="middle" dy="${TEXT_BASELINE_SHIFT}" ` +
+        `font-size="${CLS_FONT.annotationSize}" font-weight="${CLS_FONT.annotationWeight}" ` +
+        `font-style="italic" fill="var(--_text-muted)">&lt;&lt;${escapeXml(cls.annotation)}&gt;&gt;</text>`,
+    );
+    nameY = y + headerHeight / 2 + 6;
   }
 
   // Class name (supports multi-line via <br> tags)
   parts.push(
-    '  ' + renderMultilineText(
-      cls.label,
-      x + width / 2,
-      nameY,
-      FONT_SIZES.nodeLabel,
-      `text-anchor="middle" font-size="${FONT_SIZES.nodeLabel}" font-weight="700" fill="var(--_text)"`
-    )
-  )
+    '  ' +
+      renderMultilineText(
+        cls.label,
+        x + width / 2,
+        nameY,
+        FONT_SIZES.nodeLabel,
+        `text-anchor="middle" font-size="${FONT_SIZES.nodeLabel}" font-weight="700" fill="var(--_text)"`,
+      ),
+  );
 
   // Divider line between header and attributes
-  const attrTop = y + headerHeight
+  const attrTop = y + headerHeight;
   parts.push(
-    `  <line x1="${x}" y1="${attrTop}" x2="${x + width}" y2="${attrTop}" ` +
-    `stroke="var(--_node-stroke)" stroke-width="${STROKE_WIDTHS.innerBox}" />`
-  )
+    f`  <line x1="${x}" y1="${attrTop}" x2="${x + width}" y2="${attrTop}" ` +
+      `stroke="var(--_node-stroke)" stroke-width="${STROKE_WIDTHS.innerBox}" />`,
+  );
 
   // Attributes
-  const memberRowH = 20
+  const memberRowH = 20;
   for (let i = 0; i < cls.attributes.length; i++) {
-    const member = cls.attributes[i]!
-    const memberY = attrTop + 4 + i * memberRowH + memberRowH / 2
-    parts.push('  ' + renderMember(member, x + CLS.boxPadX, memberY))
+    const member = cls.attributes[i]!;
+    const memberY = attrTop + 4 + i * memberRowH + memberRowH / 2;
+    parts.push('  ' + renderMember(member, x + CLS.boxPadX, memberY));
   }
 
   // Divider line between attributes and methods
-  const methodTop = attrTop + attrHeight
+  const methodTop = attrTop + attrHeight;
   parts.push(
-    `  <line x1="${x}" y1="${methodTop}" x2="${x + width}" y2="${methodTop}" ` +
-    `stroke="var(--_node-stroke)" stroke-width="${STROKE_WIDTHS.innerBox}" />`
-  )
+    f`  <line x1="${x}" y1="${methodTop}" x2="${x + width}" y2="${methodTop}" ` +
+      `stroke="var(--_node-stroke)" stroke-width="${STROKE_WIDTHS.innerBox}" />`,
+  );
 
   // Methods
   for (let i = 0; i < cls.methods.length; i++) {
-    const member = cls.methods[i]!
-    const memberY = methodTop + 4 + i * memberRowH + memberRowH / 2
-    parts.push('  ' + renderMember(member, x + CLS.boxPadX, memberY))
+    const member = cls.methods[i]!;
+    const memberY = methodTop + 4 + i * memberRowH + memberRowH / 2;
+    parts.push('  ' + renderMember(member, x + CLS.boxPadX, memberY));
   }
 
-  parts.push('</g>')
+  parts.push('</g>');
 
-  return parts.join('\n')
+  return parts.join('\n');
 }
 
 /**
@@ -202,32 +216,30 @@ function renderClassBox(cls: PositionedClassNode): string {
  *   - type annotation → textMuted
  */
 function renderMember(member: ClassMember, x: number, y: number): string {
-  const fontStyle = member.isAbstract ? ' font-style="italic"' : ''
-  const decoration = member.isStatic ? ' text-decoration="underline"' : ''
+  const fontStyle = member.isAbstract ? ' font-style="italic"' : '';
+  const decoration = member.isStatic ? ' text-decoration="underline"' : '';
 
   // Build tspan parts for syntax-highlighted member text
-  const spans: string[] = []
+  const spans: string[] = [];
 
   if (member.visibility) {
-    spans.push(`<tspan fill="var(--_text-faint)">${escapeXml(member.visibility)} </tspan>`)
+    spans.push(`<tspan fill="var(--_text-faint)">${escapeXml(member.visibility)} </tspan>`);
   }
 
   // Add parentheses for methods to distinguish from attributes, including parameters if present
-  const displayName = member.isMethod
-    ? `${member.name}(${member.params || ''})`
-    : member.name
-  spans.push(`<tspan fill="var(--_text-sec)">${escapeXml(displayName)}</tspan>`)
+  const displayName = member.isMethod ? `${member.name}(${member.params || ''})` : member.name;
+  spans.push(`<tspan fill="var(--_text-sec)">${escapeXml(displayName)}</tspan>`);
 
   if (member.type) {
-    spans.push(`<tspan fill="var(--_text-faint)">: </tspan>`)
-    spans.push(`<tspan fill="var(--_text-muted)">${escapeXml(member.type)}</tspan>`)
+    spans.push(`<tspan fill="var(--_text-faint)">: </tspan>`);
+    spans.push(`<tspan fill="var(--_text-muted)">${escapeXml(member.type)}</tspan>`);
   }
 
   return (
     `<text x="${x}" y="${y}" class="mono" dy="${TEXT_BASELINE_SHIFT}" ` +
     `font-size="${CLS_FONT.memberSize}" font-weight="${CLS_FONT.memberWeight}"${fontStyle}${decoration}>` +
     `${spans.join('')}</text>`
-  )
+  );
 }
 
 // ============================================================================
@@ -239,14 +251,14 @@ function renderMember(member: ClassMember, x: number, y: number): string {
  * Includes data-* attributes for programmatic inspection.
  */
 function renderRelationship(rel: PositionedClassRelationship): string {
-  if (rel.points.length < 2) return ''
+  if (rel.points.length < 2) return '';
 
-  const pathData = rel.points.map(p => `${p.x},${p.y}`).join(' ')
-  const isDashed = rel.type === 'dependency' || rel.type === 'realization'
-  const dashArray = isDashed ? ' stroke-dasharray="6 4"' : ''
+  const pathData = rel.points.map((p) => f`${p.x},${p.y}`).join(' ');
+  const isDashed = rel.type === 'dependency' || rel.type === 'realization';
+  const dashArray = isDashed ? ' stroke-dasharray="6 4"' : '';
 
   // Determine markers based on relationship type and which end has the marker
-  const markers = getRelationshipMarkers(rel.type, rel.markerAt)
+  const markers = getRelationshipMarkers(rel.type, rel.markerAt);
 
   // Build semantic data attributes for relationship inspection:
   // - class="class-relationship": CSS targeting
@@ -261,21 +273,21 @@ function renderRelationship(rel: PositionedClassRelationship): string {
     `data-to="${escapeAttr(rel.to)}"`,
     `data-type="${rel.type}"`,
     `data-marker-at="${rel.markerAt}"`,
-  ]
+  ];
   if (rel.label) {
-    dataAttrs.push(`data-label="${escapeAttr(rel.label)}"`)
+    dataAttrs.push(`data-label="${escapeAttr(rel.label)}"`);
   }
   if (rel.fromCardinality) {
-    dataAttrs.push(`data-from-cardinality="${escapeAttr(rel.fromCardinality)}"`)
+    dataAttrs.push(`data-from-cardinality="${escapeAttr(rel.fromCardinality)}"`);
   }
   if (rel.toCardinality) {
-    dataAttrs.push(`data-to-cardinality="${escapeAttr(rel.toCardinality)}"`)
+    dataAttrs.push(`data-to-cardinality="${escapeAttr(rel.toCardinality)}"`);
   }
 
   return (
     `<polyline ${dataAttrs.join(' ')} points="${pathData}" fill="none" stroke="var(--_line)" ` +
     `stroke-width="${STROKE_WIDTHS.connector}"${dashArray}${markers} />`
-  )
+  );
 }
 
 /**
@@ -285,13 +297,13 @@ function renderRelationship(rel: PositionedClassRelationship): string {
  *   - 'to'   → marker-end   (suffix arrows like `..|>`, `-->`, `--*`)
  */
 function getRelationshipMarkers(type: RelationshipType, markerAt: 'from' | 'to'): string {
-  const markerId = getMarkerDefId(type)
-  if (!markerId) return ''
+  const markerId = getMarkerDefId(type);
+  if (!markerId) return '';
 
   if (markerAt === 'from') {
-    return ` marker-start="url(#${markerId})"`
+    return ` marker-start="url(#${markerId})"`;
   } else {
-    return ` marker-end="url(#${markerId})"`
+    return ` marker-end="url(#${markerId})"`;
   }
 }
 
@@ -300,81 +312,96 @@ function getMarkerDefId(type: RelationshipType): string | null {
   switch (type) {
     case 'inheritance':
     case 'realization':
-      return 'cls-inherit'
+      return 'cls-inherit';
     case 'composition':
-      return 'cls-composition'
+      return 'cls-composition';
     case 'aggregation':
-      return 'cls-aggregation'
+      return 'cls-aggregation';
     case 'association':
     case 'dependency':
-      return 'cls-arrow'
+      return 'cls-arrow';
     default:
-      return null
+      return null;
   }
 }
 
 /** Render relationship labels and cardinality text (supports multi-line) */
 function renderRelationshipLabels(rel: PositionedClassRelationship): string {
-  if (!rel.label && !rel.fromCardinality && !rel.toCardinality) return ''
-  if (rel.points.length < 2) return ''
+  if (!rel.label && !rel.fromCardinality && !rel.toCardinality) return '';
+  if (rel.points.length < 2) return '';
 
-  const parts: string[] = []
+  const parts: string[] = [];
 
   // Label — prefer layout-computed position (collision-aware), fall back to midpoint
   if (rel.label) {
-    const pos = rel.labelPosition ?? midpoint(rel.points)
+    const pos = rel.labelPosition ?? midpoint(rel.points);
     parts.push(
-      renderMultilineText(rel.label, pos.x, pos.y - 8, FONT_SIZES.edgeLabel,
-        `font-size="${FONT_SIZES.edgeLabel}" text-anchor="middle" font-weight="${FONT_WEIGHTS.edgeLabel}" fill="var(--_text-muted)"`)
-    )
+      renderMultilineText(
+        rel.label,
+        pos.x,
+        pos.y - 8,
+        FONT_SIZES.edgeLabel,
+        `font-size="${FONT_SIZES.edgeLabel}" text-anchor="middle" font-weight="${FONT_WEIGHTS.edgeLabel}" fill="var(--_text-muted)"`,
+      ),
+    );
   }
 
   // From cardinality (near start)
   if (rel.fromCardinality) {
-    const p = rel.points[0]!
-    const next = rel.points[1]!
-    const offset = cardinalityOffset(p, next)
+    const p = rel.points[0]!;
+    const next = rel.points[1]!;
+    const offset = cardinalityOffset(p, next);
     parts.push(
-      renderMultilineText(rel.fromCardinality, p.x + offset.x, p.y + offset.y, FONT_SIZES.edgeLabel,
-        `font-size="${FONT_SIZES.edgeLabel}" text-anchor="middle" font-weight="${FONT_WEIGHTS.edgeLabel}" fill="var(--_text-muted)"`)
-    )
+      renderMultilineText(
+        rel.fromCardinality,
+        p.x + offset.x,
+        p.y + offset.y,
+        FONT_SIZES.edgeLabel,
+        `font-size="${FONT_SIZES.edgeLabel}" text-anchor="middle" font-weight="${FONT_WEIGHTS.edgeLabel}" fill="var(--_text-muted)"`,
+      ),
+    );
   }
 
   // To cardinality (near end)
   if (rel.toCardinality) {
-    const p = rel.points[rel.points.length - 1]!
-    const prev = rel.points[rel.points.length - 2]!
-    const offset = cardinalityOffset(p, prev)
+    const p = rel.points[rel.points.length - 1]!;
+    const prev = rel.points[rel.points.length - 2]!;
+    const offset = cardinalityOffset(p, prev);
     parts.push(
-      renderMultilineText(rel.toCardinality, p.x + offset.x, p.y + offset.y, FONT_SIZES.edgeLabel,
-        `font-size="${FONT_SIZES.edgeLabel}" text-anchor="middle" font-weight="${FONT_WEIGHTS.edgeLabel}" fill="var(--_text-muted)"`)
-    )
+      renderMultilineText(
+        rel.toCardinality,
+        p.x + offset.x,
+        p.y + offset.y,
+        FONT_SIZES.edgeLabel,
+        `font-size="${FONT_SIZES.edgeLabel}" text-anchor="middle" font-weight="${FONT_WEIGHTS.edgeLabel}" fill="var(--_text-muted)"`,
+      ),
+    );
   }
 
-  return parts.join('\n')
+  return parts.join('\n');
 }
 
 /** Get the midpoint of a point array */
 function midpoint(points: Array<{ x: number; y: number }>): { x: number; y: number } {
-  if (points.length === 0) return { x: 0, y: 0 }
-  const mid = Math.floor(points.length / 2)
-  return points[mid]!
+  if (points.length === 0) return { x: 0, y: 0 };
+  const mid = Math.floor(points.length / 2);
+  return points[mid]!;
 }
 
 /** Calculate offset for cardinality label perpendicular to edge direction */
 function cardinalityOffset(
   from: { x: number; y: number },
-  to: { x: number; y: number }
+  to: { x: number; y: number },
 ): { x: number; y: number } {
-  const dx = to.x - from.x
-  const dy = to.y - from.y
+  const dx = to.x - from.x;
+  const dy = to.y - from.y;
   // Place label perpendicular to the edge, 14px away
   if (Math.abs(dx) > Math.abs(dy)) {
     // Mostly horizontal — offset vertically
-    return { x: dx > 0 ? 14 : -14, y: -10 }
+    return { x: dx > 0 ? 14 : -14, y: -10 };
   }
   // Mostly vertical — offset horizontally
-  return { x: -14, y: dy > 0 ? 14 : -14 }
+  return { x: -14, y: dy > 0 ? 14 : -14 };
 }
 
 // ============================================================================
@@ -382,7 +409,7 @@ function cardinalityOffset(
 // ============================================================================
 
 // Use shared escapeXml from multiline-utils
-const escapeXml = escapeXmlUtil
+const escapeXml = escapeXmlUtil;
 
 /**
  * Escape a string for use as an XML/HTML attribute value.
@@ -393,5 +420,5 @@ function escapeAttr(value: string): string {
     .replace(/&/g, '&amp;')
     .replace(/"/g, '&quot;')
     .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
+    .replace(/>/g, '&gt;');
 }

--- a/src/er/renderer.ts
+++ b/src/er/renderer.ts
@@ -1,9 +1,22 @@
-import type { PositionedErDiagram, PositionedErEntity, PositionedErRelationship, ErAttribute, Cardinality } from './types.ts'
-import type { DiagramColors } from '../theme.ts'
-import { svgOpenTag, buildStyleBlock } from '../theme.ts'
-import { FONT_SIZES, FONT_WEIGHTS, STROKE_WIDTHS, estimateTextWidth, TEXT_BASELINE_SHIFT } from '../styles.ts'
-import { renderMultilineText, escapeXml as escapeXmlUtil } from '../multiline-utils.ts'
-import { measureMultilineText } from '../text-metrics.ts'
+import type {
+  PositionedErDiagram,
+  PositionedErEntity,
+  PositionedErRelationship,
+  ErAttribute,
+  Cardinality,
+} from './types.ts';
+import type { DiagramColors } from '../theme.ts';
+import { svgOpenTag, buildStyleBlock } from '../theme.ts';
+import {
+  FONT_SIZES,
+  FONT_WEIGHTS,
+  STROKE_WIDTHS,
+  estimateTextWidth,
+  TEXT_BASELINE_SHIFT,
+} from '../styles.ts';
+import { renderMultilineText, escapeXml as escapeXmlUtil } from '../multiline-utils.ts';
+import { measureMultilineText } from '../text-metrics.ts';
+import { f } from '../render-utils.ts';
 
 // ============================================================================
 // ER diagram SVG renderer
@@ -24,7 +37,7 @@ const ER_FONT = {
   attrWeight: 400,
   keySize: 9,
   keyWeight: 600,
-} as const
+} as const;
 
 /**
  * Render a positioned ER diagram as an SVG string.
@@ -36,38 +49,38 @@ export function renderErSvg(
   diagram: PositionedErDiagram,
   colors: DiagramColors,
   font: string = 'Inter',
-  transparent: boolean = false
+  transparent: boolean = false,
 ): string {
-  const parts: string[] = []
+  const parts: string[] = [];
 
   // SVG root with CSS variables + style block (with mono font) + defs
-  parts.push(svgOpenTag(diagram.width, diagram.height, colors, transparent))
-  parts.push(buildStyleBlock(font, true))
-  parts.push('<defs>')
-  parts.push('</defs>') // No marker defs — we draw crow's foot inline
+  parts.push(svgOpenTag(diagram.width, diagram.height, colors, transparent));
+  parts.push(buildStyleBlock(font, true));
+  parts.push('<defs>');
+  parts.push('</defs>'); // No marker defs — we draw crow's foot inline
 
   // 1. Relationship lines
   for (const rel of diagram.relationships) {
-    parts.push(renderRelationshipLine(rel))
+    parts.push(renderRelationshipLine(rel));
   }
 
   // 2. Entity boxes
   for (const entity of diagram.entities) {
-    parts.push(renderEntityBox(entity))
+    parts.push(renderEntityBox(entity));
   }
 
   // 3. Cardinality markers at relationship endpoints
   for (const rel of diagram.relationships) {
-    parts.push(renderCardinality(rel))
+    parts.push(renderCardinality(rel));
   }
 
   // 4. Relationship labels
   for (const rel of diagram.relationships) {
-    parts.push(renderRelationshipLabel(rel))
+    parts.push(renderRelationshipLabel(rel));
   }
 
-  parts.push('</svg>')
-  return parts.join('\n')
+  parts.push('</svg>');
+  return parts.join('\n');
 }
 
 // ============================================================================
@@ -79,61 +92,60 @@ export function renderErSvg(
  * Wrapped in <g class="entity"> with semantic data attributes.
  */
 function renderEntityBox(entity: PositionedErEntity): string {
-  const { id, x, y, width, height, headerHeight, rowHeight, label, attributes } = entity
-  const parts: string[] = []
+  const { id, x, y, width, height, headerHeight, rowHeight, label, attributes } = entity;
+  const parts: string[] = [];
 
   // Semantic wrapper with entity metadata
-  parts.push(
-    `<g class="entity" data-id="${escapeAttr(id)}" data-label="${escapeAttr(label)}">`
-  )
+  parts.push(`<g class="entity" data-id="${escapeAttr(id)}" data-label="${escapeAttr(label)}">`);
 
   // Outer rectangle
   parts.push(
-    `  <rect x="${x}" y="${y}" width="${width}" height="${height}" ` +
-    `rx="0" ry="0" fill="var(--_node-fill)" stroke="var(--_node-stroke)" stroke-width="${STROKE_WIDTHS.outerBox}" />`
-  )
+    f`  <rect x="${x}" y="${y}" width="${width}" height="${height}" ` +
+      `rx="0" ry="0" fill="var(--_node-fill)" stroke="var(--_node-stroke)" stroke-width="${STROKE_WIDTHS.outerBox}" />`,
+  );
 
   // Header background
   parts.push(
-    `  <rect x="${x}" y="${y}" width="${width}" height="${headerHeight}" ` +
-    `rx="0" ry="0" fill="var(--_group-hdr)" stroke="var(--_node-stroke)" stroke-width="${STROKE_WIDTHS.outerBox}" />`
-  )
+    f`  <rect x="${x}" y="${y}" width="${width}" height="${headerHeight}" ` +
+      `rx="0" ry="0" fill="var(--_group-hdr)" stroke="var(--_node-stroke)" stroke-width="${STROKE_WIDTHS.outerBox}" />`,
+  );
 
   // Entity name (supports multi-line via <br> tags)
   parts.push(
-    '  ' + renderMultilineText(
-      label,
-      x + width / 2,
-      y + headerHeight / 2,
-      FONT_SIZES.nodeLabel,
-      `text-anchor="middle" font-size="${FONT_SIZES.nodeLabel}" font-weight="700" fill="var(--_text)"`
-    )
-  )
+    '  ' +
+      renderMultilineText(
+        label,
+        x + width / 2,
+        y + headerHeight / 2,
+        FONT_SIZES.nodeLabel,
+        `text-anchor="middle" font-size="${FONT_SIZES.nodeLabel}" font-weight="700" fill="var(--_text)"`,
+      ),
+  );
 
   // Divider
-  const attrTop = y + headerHeight
+  const attrTop = y + headerHeight;
   parts.push(
-    `  <line x1="${x}" y1="${attrTop}" x2="${x + width}" y2="${attrTop}" ` +
-    `stroke="var(--_node-stroke)" stroke-width="${STROKE_WIDTHS.innerBox}" />`
-  )
+    f`  <line x1="${x}" y1="${attrTop}" x2="${x + width}" y2="${attrTop}" ` +
+      `stroke="var(--_node-stroke)" stroke-width="${STROKE_WIDTHS.innerBox}" />`,
+  );
 
   // Attribute rows
   for (let i = 0; i < attributes.length; i++) {
-    const attr = attributes[i]!
-    const rowY = attrTop + i * rowHeight + rowHeight / 2
-    parts.push('  ' + renderAttribute(attr, x, rowY, width).replace(/\n/g, '\n  '))
+    const attr = attributes[i]!;
+    const rowY = attrTop + i * rowHeight + rowHeight / 2;
+    parts.push('  ' + renderAttribute(attr, x, rowY, width).replace(/\n/g, '\n  '));
   }
 
   // Empty row placeholder when no attributes
   if (attributes.length === 0) {
     parts.push(
-      `  <text x="${x + width / 2}" y="${attrTop + rowHeight / 2}" text-anchor="middle" dy="${TEXT_BASELINE_SHIFT}" ` +
-      `font-size="${ER_FONT.attrSize}" fill="var(--_text-faint)" font-style="italic">(no attributes)</text>`
-    )
+      f`  <text x="${x + width / 2}" y="${attrTop + rowHeight / 2}" text-anchor="middle" dy="${TEXT_BASELINE_SHIFT}" ` +
+        `font-size="${ER_FONT.attrSize}" fill="var(--_text-faint)" font-style="italic">(no attributes)</text>`,
+    );
   }
 
-  parts.push('</g>')
-  return parts.join('\n')
+  parts.push('</g>');
+  return parts.join('\n');
 }
 
 /**
@@ -145,53 +157,53 @@ function renderEntityBox(entity: PositionedErEntity): string {
  * Comments are shown as tooltips via SVG <title> element.
  */
 function renderAttribute(attr: ErAttribute, boxX: number, y: number, boxWidth: number): string {
-  const parts: string[] = []
+  const parts: string[] = [];
 
   // Wrap in a group if there's a comment (for tooltip support)
-  const hasComment = attr.comment && attr.comment.length > 0
+  const hasComment = attr.comment && attr.comment.length > 0;
   if (hasComment) {
     // Replace <br> with newlines for tooltip display
-    const tooltipText = attr.comment!.replace(/<br\s*\/?>/gi, '\n')
-    parts.push(`<g><title>${escapeXml(tooltipText)}</title>`)
+    const tooltipText = attr.comment!.replace(/<br\s*\/?>/gi, '\n');
+    parts.push(`<g><title>${escapeXml(tooltipText)}</title>`);
   }
 
   // Key badges on the left (keep proportional font — they're visual tags, not code)
-  let keyWidth = 0
+  let keyWidth = 0;
   if (attr.keys.length > 0) {
-    const keyText = attr.keys.join(',')
-    keyWidth = estimateTextWidth(keyText, ER_FONT.keySize, ER_FONT.keyWeight) + 8
+    const keyText = attr.keys.join(',');
+    keyWidth = estimateTextWidth(keyText, ER_FONT.keySize, ER_FONT.keyWeight) + 8;
     parts.push(
-      `<rect x="${boxX + 6}" y="${y - 7}" width="${keyWidth}" height="14" rx="2" ry="2" ` +
-      `fill="var(--_key-badge)" />`
-    )
+      f`<rect x="${boxX + 6}" y="${y - 7}" width="${keyWidth}" height="14" rx="2" ry="2" ` +
+        `fill="var(--_key-badge)" />`,
+    );
     parts.push(
-      `<text x="${boxX + 6 + keyWidth / 2}" y="${y}" text-anchor="middle" dy="${TEXT_BASELINE_SHIFT}" ` +
-      `font-size="${ER_FONT.keySize}" font-weight="${ER_FONT.keyWeight}" fill="var(--_text-sec)">${attr.keys.join(',')}</text>`
-    )
+      f`<text x="${boxX + 6 + keyWidth / 2}" y="${y}" text-anchor="middle" dy="${TEXT_BASELINE_SHIFT}" ` +
+        `font-size="${ER_FONT.keySize}" font-weight="${ER_FONT.keyWeight}" fill="var(--_text-sec)">${attr.keys.join(',')}</text>`,
+    );
   }
 
   // Type (left-aligned after keys, monospace with syntax highlighting)
-  const typeX = boxX + 8 + (keyWidth > 0 ? keyWidth + 6 : 0)
+  const typeX = boxX + 8 + (keyWidth > 0 ? keyWidth + 6 : 0);
   parts.push(
     `<text x="${typeX}" y="${y}" class="mono" dy="${TEXT_BASELINE_SHIFT}" ` +
-    `font-size="${ER_FONT.attrSize}" font-weight="${ER_FONT.attrWeight}">` +
-    `<tspan fill="var(--_text-muted)">${escapeXml(attr.type)}</tspan></text>`
-  )
+      `font-size="${ER_FONT.attrSize}" font-weight="${ER_FONT.attrWeight}">` +
+      `<tspan fill="var(--_text-muted)">${escapeXml(attr.type)}</tspan></text>`,
+  );
 
   // Name (right-aligned, monospace with syntax highlighting)
-  const nameX = boxX + boxWidth - 8
+  const nameX = boxX + boxWidth - 8;
   parts.push(
     `<text x="${nameX}" y="${y}" class="mono" text-anchor="end" dy="${TEXT_BASELINE_SHIFT}" ` +
-    `font-size="${ER_FONT.attrSize}" font-weight="${ER_FONT.attrWeight}">` +
-    `<tspan fill="var(--_text-sec)">${escapeXml(attr.name)}</tspan></text>`
-  )
+      `font-size="${ER_FONT.attrSize}" font-weight="${ER_FONT.attrWeight}">` +
+      `<tspan fill="var(--_text-sec)">${escapeXml(attr.name)}</tspan></text>`,
+  );
 
   // Close the group if we opened one
   if (hasComment) {
-    parts.push('</g>')
+    parts.push('</g>');
   }
 
-  return parts.join('\n')
+  return parts.join('\n');
 }
 
 // ============================================================================
@@ -202,13 +214,13 @@ function renderAttribute(attr: ErAttribute, boxX: number, y: number, boxWidth: n
  * Render a relationship line with semantic data attributes.
  */
 function renderRelationshipLine(rel: PositionedErRelationship): string {
-  if (rel.points.length < 2) return ''
+  if (rel.points.length < 2) return '';
 
-  const pathData = rel.points.map(p => `${p.x},${p.y}`).join(' ')
-  const dashArray = !rel.identifying ? ' stroke-dasharray="6 4"' : ''
+  const pathData = rel.points.map((p) => f`${p.x},${p.y}`).join(' ');
+  const dashArray = !rel.identifying ? ' stroke-dasharray="6 4"' : '';
 
   // Semantic data attributes for relationship inspection
-  const labelAttr = rel.label ? ` data-label="${escapeAttr(rel.label)}"` : ''
+  const labelAttr = rel.label ? ` data-label="${escapeAttr(rel.label)}"` : '';
   const dataAttrs = [
     'class="er-relationship"',
     `data-entity1="${escapeAttr(rel.entity1)}"`,
@@ -216,31 +228,36 @@ function renderRelationshipLine(rel: PositionedErRelationship): string {
     `data-cardinality1="${rel.cardinality1}"`,
     `data-cardinality2="${rel.cardinality2}"`,
     `data-identifying="${rel.identifying}"`,
-  ]
+  ];
 
   return (
     `<polyline ${dataAttrs.join(' ')}${labelAttr} points="${pathData}" fill="none" stroke="var(--_line)" ` +
     `stroke-width="${STROKE_WIDTHS.connector}"${dashArray} />`
-  )
+  );
 }
 
 /** Render a relationship label at the midpoint (supports multi-line) */
 function renderRelationshipLabel(rel: PositionedErRelationship): string {
-  if (!rel.label || rel.points.length < 2) return ''
+  if (!rel.label || rel.points.length < 2) return '';
 
-  const mid = midpoint(rel.points)
-  const metrics = measureMultilineText(rel.label, FONT_SIZES.edgeLabel, FONT_WEIGHTS.edgeLabel)
+  const mid = midpoint(rel.points);
+  const metrics = measureMultilineText(rel.label, FONT_SIZES.edgeLabel, FONT_WEIGHTS.edgeLabel);
 
   // Background pill for readability
-  const bgW = metrics.width + 8
-  const bgH = metrics.height + 6
+  const bgW = metrics.width + 8;
+  const bgH = metrics.height + 6;
 
   return (
-    `<rect x="${mid.x - bgW / 2}" y="${mid.y - bgH / 2}" width="${bgW}" height="${bgH}" rx="2" ry="2" ` +
+    f`<rect x="${mid.x - bgW / 2}" y="${mid.y - bgH / 2}" width="${bgW}" height="${bgH}" rx="2" ry="2" ` +
     `fill="var(--bg)" stroke="var(--_inner-stroke)" stroke-width="0.5" />` +
-    `\n${renderMultilineText(rel.label, mid.x, mid.y, FONT_SIZES.edgeLabel,
-      `text-anchor="middle" font-size="${FONT_SIZES.edgeLabel}" font-weight="${FONT_WEIGHTS.edgeLabel}" fill="var(--_text-muted)"`)}`
-  )
+    `\n${renderMultilineText(
+      rel.label,
+      mid.x,
+      mid.y,
+      FONT_SIZES.edgeLabel,
+      `text-anchor="middle" font-size="${FONT_SIZES.edgeLabel}" font-weight="${FONT_WEIGHTS.edgeLabel}" fill="var(--_text-muted)"`,
+    )}`
+  );
 }
 
 /**
@@ -253,20 +270,20 @@ function renderRelationshipLabel(rel: PositionedErRelationship): string {
  *   'zero-many': ─o╣─  (circle + crow's foot)
  */
 function renderCardinality(rel: PositionedErRelationship): string {
-  if (rel.points.length < 2) return ''
-  const parts: string[] = []
+  if (rel.points.length < 2) return '';
+  const parts: string[] = [];
 
   // Entity1 side (first point, direction toward second point)
-  const p1 = rel.points[0]!
-  const p2 = rel.points[1]!
-  parts.push(renderCrowsFoot(p1, p2, rel.cardinality1))
+  const p1 = rel.points[0]!;
+  const p2 = rel.points[1]!;
+  parts.push(renderCrowsFoot(p1, p2, rel.cardinality1));
 
   // Entity2 side (last point, direction toward second-to-last point)
-  const pN = rel.points[rel.points.length - 1]!
-  const pN1 = rel.points[rel.points.length - 2]!
-  parts.push(renderCrowsFoot(pN, pN1, rel.cardinality2))
+  const pN = rel.points[rel.points.length - 1]!;
+  const pN1 = rel.points[rel.points.length - 2]!;
+  parts.push(renderCrowsFoot(pN, pN1, rel.cardinality2));
 
-  return parts.join('\n')
+  return parts.join('\n');
 }
 
 /**
@@ -276,91 +293,91 @@ function renderCardinality(rel: PositionedErRelationship): string {
 function renderCrowsFoot(
   point: { x: number; y: number },
   toward: { x: number; y: number },
-  cardinality: Cardinality
+  cardinality: Cardinality,
 ): string {
-  const parts: string[] = []
-  const sw = STROKE_WIDTHS.connector + 0.25
+  const parts: string[] = [];
+  const sw = STROKE_WIDTHS.connector + 0.25;
 
   // Calculate direction from toward → point (unit vector)
-  const dx = point.x - toward.x
-  const dy = point.y - toward.y
-  const len = Math.sqrt(dx * dx + dy * dy)
-  if (len === 0) return ''
-  const ux = dx / len
-  const uy = dy / len
+  const dx = point.x - toward.x;
+  const dy = point.y - toward.y;
+  const len = Math.sqrt(dx * dx + dy * dy);
+  if (len === 0) return '';
+  const ux = dx / len;
+  const uy = dy / len;
 
   // Perpendicular direction
-  const px = -uy
-  const py = ux
+  const px = -uy;
+  const py = ux;
 
   // Marker sits 4px from the endpoint, extending 12px back along the edge
-  const tipX = point.x - ux * 4
-  const tipY = point.y - uy * 4
-  const backX = point.x - ux * 16
-  const backY = point.y - uy * 16
+  const tipX = point.x - ux * 4;
+  const tipY = point.y - uy * 4;
+  const backX = point.x - ux * 16;
+  const backY = point.y - uy * 16;
 
   // Single line: always present for 'one' and part of others
-  const hasOneLine = cardinality === 'one' || cardinality === 'zero-one'
-  const hasCrowsFoot = cardinality === 'many' || cardinality === 'zero-many'
-  const hasCircle = cardinality === 'zero-one' || cardinality === 'zero-many'
+  const hasOneLine = cardinality === 'one' || cardinality === 'zero-one';
+  const hasCrowsFoot = cardinality === 'many' || cardinality === 'zero-many';
+  const hasCircle = cardinality === 'zero-one' || cardinality === 'zero-many';
 
   // Draw single vertical line (perpendicular to edge) at the tip
   if (hasOneLine) {
-    const halfW = 6
+    const halfW = 6;
     parts.push(
-      `<line x1="${tipX + px * halfW}" y1="${tipY + py * halfW}" ` +
-      `x2="${tipX - px * halfW}" y2="${tipY - py * halfW}" ` +
-      `stroke="var(--_line)" stroke-width="${sw}" />`
-    )
+      f`<line x1="${tipX + px * halfW}" y1="${tipY + py * halfW}" ` +
+        f`x2="${tipX - px * halfW}" y2="${tipY - py * halfW}" ` +
+        f`stroke="var(--_line)" stroke-width="${sw}" />`,
+    );
     // Second line slightly back for "exactly one" emphasis
-    const line2X = tipX - ux * 4
-    const line2Y = tipY - uy * 4
+    const line2X = tipX - ux * 4;
+    const line2Y = tipY - uy * 4;
     parts.push(
-      `<line x1="${line2X + px * halfW}" y1="${line2Y + py * halfW}" ` +
-      `x2="${line2X - px * halfW}" y2="${line2Y - py * halfW}" ` +
-      `stroke="var(--_line)" stroke-width="${sw}" />`
-    )
+      f`<line x1="${line2X + px * halfW}" y1="${line2Y + py * halfW}" ` +
+        f`x2="${line2X - px * halfW}" y2="${line2Y - py * halfW}" ` +
+        f`stroke="var(--_line)" stroke-width="${sw}" />`,
+    );
   }
 
   // Crow's foot (three lines fanning out from tip)
   if (hasCrowsFoot) {
-    const fanW = 7
+    const fanW = 7;
     // Center line
-    const cfTipX = tipX
-    const cfTipY = tipY
+    const cfTipX = tipX;
+    const cfTipY = tipY;
     // Three lines from tip to back, fanning out
     parts.push(
       // Top fan line
-      `<line x1="${cfTipX + px * fanW}" y1="${cfTipY + py * fanW}" ` +
-      `x2="${backX}" y2="${backY}" ` +
-      `stroke="var(--_line)" stroke-width="${sw}" />`
-    )
+      f`<line x1="${cfTipX + px * fanW}" y1="${cfTipY + py * fanW}" ` +
+        f`x2="${backX}" y2="${backY}" ` +
+        f`stroke="var(--_line)" stroke-width="${sw}" />`,
+    );
     parts.push(
       // Center line
-      `<line x1="${cfTipX}" y1="${cfTipY}" ` +
-      `x2="${backX}" y2="${backY}" ` +
-      `stroke="var(--_line)" stroke-width="${sw}" />`
-    )
+      f`<line x1="${cfTipX}" y1="${cfTipY}" ` +
+        f`x2="${backX}" y2="${backY}" ` +
+        f`stroke="var(--_line)" stroke-width="${sw}" />`,
+    );
     parts.push(
       // Bottom fan line
-      `<line x1="${cfTipX - px * fanW}" y1="${cfTipY - py * fanW}" ` +
-      `x2="${backX}" y2="${backY}" ` +
-      `stroke="var(--_line)" stroke-width="${sw}" />`
-    )
+      f`<line x1="${cfTipX - px * fanW}" y1="${cfTipY - py * fanW}" ` +
+        f`x2="${backX}" y2="${backY}" ` +
+        f`stroke="var(--_line)" stroke-width="${sw}" />`,
+    );
   }
 
   // Circle (for zero variants)
   if (hasCircle) {
-    const circleOffset = hasCrowsFoot ? 20 : 12
-    const circleX = point.x - ux * circleOffset
-    const circleY = point.y - uy * circleOffset
+    const circleOffset = hasCrowsFoot ? 20 : 12;
+    const circleX = point.x - ux * circleOffset;
+    const circleY = point.y - uy * circleOffset;
     parts.push(
-      `<circle cx="${circleX}" cy="${circleY}" r="4" ` +
-      `fill="var(--bg)" stroke="var(--_line)" stroke-width="${sw}" />`
-    )
+      f`<circle cx="${circleX}" cy="${circleY}" r="4" ` +
+        f`fill="var(--bg)" stroke="var(--_line)" stroke-width="${sw}" />`,
+    );
   }
 
-  return parts.join('\n')
+  return parts.join('\n');
 }
 
 /** Compute the arc-length midpoint of a polyline path.
@@ -368,37 +385,37 @@ function renderCrowsFoot(
  *  This ensures the label sits ON the path even for orthogonal routes with bends,
  *  unlike the naive first/last geometric center which floats in space for L/Z shapes. */
 function midpoint(points: Array<{ x: number; y: number }>): { x: number; y: number } {
-  if (points.length === 0) return { x: 0, y: 0 }
-  if (points.length === 1) return points[0]!
+  if (points.length === 0) return { x: 0, y: 0 };
+  if (points.length === 1) return points[0]!;
 
   // Compute total path length
-  let totalLen = 0
+  let totalLen = 0;
   for (let i = 1; i < points.length; i++) {
-    const dx = points[i]!.x - points[i - 1]!.x
-    const dy = points[i]!.y - points[i - 1]!.y
-    totalLen += Math.sqrt(dx * dx + dy * dy)
+    const dx = points[i]!.x - points[i - 1]!.x;
+    const dy = points[i]!.y - points[i - 1]!.y;
+    totalLen += Math.sqrt(dx * dx + dy * dy);
   }
 
-  if (totalLen === 0) return points[0]!
+  if (totalLen === 0) return points[0]!;
 
   // Walk to 50% of total length, interpolating within the segment that crosses the halfway mark
-  const halfLen = totalLen / 2
-  let walked = 0
+  const halfLen = totalLen / 2;
+  let walked = 0;
   for (let i = 1; i < points.length; i++) {
-    const dx = points[i]!.x - points[i - 1]!.x
-    const dy = points[i]!.y - points[i - 1]!.y
-    const segLen = Math.sqrt(dx * dx + dy * dy)
+    const dx = points[i]!.x - points[i - 1]!.x;
+    const dy = points[i]!.y - points[i - 1]!.y;
+    const segLen = Math.sqrt(dx * dx + dy * dy);
     if (walked + segLen >= halfLen) {
-      const t = segLen > 0 ? (halfLen - walked) / segLen : 0
+      const t = segLen > 0 ? (halfLen - walked) / segLen : 0;
       return {
         x: points[i - 1]!.x + dx * t,
         y: points[i - 1]!.y + dy * t,
-      }
+      };
     }
-    walked += segLen
+    walked += segLen;
   }
 
-  return points[points.length - 1]!
+  return points[points.length - 1]!;
 }
 
 // ============================================================================
@@ -406,7 +423,7 @@ function midpoint(points: Array<{ x: number; y: number }>): { x: number; y: numb
 // ============================================================================
 
 // Use shared escapeXml from multiline-utils
-const escapeXml = escapeXmlUtil
+const escapeXml = escapeXmlUtil;
 
 /**
  * Escape a string for use as an XML/HTML attribute value.
@@ -416,5 +433,5 @@ function escapeAttr(value: string): string {
     .replace(/&/g, '&amp;')
     .replace(/"/g, '&quot;')
     .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
+    .replace(/>/g, '&gt;');
 }

--- a/src/multiline-utils.ts
+++ b/src/multiline-utils.ts
@@ -6,7 +6,8 @@
 // Used across all diagram types (flowcharts, state, sequence, class, ER).
 // ============================================================================
 
-import { LINE_HEIGHT_RATIO } from './text-metrics.ts'
+import { LINE_HEIGHT_RATIO } from './text-metrics.ts';
+import { f } from './render-utils.ts';
 
 /**
  * Normalize label text: strip surrounding quotes, convert <br> tags and
@@ -15,15 +16,17 @@ import { LINE_HEIGHT_RATIO } from './text-metrics.ts'
  */
 export function normalizeBrTags(label: string): string {
   // Strip surrounding double quotes (Mermaid uses them for special chars in labels)
-  const unquoted = label.startsWith('"') && label.endsWith('"') ? label.slice(1, -1) : label
-  return unquoted
-    .replace(/<br\s*\/?>/gi, '\n')
-    .replace(/\\n/g, '\n')
-    .replace(/<\/?(?:sub|sup|small|mark)\s*>/gi, '')
-    // Markdown formatting → HTML tags (order matters: ** before *)
-    .replace(/\*\*(.+?)\*\*/g, '<b>$1</b>')
-    .replace(/(?<!\*)\*([^\s*](?:[^*]*[^\s*])?)\*(?!\*)/g, '<i>$1</i>')
-    .replace(/~~(.+?)~~/g, '<s>$1</s>')
+  const unquoted = label.startsWith('"') && label.endsWith('"') ? label.slice(1, -1) : label;
+  return (
+    unquoted
+      .replace(/<br\s*\/?>/gi, '\n')
+      .replace(/\\n/g, '\n')
+      .replace(/<\/?(?:sub|sup|small|mark)\s*>/gi, '')
+      // Markdown formatting → HTML tags (order matters: ** before *)
+      .replace(/\*\*(.+?)\*\*/g, '<b>$1</b>')
+      .replace(/(?<!\*)\*([^\s*](?:[^*]*[^\s*])?)\*(?!\*)/g, '<i>$1</i>')
+      .replace(/~~(.+?)~~/g, '<s>$1</s>')
+  );
 }
 
 /**
@@ -31,7 +34,7 @@ export function normalizeBrTags(label: string): string {
  * Used for text measurement where tag characters shouldn't affect width.
  */
 export function stripFormattingTags(text: string): string {
-  return text.replace(/<\/?(?:b|strong|i|em|u|s|del)\s*>/gi, '')
+  return text.replace(/<\/?(?:b|strong|i|em|u|s|del)\s*>/gi, '');
 }
 
 /**
@@ -43,7 +46,7 @@ export function escapeXml(text: string): string {
     .replace(/</g, '&lt;')
     .replace(/>/g, '&gt;')
     .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#39;')
+    .replace(/'/g, '&#39;');
 }
 
 // ============================================================================
@@ -51,54 +54,63 @@ export function escapeXml(text: string): string {
 // ============================================================================
 
 interface StyledSegment {
-  text: string
-  bold: boolean
-  italic: boolean
-  underline: boolean
-  strikethrough: boolean
+  text: string;
+  bold: boolean;
+  italic: boolean;
+  underline: boolean;
+  strikethrough: boolean;
 }
 
 /** Regex to match opening/closing formatting tags */
-const FORMAT_TAG_REGEX = /<(\/)?(?:(b|strong)|(i|em)|(u)|(s|del))\s*>/gi
+const FORMAT_TAG_REGEX = /<(\/)?(?:(b|strong)|(i|em)|(u)|(s|del))\s*>/gi;
 
 /**
  * Parse a line of text into styled segments based on inline formatting tags.
  * Supports nesting: `<b>bold <i>both</i> bold</b>`.
  */
 function parseInlineFormatting(line: string): StyledSegment[] {
-  const segments: StyledSegment[] = []
-  let bold = false, italic = false, underline = false, strikethrough = false
-  let lastIndex = 0
+  const segments: StyledSegment[] = [];
+  let bold = false,
+    italic = false,
+    underline = false,
+    strikethrough = false;
+  let lastIndex = 0;
 
   // Reset lastIndex for global regex
-  FORMAT_TAG_REGEX.lastIndex = 0
+  FORMAT_TAG_REGEX.lastIndex = 0;
 
-  let match: RegExpExecArray | null
+  let match: RegExpExecArray | null;
   while ((match = FORMAT_TAG_REGEX.exec(line)) !== null) {
     // Capture text before this tag
     if (match.index > lastIndex) {
-      segments.push({ text: line.slice(lastIndex, match.index), bold, italic, underline, strikethrough })
+      segments.push({
+        text: line.slice(lastIndex, match.index),
+        bold,
+        italic,
+        underline,
+        strikethrough,
+      });
     }
-    lastIndex = match.index + match[0].length
+    lastIndex = match.index + match[0].length;
 
-    const isClosing = Boolean(match[1])
+    const isClosing = Boolean(match[1]);
     // match[2] = b|strong, match[3] = i|em, match[4] = u, match[5] = s|del
-    if (match[2]) bold = !isClosing
-    else if (match[3]) italic = !isClosing
-    else if (match[4]) underline = !isClosing
-    else if (match[5]) strikethrough = !isClosing
+    if (match[2]) bold = !isClosing;
+    else if (match[3]) italic = !isClosing;
+    else if (match[4]) underline = !isClosing;
+    else if (match[5]) strikethrough = !isClosing;
   }
 
   // Remaining text after last tag
   if (lastIndex < line.length) {
-    segments.push({ text: line.slice(lastIndex), bold, italic, underline, strikethrough })
+    segments.push({ text: line.slice(lastIndex), bold, italic, underline, strikethrough });
   }
 
-  return segments
+  return segments;
 }
 
 /** Check if a line contains any formatting tags */
-const HAS_FORMAT_TAGS = /<\/?(?:b|strong|i|em|u|s|del)\s*>/i
+const HAS_FORMAT_TAGS = /<\/?(?:b|strong|i|em|u|s|del)\s*>/i;
 
 /**
  * Render a line's content as SVG, with inline formatting applied as tspan attributes.
@@ -106,30 +118,32 @@ const HAS_FORMAT_TAGS = /<\/?(?:b|strong|i|em|u|s|del)\s*>/i
  */
 function renderLineContent(line: string): string {
   // Fast path: no formatting tags
-  if (!HAS_FORMAT_TAGS.test(line)) return escapeXml(line)
+  if (!HAS_FORMAT_TAGS.test(line)) return escapeXml(line);
 
-  const segments = parseInlineFormatting(line)
-  if (segments.length === 0) return ''
+  const segments = parseInlineFormatting(line);
+  if (segments.length === 0) return '';
 
   // If all segments are unstyled, just escape
-  const allPlain = segments.every(s => !s.bold && !s.italic && !s.underline && !s.strikethrough)
-  if (allPlain) return segments.map(s => escapeXml(s.text)).join('')
+  const allPlain = segments.every((s) => !s.bold && !s.italic && !s.underline && !s.strikethrough);
+  if (allPlain) return segments.map((s) => escapeXml(s.text)).join('');
 
-  return segments.map(seg => {
-    const escaped = escapeXml(seg.text)
-    if (!seg.bold && !seg.italic && !seg.underline && !seg.strikethrough) return escaped
+  return segments
+    .map((seg) => {
+      const escaped = escapeXml(seg.text);
+      if (!seg.bold && !seg.italic && !seg.underline && !seg.strikethrough) return escaped;
 
-    const attrs: string[] = []
-    if (seg.bold) attrs.push('font-weight="bold"')
-    if (seg.italic) attrs.push('font-style="italic"')
-    // SVG text-decoration can combine values
-    const deco: string[] = []
-    if (seg.underline) deco.push('underline')
-    if (seg.strikethrough) deco.push('line-through')
-    if (deco.length) attrs.push(`text-decoration="${deco.join(' ')}"`)
+      const attrs: string[] = [];
+      if (seg.bold) attrs.push('font-weight="bold"');
+      if (seg.italic) attrs.push('font-style="italic"');
+      // SVG text-decoration can combine values
+      const deco: string[] = [];
+      if (seg.underline) deco.push('underline');
+      if (seg.strikethrough) deco.push('line-through');
+      if (deco.length) attrs.push(`text-decoration="${deco.join(' ')}"`);
 
-    return `<tspan ${attrs.join(' ')}>${escaped}</tspan>`
-  }).join('')
+      return `<tspan ${attrs.join(' ')}>${escaped}</tspan>`;
+    })
+    .join('');
 }
 
 // ============================================================================
@@ -157,27 +171,29 @@ export function renderMultilineText(
   cy: number,
   fontSize: number,
   attrs: string,
-  baselineShift: number = 0.35
+  baselineShift: number = 0.35,
 ): string {
-  const lines = text.split('\n')
+  const lines = text.split('\n');
 
   // Single line — simple text element
   if (lines.length === 1) {
-    const dy = fontSize * baselineShift
-    return `<text x="${cx}" y="${cy}" ${attrs} dy="${dy}">${renderLineContent(text)}</text>`
+    const dy = fontSize * baselineShift;
+    return f`<text x="${cx}" y="${cy}" ${attrs} dy="${dy}">${renderLineContent(text)}</text>`;
   }
 
   // Multi-line — use tspan elements with vertical centering
-  const lineHeight = fontSize * LINE_HEIGHT_RATIO
+  const lineHeight = fontSize * LINE_HEIGHT_RATIO;
   // First line dy: shift up by (n-1)/2 line heights, then add baseline shift
-  const firstDy = -((lines.length - 1) / 2) * lineHeight + fontSize * baselineShift
+  const firstDy = -((lines.length - 1) / 2) * lineHeight + fontSize * baselineShift;
 
-  const tspans = lines.map((line, i) => {
-    const dy = i === 0 ? firstDy : lineHeight
-    return `<tspan x="${cx}" dy="${dy}">${renderLineContent(line)}</tspan>`
-  }).join('')
+  const tspans = lines
+    .map((line, i) => {
+      const dy = i === 0 ? firstDy : lineHeight;
+      return f`<tspan x="${cx}" dy="${dy}">${renderLineContent(line)}</tspan>`;
+    })
+    .join('');
 
-  return `<text x="${cx}" y="${cy}" ${attrs}>${tspans}</text>`
+  return f`<text x="${cx}" y="${cy}" ${attrs}>${tspans}</text>`;
 }
 
 /**
@@ -205,15 +221,16 @@ export function renderMultilineTextWithBackground(
   fontSize: number,
   padding: number,
   textAttrs: string,
-  bgAttrs: string
+  bgAttrs: string,
 ): string {
-  const bgWidth = textWidth + padding * 2
-  const bgHeight = textHeight + padding * 2
+  const bgWidth = textWidth + padding * 2;
+  const bgHeight = textHeight + padding * 2;
 
-  const rect = `<rect x="${cx - bgWidth / 2}" y="${cy - bgHeight / 2}" ` +
-    `width="${bgWidth}" height="${bgHeight}" ${bgAttrs} />`
+  const rect =
+    f`<rect x="${cx - bgWidth / 2}" y="${cy - bgHeight / 2}" ` +
+    f`width="${bgWidth}" height="${bgHeight}" ${bgAttrs} />`;
 
-  const textEl = renderMultilineText(text, cx, cy, fontSize, textAttrs)
+  const textEl = renderMultilineText(text, cx, cy, fontSize, textAttrs);
 
-  return `${rect}\n${textEl}`
+  return `${rect}\n${textEl}`;
 }

--- a/src/render-utils.ts
+++ b/src/render-utils.ts
@@ -1,0 +1,7 @@
+/** Tagged template literal function that rounds floats, keep other values untouched */
+export function f(strings: TemplateStringsArray, ...values: any[]) {
+  return String.raw(
+    { raw: strings },
+    ...values.map((v) => (typeof v === 'number' ? Number(v.toFixed(2)) : v)),
+  );
+}

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -1,9 +1,27 @@
-import type { PositionedGraph, PositionedNode, PositionedEdge, PositionedGroup, Point } from './types.ts'
-import type { DiagramColors } from './theme.ts'
-import { svgOpenTag, buildStyleBlock } from './theme.ts'
-import { FONT_SIZES, FONT_WEIGHTS, STROKE_WIDTHS, ARROW_HEAD, estimateTextWidth, TEXT_BASELINE_SHIFT } from './styles.ts'
-import { measureMultilineText } from './text-metrics.ts'
-import { renderMultilineText, renderMultilineTextWithBackground, escapeXml } from './multiline-utils.ts'
+import type {
+  PositionedGraph,
+  PositionedNode,
+  PositionedEdge,
+  PositionedGroup,
+  Point,
+} from './types.ts';
+import type { DiagramColors } from './theme.ts';
+import { svgOpenTag, buildStyleBlock } from './theme.ts';
+import {
+  FONT_SIZES,
+  FONT_WEIGHTS,
+  STROKE_WIDTHS,
+  ARROW_HEAD,
+  estimateTextWidth,
+  TEXT_BASELINE_SHIFT,
+} from './styles.ts';
+import { measureMultilineText } from './text-metrics.ts';
+import {
+  renderMultilineText,
+  renderMultilineTextWithBackground,
+  escapeXml,
+} from './multiline-utils.ts';
+import { f } from './render-utils.ts';
 
 // ============================================================================
 // SVG renderer — converts a PositionedGraph into an SVG string.
@@ -36,54 +54,54 @@ export function renderSvg(
   graph: PositionedGraph,
   colors: DiagramColors,
   font: string = 'Inter',
-  transparent: boolean = false
+  transparent: boolean = false,
 ): string {
-  const parts: string[] = []
+  const parts: string[] = [];
 
   // SVG root with CSS variables + style block + defs
-  parts.push(svgOpenTag(graph.width, graph.height, colors, transparent))
-  parts.push(buildStyleBlock(font, false))
-  parts.push('<defs>')
-  parts.push(arrowMarkerDefs())
+  parts.push(svgOpenTag(graph.width, graph.height, colors, transparent));
+  parts.push(buildStyleBlock(font, false));
+  parts.push('<defs>');
+  parts.push(arrowMarkerDefs());
   // Per-color arrow markers for edges with custom stroke via linkStyle
-  const customStrokeColors = new Set<string>()
+  const customStrokeColors = new Set<string>();
   for (const edge of graph.edges) {
     if (edge.inlineStyle?.stroke) {
-      customStrokeColors.add(edge.inlineStyle.stroke)
+      customStrokeColors.add(edge.inlineStyle.stroke);
     }
   }
   for (const color of customStrokeColors) {
-    parts.push(arrowMarkerDefsForColor(color))
+    parts.push(arrowMarkerDefsForColor(color));
   }
-  parts.push('</defs>')
+  parts.push('</defs>');
 
   // 1. Subgraph backgrounds (group rectangles with header bands)
   for (const group of graph.groups) {
-    parts.push(renderGroup(group, font))
+    parts.push(renderGroup(group, font));
   }
 
   // 2. Edges (polylines — rendered behind nodes)
   // Each edge is a <polyline> with semantic data-* attributes
   for (const edge of graph.edges) {
-    parts.push(renderEdge(edge))
+    parts.push(renderEdge(edge));
   }
 
   // 3. Edge labels (positioned at midpoint of edge)
   // Each label is wrapped in <g class="edge-label">
   for (const edge of graph.edges) {
     if (edge.label) {
-      parts.push(renderEdgeLabel(edge, font))
+      parts.push(renderEdgeLabel(edge, font));
     }
   }
 
   // 4. Nodes (shape + label wrapped in <g class="node">)
   for (const node of graph.nodes) {
-    parts.push(renderNode(node, font))
+    parts.push(renderNode(node, font));
   }
 
-  parts.push('</svg>')
+  parts.push('</svg>');
 
-  return parts.join('\n')
+  return parts.join('\n');
 }
 
 // ============================================================================
@@ -96,22 +114,23 @@ export function renderSvg(
  * Arrow color uses var(--_arrow) CSS variable.
  */
 function arrowMarkerDefs(): string {
-  const w = ARROW_HEAD.width
-  const h = ARROW_HEAD.height
+  const w = ARROW_HEAD.width;
+  const h = ARROW_HEAD.height;
   // Arrow polygons have both fill and a thin stroke for better definition at small sizes
-  const arrowStyle = 'fill="var(--_arrow)" stroke="var(--_arrow)" stroke-width="0.75" stroke-linejoin="round"'
+  const arrowStyle =
+    'fill="var(--_arrow)" stroke="var(--_arrow)" stroke-width="0.75" stroke-linejoin="round"';
   // Pull arrowhead back slightly (refX = w - 1) to prevent clipping at node boundaries
-  const refX = w - 1
+  const refX = w - 1;
   return (
     // Forward arrow (marker-end) — orient="auto" ensures arrow points along line direction
-    `  <marker id="arrowhead" markerWidth="${w}" markerHeight="${h}" refX="${refX}" refY="${h / 2}" orient="auto">` +
-    `\n    <polygon points="0 0, ${w} ${h / 2}, 0 ${h}" ${arrowStyle} />` +
-    `\n  </marker>` +
+    f`  <marker id="arrowhead" markerWidth="${w}" markerHeight="${h}" refX="${refX}" refY="${h / 2}" orient="auto">` +
+    f`\n    <polygon points="0 0, ${w} ${h / 2}, 0 ${h}" ${arrowStyle} />` +
+    f`\n  </marker>` +
     // Reverse arrow (marker-start) — refX=1 so it sits at the line start with slight offset, auto-start-reverse flips it
-    `\n  <marker id="arrowhead-start" markerWidth="${w}" markerHeight="${h}" refX="1" refY="${h / 2}" orient="auto-start-reverse">` +
-    `\n    <polygon points="${w} 0, 0 ${h / 2}, ${w} ${h}" ${arrowStyle} />` +
-    `\n  </marker>`
-  )
+    f`\n  <marker id="arrowhead-start" markerWidth="${w}" markerHeight="${h}" refX="1" refY="${h / 2}" orient="auto-start-reverse">` +
+    f`\n    <polygon points="${w} 0, 0 ${h / 2}, ${w} ${h}" ${arrowStyle} />` +
+    f`\n  </marker>`
+  );
 }
 
 /**
@@ -119,27 +138,27 @@ function arrowMarkerDefs(): string {
  * IDs are suffixed with a sanitized color string to avoid collisions.
  */
 function arrowMarkerDefsForColor(color: string): string {
-  const w = ARROW_HEAD.width
-  const h = ARROW_HEAD.height
-  const escaped = escapeAttr(color)
-  const arrowStyle = `fill="${escaped}" stroke="${escaped}" stroke-width="0.75" stroke-linejoin="round"`
-  const refX = w - 1
-  const suffix = markerSuffix(color)
+  const w = ARROW_HEAD.width;
+  const h = ARROW_HEAD.height;
+  const escaped = escapeAttr(color);
+  const arrowStyle = `fill="${escaped}" stroke="${escaped}" stroke-width="0.75" stroke-linejoin="round"`;
+  const refX = w - 1;
+  const suffix = markerSuffix(color);
   return (
-    `  <marker id="arrowhead-${suffix}" markerWidth="${w}" markerHeight="${h}" refX="${refX}" refY="${h / 2}" orient="auto">` +
-    `\n    <polygon points="0 0, ${w} ${h / 2}, 0 ${h}" ${arrowStyle} />` +
-    `\n  </marker>` +
-    `\n  <marker id="arrowhead-start-${suffix}" markerWidth="${w}" markerHeight="${h}" refX="1" refY="${h / 2}" orient="auto-start-reverse">` +
-    `\n    <polygon points="${w} 0, 0 ${h / 2}, ${w} ${h}" ${arrowStyle} />` +
-    `\n  </marker>`
-  )
+    f`  <marker id="arrowhead-${suffix}" markerWidth="${w}" markerHeight="${h}" refX="${refX}" refY="${h / 2}" orient="auto">` +
+    f`\n    <polygon points="0 0, ${w} ${h / 2}, 0 ${h}" ${arrowStyle} />` +
+    f`\n  </marker>` +
+    f`\n  <marker id="arrowhead-start-${suffix}" markerWidth="${w}" markerHeight="${h}" refX="1" refY="${h / 2}" orient="auto-start-reverse">` +
+    f`\n    <polygon points="${w} 0, 0 ${h / 2}, ${w} ${h}" ${arrowStyle} />` +
+    f`\n  </marker>`
+  );
 }
 
 /** Sanitize a color value into a collision-free SVG ID suffix.
  *  Non-alphanumeric chars are hex-encoded so distinct inputs never collapse
  *  (e.g. "var(--line-1)" → "var28--line2d129", "var(--line1)" → "var28--line129"). */
 function markerSuffix(color: string): string {
-  return color.replace(/[^a-zA-Z0-9]/g, (ch) => ch.charCodeAt(0).toString(16))
+  return color.replace(/[^a-zA-Z0-9]/g, (ch) => ch.charCodeAt(0).toString(16));
 }
 
 // ============================================================================
@@ -147,47 +166,48 @@ function markerSuffix(color: string): string {
 // ============================================================================
 
 function renderGroup(group: PositionedGroup, font: string): string {
-  const headerHeight = FONT_SIZES.groupHeader + 16
-  const parts: string[] = []
+  const headerHeight = FONT_SIZES.groupHeader + 16;
+  const parts: string[] = [];
 
   // Opening <g> with semantic attributes for subgraph identification
   // data-id: original Mermaid subgraph ID
   // data-label: display label (may differ from ID)
   parts.push(
-    `<g class="subgraph" data-id="${escapeAttr(group.id)}" data-label="${escapeAttr(group.label)}">`
-  )
+    `<g class="subgraph" data-id="${escapeAttr(group.id)}" data-label="${escapeAttr(group.label)}">`,
+  );
 
   // Outer rectangle
   parts.push(
-    `  <rect x="${group.x}" y="${group.y}" width="${group.width}" height="${group.height}" ` +
-    `rx="0" ry="0" fill="var(--_group-fill)" stroke="var(--_node-stroke)" stroke-width="${STROKE_WIDTHS.outerBox}" />`
-  )
+    f`  <rect x="${group.x}" y="${group.y}" width="${group.width}" height="${group.height}" ` +
+      f`rx="0" ry="0" fill="var(--_group-fill)" stroke="var(--_node-stroke)" stroke-width="${STROKE_WIDTHS.outerBox}" />`,
+  );
 
   // Header band
   parts.push(
-    `  <rect x="${group.x}" y="${group.y}" width="${group.width}" height="${headerHeight}" ` +
-    `rx="0" ry="0" fill="var(--_group-hdr)" stroke="var(--_node-stroke)" stroke-width="${STROKE_WIDTHS.outerBox}" />`
-  )
+    f`  <rect x="${group.x}" y="${group.y}" width="${group.width}" height="${headerHeight}" ` +
+      f`rx="0" ry="0" fill="var(--_group-hdr)" stroke="var(--_node-stroke)" stroke-width="${STROKE_WIDTHS.outerBox}" />`,
+  );
 
   // Header label (supports multi-line via <br> tags)
   parts.push(
-    '  ' + renderMultilineText(
-      group.label,
-      group.x + 12,
-      group.y + headerHeight / 2,
-      FONT_SIZES.groupHeader,
-      `font-size="${FONT_SIZES.groupHeader}" font-weight="${FONT_WEIGHTS.groupHeader}" fill="var(--_text-sec)"`
-    )
-  )
+    '  ' +
+      renderMultilineText(
+        group.label,
+        group.x + 12,
+        group.y + headerHeight / 2,
+        FONT_SIZES.groupHeader,
+        `font-size="${FONT_SIZES.groupHeader}" font-weight="${FONT_WEIGHTS.groupHeader}" fill="var(--_text-sec)"`,
+      ),
+  );
 
   // Render nested groups recursively (inside this group)
   for (const child of group.children) {
-    parts.push(renderGroup(child, font))
+    parts.push(renderGroup(child, font));
   }
 
-  parts.push('</g>')
+  parts.push('</g>');
 
-  return parts.join('\n')
+  return parts.join('\n');
 }
 
 // ============================================================================
@@ -195,20 +215,21 @@ function renderGroup(group: PositionedGroup, font: string): string {
 // ============================================================================
 
 function renderEdge(edge: PositionedEdge): string {
-  if (edge.points.length < 2) return ''
+  if (edge.points.length < 2) return '';
 
-  const pathData = pointsToPolylinePath(edge.points)
-  const dashArray = edge.style === 'dotted' ? ' stroke-dasharray="4 4"' : ''
-  const baseStrokeWidth = edge.style === 'thick' ? STROKE_WIDTHS.connector * 2 : STROKE_WIDTHS.connector
-  const strokeColor = escapeAttr(edge.inlineStyle?.stroke ?? 'var(--_line)')
-  const strokeWidth = escapeAttr(edge.inlineStyle?.['stroke-width'] ?? String(baseStrokeWidth))
+  const pathData = pointsToPolylinePath(edge.points);
+  const dashArray = edge.style === 'dotted' ? ' stroke-dasharray="4 4"' : '';
+  const baseStrokeWidth =
+    edge.style === 'thick' ? STROKE_WIDTHS.connector * 2 : STROKE_WIDTHS.connector;
+  const strokeColor = escapeAttr(edge.inlineStyle?.stroke ?? 'var(--_line)');
+  const strokeWidth = escapeAttr(edge.inlineStyle?.['stroke-width'] ?? String(baseStrokeWidth));
 
   // Build marker attributes based on arrow direction flags
   // Use color-specific markers when edge has a custom stroke from linkStyle
-  const suffix = edge.inlineStyle?.stroke ? `-${markerSuffix(edge.inlineStyle.stroke)}` : ''
-  let markers = ''
-  if (edge.hasArrowEnd) markers += ` marker-end="url(#arrowhead${suffix})"`
-  if (edge.hasArrowStart) markers += ` marker-start="url(#arrowhead-start${suffix})"`
+  const suffix = edge.inlineStyle?.stroke ? `-${markerSuffix(edge.inlineStyle.stroke)}` : '';
+  let markers = '';
+  if (edge.hasArrowEnd) markers += ` marker-end="url(#arrowhead${suffix})"`;
+  if (edge.hasArrowStart) markers += ` marker-start="url(#arrowhead-start${suffix})"`;
 
   // Semantic data attributes for edge identification and inspection:
   // - class="edge": CSS targeting and type identification
@@ -223,31 +244,31 @@ function renderEdge(edge: PositionedEdge): string {
     `data-style="${edge.style}"`,
     `data-arrow-start="${edge.hasArrowStart}"`,
     `data-arrow-end="${edge.hasArrowEnd}"`,
-  ]
+  ];
   if (edge.label) {
-    dataAttrs.push(`data-label="${escapeAttr(edge.label)}"`)
+    dataAttrs.push(`data-label="${escapeAttr(edge.label)}"`);
   }
 
   return (
     `<polyline ${dataAttrs.join(' ')} points="${pathData}" fill="none" stroke="${strokeColor}" ` +
     `stroke-width="${strokeWidth}"${dashArray}${markers} />`
-  )
+  );
 }
 
 /** Convert points to SVG polyline points attribute: "x1,y1 x2,y2 ..." */
 function pointsToPolylinePath(points: Point[]): string {
-  return points.map(p => `${p.x},${p.y}`).join(' ')
+  return points.map((p) => f`${p.x},${p.y}`).join(' ');
 }
 
 function renderEdgeLabel(edge: PositionedEdge, font: string): string {
   // Use layout-computed label position when available (layout-aware, avoids collisions).
   // Fall back to geometric midpoint of the edge polyline.
-  const mid = edge.labelPosition ?? edgeMidpoint(edge.points)
-  const label = edge.label!
-  const padding = 8
+  const mid = edge.labelPosition ?? edgeMidpoint(edge.points);
+  const label = edge.label!;
+  const padding = 8;
 
   // Measure text (works for both single and multi-line)
-  const metrics = measureMultilineText(label, FONT_SIZES.edgeLabel, FONT_WEIGHTS.edgeLabel)
+  const metrics = measureMultilineText(label, FONT_SIZES.edgeLabel, FONT_WEIGHTS.edgeLabel);
 
   // Wrap in <g class="edge-label"> with reference to the edge it belongs to
   const content = renderMultilineTextWithBackground(
@@ -261,47 +282,47 @@ function renderEdgeLabel(edge: PositionedEdge, font: string): string {
     // Use --_text-sec for better contrast (was --_text-muted)
     `text-anchor="middle" font-size="${FONT_SIZES.edgeLabel}" font-weight="${FONT_WEIGHTS.edgeLabel}" fill="var(--_text-sec)"`,
     // Increased stroke width from 0.5 to 1 for better label separation from edges
-    `rx="2" ry="2" fill="var(--bg)" stroke="var(--_inner-stroke)" stroke-width="1"`
-  )
+    `rx="2" ry="2" fill="var(--bg)" stroke="var(--_inner-stroke)" stroke-width="1"`,
+  );
 
   // Semantic wrapper: links label to its edge via data-from/data-to
   return (
     `<g class="edge-label" data-from="${escapeAttr(edge.source)}" data-to="${escapeAttr(edge.target)}" data-label="${escapeAttr(label)}">\n` +
     `  ${content.replace(/\n/g, '\n  ')}\n` +
     `</g>`
-  )
+  );
 }
 
 /** Get the midpoint of a polyline (by walking segments) */
 function edgeMidpoint(points: Point[]): Point {
-  if (points.length === 0) return { x: 0, y: 0 }
-  if (points.length === 1) return points[0]!
+  if (points.length === 0) return { x: 0, y: 0 };
+  if (points.length === 1) return points[0]!;
 
   // Calculate total length
-  let totalLength = 0
+  let totalLength = 0;
   for (let i = 1; i < points.length; i++) {
-    totalLength += dist(points[i - 1]!, points[i]!)
+    totalLength += dist(points[i - 1]!, points[i]!);
   }
 
   // Walk to the halfway point
-  let remaining = totalLength / 2
+  let remaining = totalLength / 2;
   for (let i = 1; i < points.length; i++) {
-    const segLen = dist(points[i - 1]!, points[i]!)
+    const segLen = dist(points[i - 1]!, points[i]!);
     if (remaining <= segLen) {
-      const t = remaining / segLen
+      const t = remaining / segLen;
       return {
         x: points[i - 1]!.x + t * (points[i]!.x - points[i - 1]!.x),
         y: points[i - 1]!.y + t * (points[i]!.y - points[i - 1]!.y),
-      }
+      };
     }
-    remaining -= segLen
+    remaining -= segLen;
   }
 
-  return points[points.length - 1]!
+  return points[points.length - 1]!;
 }
 
 function dist(a: Point, b: Point): number {
-  return Math.sqrt((b.x - a.x) ** 2 + (b.y - a.y) ** 2)
+  return Math.sqrt((b.x - a.x) ** 2 + (b.y - a.y) ** 2);
 }
 
 // ============================================================================
@@ -317,248 +338,342 @@ function dist(a: Point, b: Point): number {
  * - data-shape: shape type (rectangle, diamond, circle, etc.)
  */
 function renderNode(node: PositionedNode, font: string): string {
-  const shape = renderNodeShape(node)
-  const label = renderNodeLabel(node, font)
+  const shape = renderNodeShape(node);
+  const label = renderNodeLabel(node, font);
 
   // Combine shape and label inside a semantic group
   // This enables reliable node identification without heuristics
-  const parts: string[] = []
+  const parts: string[] = [];
   parts.push(
-    `<g class="node" data-id="${escapeAttr(node.id)}" data-label="${escapeAttr(node.label)}" data-shape="${node.shape}">`
-  )
-  parts.push(`  ${shape.replace(/\n/g, '\n  ')}`)
+    `<g class="node" data-id="${escapeAttr(node.id)}" data-label="${escapeAttr(node.label)}" data-shape="${node.shape}">`,
+  );
+  parts.push(`  ${shape.replace(/\n/g, '\n  ')}`);
   if (label) {
-    parts.push(`  ${label.replace(/\n/g, '\n  ')}`)
+    parts.push(`  ${label.replace(/\n/g, '\n  ')}`);
   }
-  parts.push('</g>')
+  parts.push('</g>');
 
-  return parts.join('\n')
+  return parts.join('\n');
 }
 
 function renderNodeShape(node: PositionedNode): string {
-  const { x, y, width, height, shape, inlineStyle } = node
+  const { x, y, width, height, shape, inlineStyle } = node;
 
   // Resolve fill and stroke — inline styles (from mermaid `style` directives)
   // override the CSS variable defaults. When no inline style is present, the
   // CSS variable handles theming automatically via color-mix() derivation.
-  const fill = escapeAttr(inlineStyle?.fill ?? 'var(--_node-fill)')
-  const stroke = escapeAttr(inlineStyle?.stroke ?? 'var(--_node-stroke)')
-  const sw = escapeAttr(inlineStyle?.['stroke-width'] ?? String(STROKE_WIDTHS.innerBox))
+  const fill = escapeAttr(inlineStyle?.fill ?? 'var(--_node-fill)');
+  const stroke = escapeAttr(inlineStyle?.stroke ?? 'var(--_node-stroke)');
+  const sw = escapeAttr(inlineStyle?.['stroke-width'] ?? String(STROKE_WIDTHS.innerBox));
 
   switch (shape) {
     case 'diamond':
-      return renderDiamond(x, y, width, height, fill, stroke, sw)
+      return renderDiamond(x, y, width, height, fill, stroke, sw);
     case 'rounded':
-      return renderRoundedRect(x, y, width, height, fill, stroke, sw)
+      return renderRoundedRect(x, y, width, height, fill, stroke, sw);
     case 'stadium':
-      return renderStadium(x, y, width, height, fill, stroke, sw)
+      return renderStadium(x, y, width, height, fill, stroke, sw);
     case 'circle':
-      return renderCircle(x, y, width, height, fill, stroke, sw)
+      return renderCircle(x, y, width, height, fill, stroke, sw);
     case 'subroutine':
-      return renderSubroutine(x, y, width, height, fill, stroke, sw)
+      return renderSubroutine(x, y, width, height, fill, stroke, sw);
     case 'doublecircle':
-      return renderDoubleCircle(x, y, width, height, fill, stroke, sw)
+      return renderDoubleCircle(x, y, width, height, fill, stroke, sw);
     case 'hexagon':
-      return renderHexagon(x, y, width, height, fill, stroke, sw)
+      return renderHexagon(x, y, width, height, fill, stroke, sw);
     case 'cylinder':
-      return renderCylinder(x, y, width, height, fill, stroke, sw)
+      return renderCylinder(x, y, width, height, fill, stroke, sw);
     case 'asymmetric':
-      return renderAsymmetric(x, y, width, height, fill, stroke, sw)
+      return renderAsymmetric(x, y, width, height, fill, stroke, sw);
     case 'trapezoid':
-      return renderTrapezoid(x, y, width, height, fill, stroke, sw)
+      return renderTrapezoid(x, y, width, height, fill, stroke, sw);
     case 'trapezoid-alt':
-      return renderTrapezoidAlt(x, y, width, height, fill, stroke, sw)
+      return renderTrapezoidAlt(x, y, width, height, fill, stroke, sw);
     case 'state-start':
-      return renderStateStart(x, y, width, height)
+      return renderStateStart(x, y, width, height);
     case 'state-end':
-      return renderStateEnd(x, y, width, height)
+      return renderStateEnd(x, y, width, height);
     case 'rectangle':
     default:
-      return renderRect(x, y, width, height, fill, stroke, sw)
+      return renderRect(x, y, width, height, fill, stroke, sw);
   }
 }
 
 // --- Basic shapes ---
 
-function renderRect(x: number, y: number, w: number, h: number, fill: string, stroke: string, sw: string): string {
+function renderRect(
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+  fill: string,
+  stroke: string,
+  sw: string,
+): string {
   return (
-    `<rect x="${x}" y="${y}" width="${w}" height="${h}" ` +
+    f`<rect x="${x}" y="${y}" width="${w}" height="${h}" ` +
     `rx="0" ry="0" fill="${fill}" stroke="${stroke}" stroke-width="${sw}" />`
-  )
+  );
 }
 
-function renderRoundedRect(x: number, y: number, w: number, h: number, fill: string, stroke: string, sw: string): string {
+function renderRoundedRect(
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+  fill: string,
+  stroke: string,
+  sw: string,
+): string {
   return (
-    `<rect x="${x}" y="${y}" width="${w}" height="${h}" ` +
+    f`<rect x="${x}" y="${y}" width="${w}" height="${h}" ` +
     `rx="6" ry="6" fill="${fill}" stroke="${stroke}" stroke-width="${sw}" />`
-  )
+  );
 }
 
-function renderStadium(x: number, y: number, w: number, h: number, fill: string, stroke: string, sw: string): string {
-  const r = h / 2
+function renderStadium(
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+  fill: string,
+  stroke: string,
+  sw: string,
+): string {
+  const r = h / 2;
   return (
-    `<rect x="${x}" y="${y}" width="${w}" height="${h}" ` +
-    `rx="${r}" ry="${r}" fill="${fill}" stroke="${stroke}" stroke-width="${sw}" />`
-  )
+    f`<rect x="${x}" y="${y}" width="${w}" height="${h}" ` +
+    f`rx="${r}" ry="${r}" fill="${fill}" stroke="${stroke}" stroke-width="${sw}" />`
+  );
 }
 
-function renderCircle(x: number, y: number, w: number, h: number, fill: string, stroke: string, sw: string): string {
-  const cx = x + w / 2
-  const cy = y + h / 2
-  const r = Math.min(w, h) / 2
+function renderCircle(
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+  fill: string,
+  stroke: string,
+  sw: string,
+): string {
+  const cx = x + w / 2;
+  const cy = y + h / 2;
+  const r = Math.min(w, h) / 2;
   return (
-    `<circle cx="${cx}" cy="${cy}" r="${r}" ` +
+    f`<circle cx="${cx}" cy="${cy}" r="${r}" ` +
     `fill="${fill}" stroke="${stroke}" stroke-width="${sw}" />`
-  )
+  );
 }
 
-function renderDiamond(x: number, y: number, w: number, h: number, fill: string, stroke: string, sw: string): string {
-  const cx = x + w / 2
-  const cy = y + h / 2
-  const hw = w / 2
-  const hh = h / 2
+function renderDiamond(
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+  fill: string,
+  stroke: string,
+  sw: string,
+): string {
+  const cx = x + w / 2;
+  const cy = y + h / 2;
+  const hw = w / 2;
+  const hh = h / 2;
   const points = [
-    `${cx},${cy - hh}`,   // top
-    `${cx + hw},${cy}`,   // right
-    `${cx},${cy + hh}`,   // bottom
-    `${cx - hw},${cy}`,   // left
-  ].join(' ')
+    f`${cx},${cy - hh}`, // top
+    f`${cx + hw},${cy}`, // right
+    f`${cx},${cy + hh}`, // bottom
+    f`${cx - hw},${cy}`, // left
+  ].join(' ');
 
-  return (
-    `<polygon points="${points}" fill="${fill}" stroke="${stroke}" stroke-width="${sw}" />`
-  )
+  return `<polygon points="${points}" fill="${fill}" stroke="${stroke}" stroke-width="${sw}" />`;
 }
 
 // --- Batch 1 shapes ---
 
 /** Subroutine: rectangle with double vertical borders on left and right */
-function renderSubroutine(x: number, y: number, w: number, h: number, fill: string, stroke: string, sw: string): string {
-  const inset = 8 // distance from edge to inner vertical line
+function renderSubroutine(
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+  fill: string,
+  stroke: string,
+  sw: string,
+): string {
+  const inset = 8; // distance from edge to inner vertical line
   return (
-    `<rect x="${x}" y="${y}" width="${w}" height="${h}" ` +
+    f`<rect x="${x}" y="${y}" width="${w}" height="${h}" ` +
     `rx="0" ry="0" fill="${fill}" stroke="${stroke}" stroke-width="${sw}" />` +
-    `\n<line x1="${x + inset}" y1="${y}" x2="${x + inset}" y2="${y + h}" ` +
+    f`\n<line x1="${x + inset}" y1="${y}" x2="${x + inset}" y2="${y + h}" ` +
     `stroke="${stroke}" stroke-width="${sw}" />` +
-    `\n<line x1="${x + w - inset}" y1="${y}" x2="${x + w - inset}" y2="${y + h}" ` +
+    f`\n<line x1="${x + w - inset}" y1="${y}" x2="${x + w - inset}" y2="${y + h}" ` +
     `stroke="${stroke}" stroke-width="${sw}" />`
-  )
+  );
 }
 
 /** Double circle: two concentric circles with a gap between them */
-function renderDoubleCircle(x: number, y: number, w: number, h: number, fill: string, stroke: string, sw: string): string {
-  const cx = x + w / 2
-  const cy = y + h / 2
-  const outerR = Math.min(w, h) / 2
-  const innerR = outerR - 5 // 5px gap between rings
+function renderDoubleCircle(
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+  fill: string,
+  stroke: string,
+  sw: string,
+): string {
+  const cx = x + w / 2;
+  const cy = y + h / 2;
+  const outerR = Math.min(w, h) / 2;
+  const innerR = outerR - 5; // 5px gap between rings
   return (
-    `<circle cx="${cx}" cy="${cy}" r="${outerR}" ` +
+    f`<circle cx="${cx}" cy="${cy}" r="${outerR}" ` +
     `fill="${fill}" stroke="${stroke}" stroke-width="${sw}" />` +
-    `\n<circle cx="${cx}" cy="${cy}" r="${innerR}" ` +
+    f`\n<circle cx="${cx}" cy="${cy}" r="${innerR}" ` +
     `fill="${fill}" stroke="${stroke}" stroke-width="${sw}" />`
-  )
+  );
 }
 
 /** Hexagon: 6-point polygon with flat top/bottom and angled sides */
-function renderHexagon(x: number, y: number, w: number, h: number, fill: string, stroke: string, sw: string): string {
-  const inset = h / 4 // horizontal inset for the angled sides
+function renderHexagon(
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+  fill: string,
+  stroke: string,
+  sw: string,
+): string {
+  const inset = h / 4; // horizontal inset for the angled sides
   const points = [
-    `${x + inset},${y}`,           // top-left
-    `${x + w - inset},${y}`,       // top-right
-    `${x + w},${y + h / 2}`,       // mid-right
-    `${x + w - inset},${y + h}`,   // bottom-right
-    `${x + inset},${y + h}`,       // bottom-left
-    `${x},${y + h / 2}`,           // mid-left
-  ].join(' ')
+    f`${x + inset},${y}`, // top-left
+    f`${x + w - inset},${y}`, // top-right
+    f`${x + w},${y + h / 2}`, // mid-right
+    f`${x + w - inset},${y + h}`, // bottom-right
+    f`${x + inset},${y + h}`, // bottom-left
+    f`${x},${y + h / 2}`, // mid-left
+  ].join(' ');
 
-  return `<polygon points="${points}" fill="${fill}" stroke="${stroke}" stroke-width="${sw}" />`
+  return `<polygon points="${points}" fill="${fill}" stroke="${stroke}" stroke-width="${sw}" />`;
 }
 
 // --- Batch 2 shapes ---
 
 /** Cylinder / database: top ellipse cap + body rect + bottom ellipse */
-function renderCylinder(x: number, y: number, w: number, h: number, fill: string, stroke: string, sw: string): string {
-  const ry = 7 // ellipse vertical radius for the cap
-  const cx = x + w / 2
-  const bodyTop = y + ry
-  const bodyH = h - 2 * ry
+function renderCylinder(
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+  fill: string,
+  stroke: string,
+  sw: string,
+): string {
+  const ry = 7; // ellipse vertical radius for the cap
+  const cx = x + w / 2;
+  const bodyTop = y + ry;
+  const bodyH = h - 2 * ry;
 
   return (
     // Body rectangle (no top border — covered by top ellipse)
-    `<rect x="${x}" y="${bodyTop}" width="${w}" height="${bodyH}" ` +
+    f`<rect x="${x}" y="${bodyTop}" width="${w}" height="${bodyH}" ` +
     `fill="${fill}" stroke="none" />` +
     // Left and right body borders
-    `\n<line x1="${x}" y1="${bodyTop}" x2="${x}" y2="${bodyTop + bodyH}" stroke="${stroke}" stroke-width="${sw}" />` +
-    `\n<line x1="${x + w}" y1="${bodyTop}" x2="${x + w}" y2="${bodyTop + bodyH}" stroke="${stroke}" stroke-width="${sw}" />` +
+    f`\n<line x1="${x}" y1="${bodyTop}" x2="${x}" y2="${bodyTop + bodyH}" stroke="${stroke}" stroke-width="${sw}" />` +
+    f`\n<line x1="${x + w}" y1="${bodyTop}" x2="${x + w}" y2="${bodyTop + bodyH}" stroke="${stroke}" stroke-width="${sw}" />` +
     // Bottom ellipse (half visible)
-    `\n<ellipse cx="${cx}" cy="${y + h - ry}" rx="${w / 2}" ry="${ry}" ` +
+    f`\n<ellipse cx="${cx}" cy="${y + h - ry}" rx="${w / 2}" ry="${ry}" ` +
     `fill="${fill}" stroke="${stroke}" stroke-width="${sw}" />` +
     // Top ellipse (full, on top)
-    `\n<ellipse cx="${cx}" cy="${bodyTop}" rx="${w / 2}" ry="${ry}" ` +
+    f`\n<ellipse cx="${cx}" cy="${bodyTop}" rx="${w / 2}" ry="${ry}" ` +
     `fill="${fill}" stroke="${stroke}" stroke-width="${sw}" />`
-  )
+  );
 }
 
 /** Asymmetric / flag: rectangle with a pointed left edge */
-function renderAsymmetric(x: number, y: number, w: number, h: number, fill: string, stroke: string, sw: string): string {
-  const indent = 12 // how far the point indents
+function renderAsymmetric(
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+  fill: string,
+  stroke: string,
+  sw: string,
+): string {
+  const indent = 12; // how far the point indents
   const points = [
-    `${x + indent},${y}`,       // top-left (indented)
-    `${x + w},${y}`,            // top-right
-    `${x + w},${y + h}`,        // bottom-right
-    `${x + indent},${y + h}`,   // bottom-left (indented)
-    `${x},${y + h / 2}`,        // left point
-  ].join(' ')
+    f`${x + indent},${y}`, // top-left (indented)
+    f`${x + w},${y}`, // top-right
+    f`${x + w},${y + h}`, // bottom-right
+    f`${x + indent},${y + h}`, // bottom-left (indented)
+    f`${x},${y + h / 2}`, // left point
+  ].join(' ');
 
-  return `<polygon points="${points}" fill="${fill}" stroke="${stroke}" stroke-width="${sw}" />`
+  return `<polygon points="${points}" fill="${fill}" stroke="${stroke}" stroke-width="${sw}" />`;
 }
 
 /** Trapezoid [/text\]: wider bottom, narrower top */
-function renderTrapezoid(x: number, y: number, w: number, h: number, fill: string, stroke: string, sw: string): string {
-  const inset = w * 0.15 // top edge is narrower by this amount on each side
+function renderTrapezoid(
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+  fill: string,
+  stroke: string,
+  sw: string,
+): string {
+  const inset = w * 0.15; // top edge is narrower by this amount on each side
   const points = [
-    `${x + inset},${y}`,         // top-left (indented)
-    `${x + w - inset},${y}`,     // top-right (indented)
-    `${x + w},${y + h}`,         // bottom-right (full width)
-    `${x},${y + h}`,             // bottom-left (full width)
-  ].join(' ')
+    f`${x + inset},${y}`, // top-left (indented)
+    f`${x + w - inset},${y}`, // top-right (indented)
+    f`${x + w},${y + h}`, // bottom-right (full width)
+    f`${x},${y + h}`, // bottom-left (full width)
+  ].join(' ');
 
-  return `<polygon points="${points}" fill="${fill}" stroke="${stroke}" stroke-width="${sw}" />`
+  return `<polygon points="${points}" fill="${fill}" stroke="${stroke}" stroke-width="${sw}" />`;
 }
 
 /** Trapezoid-alt [\text/]: wider top, narrower bottom */
-function renderTrapezoidAlt(x: number, y: number, w: number, h: number, fill: string, stroke: string, sw: string): string {
-  const inset = w * 0.15 // bottom edge is narrower
+function renderTrapezoidAlt(
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+  fill: string,
+  stroke: string,
+  sw: string,
+): string {
+  const inset = w * 0.15; // bottom edge is narrower
   const points = [
-    `${x},${y}`,                     // top-left (full width)
-    `${x + w},${y}`,                 // top-right (full width)
-    `${x + w - inset},${y + h}`,     // bottom-right (indented)
-    `${x + inset},${y + h}`,         // bottom-left (indented)
-  ].join(' ')
+    f`${x},${y}`, // top-left (full width)
+    f`${x + w},${y}`, // top-right (full width)
+    f`${x + w - inset},${y + h}`, // bottom-right (indented)
+    f`${x + inset},${y + h}`, // bottom-left (indented)
+  ].join(' ');
 
-  return `<polygon points="${points}" fill="${fill}" stroke="${stroke}" stroke-width="${sw}" />`
+  return `<polygon points="${points}" fill="${fill}" stroke="${stroke}" stroke-width="${sw}" />`;
 }
 
 // --- Batch 3: State diagram pseudostates ---
 
 /** State start: small filled circle using primary text color */
 function renderStateStart(x: number, y: number, w: number, h: number): string {
-  const cx = x + w / 2
-  const cy = y + h / 2
-  const r = Math.min(w, h) / 2 - 2
-  return `<circle cx="${cx}" cy="${cy}" r="${r}" fill="var(--_text)" stroke="none" />`
+  const cx = x + w / 2;
+  const cy = y + h / 2;
+  const r = Math.min(w, h) / 2 - 2;
+  return f`<circle cx="${cx}" cy="${cy}" r="${r}" fill="var(--_text)" stroke="none" />`;
 }
 
 /** State end: bullseye — outer ring + inner filled circle using primary text color */
 function renderStateEnd(x: number, y: number, w: number, h: number): string {
-  const cx = x + w / 2
-  const cy = y + h / 2
-  const outerR = Math.min(w, h) / 2 - 2
-  const innerR = outerR - 4
+  const cx = x + w / 2;
+  const cy = y + h / 2;
+  const outerR = Math.min(w, h) / 2 - 2;
+  const innerR = outerR - 4;
   return (
-    `<circle cx="${cx}" cy="${cy}" r="${outerR}" ` +
-    `fill="none" stroke="var(--_text)" stroke-width="${STROKE_WIDTHS.innerBox * 2}" />` +
-    `\n<circle cx="${cx}" cy="${cy}" r="${innerR}" fill="var(--_text)" stroke="none" />`
-  )
+    f`<circle cx="${cx}" cy="${cy}" r="${outerR}" ` +
+    f`fill="none" stroke="var(--_text)" stroke-width="${STROKE_WIDTHS.innerBox * 2}" />` +
+    f`\n<circle cx="${cx}" cy="${cy}" r="${innerR}" fill="var(--_text)" stroke="none" />`
+  );
 }
 
 // ============================================================================
@@ -568,22 +683,22 @@ function renderStateEnd(x: number, y: number, w: number, h: number): string {
 function renderNodeLabel(node: PositionedNode, font: string): string {
   // State pseudostates have no label
   if (node.shape === 'state-start' || node.shape === 'state-end') {
-    if (!node.label) return ''
+    if (!node.label) return '';
   }
 
-  const cx = node.x + node.width / 2
-  const cy = node.y + node.height / 2
+  const cx = node.x + node.width / 2;
+  const cy = node.y + node.height / 2;
 
   // Resolve text color — inline styles can override the CSS variable default
-  const textColor = escapeAttr(node.inlineStyle?.color ?? 'var(--_text)')
+  const textColor = escapeAttr(node.inlineStyle?.color ?? 'var(--_text)');
 
   return renderMultilineText(
     node.label,
     cx,
     cy,
     FONT_SIZES.nodeLabel,
-    `text-anchor="middle" font-size="${FONT_SIZES.nodeLabel}" font-weight="${FONT_WEIGHTS.nodeLabel}" fill="${textColor}"`
-  )
+    `text-anchor="middle" font-size="${FONT_SIZES.nodeLabel}" font-weight="${FONT_WEIGHTS.nodeLabel}" fill="${textColor}"`,
+  );
 }
 
 // ============================================================================
@@ -599,5 +714,5 @@ function escapeAttr(value: string): string {
     .replace(/&/g, '&amp;')
     .replace(/"/g, '&quot;')
     .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
+    .replace(/>/g, '&gt;');
 }

--- a/src/sequence/renderer.ts
+++ b/src/sequence/renderer.ts
@@ -1,8 +1,24 @@
-import type { PositionedSequenceDiagram, PositionedActor, Lifeline, PositionedMessage, Activation, PositionedBlock, PositionedNote } from './types.ts'
-import type { DiagramColors } from '../theme.ts'
-import { svgOpenTag, buildStyleBlock } from '../theme.ts'
-import { FONT_SIZES, FONT_WEIGHTS, STROKE_WIDTHS, ARROW_HEAD, estimateTextWidth, TEXT_BASELINE_SHIFT } from '../styles.ts'
-import { renderMultilineText, escapeXml as escapeXmlUtil } from '../multiline-utils.ts'
+import type {
+  PositionedSequenceDiagram,
+  PositionedActor,
+  Lifeline,
+  PositionedMessage,
+  Activation,
+  PositionedBlock,
+  PositionedNote,
+} from './types.ts';
+import type { DiagramColors } from '../theme.ts';
+import { svgOpenTag, buildStyleBlock } from '../theme.ts';
+import {
+  FONT_SIZES,
+  FONT_WEIGHTS,
+  STROKE_WIDTHS,
+  ARROW_HEAD,
+  estimateTextWidth,
+  TEXT_BASELINE_SHIFT,
+} from '../styles.ts';
+import { renderMultilineText, escapeXml as escapeXmlUtil } from '../multiline-utils.ts';
+import { f } from '../render-utils.ts';
 
 // ============================================================================
 // Sequence diagram SVG renderer
@@ -29,51 +45,51 @@ export function renderSequenceSvg(
   diagram: PositionedSequenceDiagram,
   colors: DiagramColors,
   font: string = 'Inter',
-  transparent: boolean = false
+  transparent: boolean = false,
 ): string {
-  const parts: string[] = []
+  const parts: string[] = [];
 
   // SVG root with CSS variables + style block + defs
-  parts.push(svgOpenTag(diagram.width, diagram.height, colors, transparent))
-  parts.push(buildStyleBlock(font, false))
-  parts.push('<defs>')
+  parts.push(svgOpenTag(diagram.width, diagram.height, colors, transparent));
+  parts.push(buildStyleBlock(font, false));
+  parts.push('<defs>');
 
   // Arrow marker definitions
-  parts.push(arrowMarkerDefs())
-  parts.push('</defs>')
+  parts.push(arrowMarkerDefs());
+  parts.push('</defs>');
 
   // 1. Block backgrounds (loop/alt/opt rectangles)
   for (const block of diagram.blocks) {
-    parts.push(renderBlock(block))
+    parts.push(renderBlock(block));
   }
 
   // 2. Lifelines (dashed vertical lines from actor to bottom)
   for (const lifeline of diagram.lifelines) {
-    parts.push(renderLifeline(lifeline))
+    parts.push(renderLifeline(lifeline));
   }
 
   // 3. Activation boxes
   for (const activation of diagram.activations) {
-    parts.push(renderActivation(activation))
+    parts.push(renderActivation(activation));
   }
 
   // 4. Messages (horizontal arrows with labels)
   for (const message of diagram.messages) {
-    parts.push(renderMessage(message))
+    parts.push(renderMessage(message));
   }
 
   // 5. Notes
   for (const note of diagram.notes) {
-    parts.push(renderNote(note))
+    parts.push(renderNote(note));
   }
 
   // 6. Actor boxes at top (rendered last so they're on top)
   for (const actor of diagram.actors) {
-    parts.push(renderActor(actor))
+    parts.push(renderActor(actor));
   }
 
-  parts.push('</svg>')
-  return parts.join('\n')
+  parts.push('</svg>');
+  return parts.join('\n');
 }
 
 // ============================================================================
@@ -81,17 +97,17 @@ export function renderSequenceSvg(
 // ============================================================================
 
 function arrowMarkerDefs(): string {
-  const w = ARROW_HEAD.width
-  const h = ARROW_HEAD.height
+  const w = ARROW_HEAD.width;
+  const h = ARROW_HEAD.height;
   return (
-    `  <marker id="seq-arrow" markerWidth="${w}" markerHeight="${h}" refX="${w}" refY="${h / 2}" orient="auto-start-reverse">` +
-    `\n    <polygon points="0 0, ${w} ${h / 2}, 0 ${h}" fill="var(--_arrow)" />` +
-    `\n  </marker>` +
+    f`  <marker id="seq-arrow" markerWidth="${w}" markerHeight="${h}" refX="${w}" refY="${h / 2}" orient="auto-start-reverse">` +
+    f`\n    <polygon points="0 0, ${w} ${h / 2}, 0 ${h}" fill="var(--_arrow)" />` +
+    f`\n  </marker>` +
     // Open arrow head (just lines, no fill)
-    `\n  <marker id="seq-arrow-open" markerWidth="${w}" markerHeight="${h}" refX="${w}" refY="${h / 2}" orient="auto-start-reverse">` +
-    `\n    <polyline points="0 0, ${w} ${h / 2}, 0 ${h}" fill="none" stroke="var(--_arrow)" stroke-width="1" />` +
-    `\n  </marker>`
-  )
+    f`\n  <marker id="seq-arrow-open" markerWidth="${w}" markerHeight="${h}" refX="${w}" refY="${h / 2}" orient="auto-start-reverse">` +
+    f`\n    <polyline points="0 0, ${w} ${h / 2}, 0 ${h}" fill="none" stroke="var(--_arrow)" stroke-width="1" />` +
+    f`\n  </marker>`
+  );
 }
 
 // ============================================================================
@@ -103,55 +119,67 @@ function arrowMarkerDefs(): string {
  * Wrapped in <g class="actor"> with semantic data attributes.
  */
 function renderActor(actor: PositionedActor): string {
-  const { id, x, y, width, height, label, type } = actor
-  const parts: string[] = []
+  const { id, x, y, width, height, label, type } = actor;
+  const parts: string[] = [];
 
   // Semantic wrapper with actor metadata
   parts.push(
-    `<g class="actor" data-id="${escapeAttr(id)}" data-label="${escapeAttr(label)}" data-type="${type}">`
-  )
+    `<g class="actor" data-id="${escapeAttr(id)}" data-label="${escapeAttr(label)}" data-type="${type}">`,
+  );
 
   if (type === 'actor') {
     // Circle-person icon: outer circle + head circle + shoulders arc.
     // Defined in a 24×24 coordinate space, scaled to 90% of the actor box height
     // and centered both horizontally and vertically within the box.
     // Stroke width is inverse-scaled so the visual thickness matches STROKE_WIDTHS.outerBox.
-    const s = (height / 24) * 0.9
-    const tx = x - 12 * s            // center icon horizontally on actor.x
-    const ty = y + (height - 24 * s) / 2  // center icon vertically in actor box
-    const sw = STROKE_WIDTHS.outerBox / s  // compensate for scale transform
-    const iconStroke = 'var(--_line)'      // use line color for actor icon strokes
+    const s = (height / 24) * 0.9;
+    const tx = x - 12 * s; // center icon horizontally on actor.x
+    const ty = y + (height - 24 * s) / 2; // center icon vertically in actor box
+    const sw = STROKE_WIDTHS.outerBox / s; // compensate for scale transform
+    const iconStroke = 'var(--_line)'; // use line color for actor icon strokes
 
     parts.push(
-      `  <g transform="translate(${tx},${ty}) scale(${s})">` +
-      // Outer circle
-      `\n    <path d="M21 12C21 16.9706 16.9706 21 12 21C7.02944 21 3 16.9706 3 12C3 7.02944 7.02944 3 12 3C16.9706 3 21 7.02944 21 12Z" fill="none" stroke="${iconStroke}" stroke-width="${sw}" />` +
-      // Head
-      `\n    <path d="M15 10C15 11.6569 13.6569 13 12 13C10.3431 13 9 11.6569 9 10C9 8.34315 10.3431 7 12 7C13.6569 7 15 8.34315 15 10Z" fill="none" stroke="${iconStroke}" stroke-width="${sw}" />` +
-      // Shoulders
-      `\n    <path d="M5.62842 18.3563C7.08963 17.0398 9.39997 16 12 16C14.6 16 16.9104 17.0398 18.3716 18.3563" fill="none" stroke="${iconStroke}" stroke-width="${sw}" />` +
-      `\n  </g>`
-    )
+      f`  <g transform="translate(${tx},${ty}) scale(${s})">` +
+        // Outer circle
+        f`\n    <path d="M21 12C21 16.9706 16.9706 21 12 21C7.02944 21 3 16.9706 3 12C3 7.02944 7.02944 3 12 3C16.9706 3 21 7.02944 21 12Z" fill="none" stroke="${iconStroke}" stroke-width="${sw}" />` +
+        // Head
+        f`\n    <path d="M15 10C15 11.6569 13.6569 13 12 13C10.3431 13 9 11.6569 9 10C9 8.34315 10.3431 7 12 7C13.6569 7 15 8.34315 15 10Z" fill="none" stroke="${iconStroke}" stroke-width="${sw}" />` +
+        // Shoulders
+        f`\n    <path d="M5.62842 18.3563C7.08963 17.0398 9.39997 16 12 16C14.6 16 16.9104 17.0398 18.3716 18.3563" fill="none" stroke="${iconStroke}" stroke-width="${sw}" />` +
+        `\n  </g>`,
+    );
     // Label below the icon (supports multi-line)
     parts.push(
-      '  ' + renderMultilineText(label, x, y + height + 14, FONT_SIZES.nodeLabel,
-        `font-size="${FONT_SIZES.nodeLabel}" text-anchor="middle" font-weight="${FONT_WEIGHTS.nodeLabel}" fill="var(--_text)"`)
-    )
+      '  ' +
+        renderMultilineText(
+          label,
+          x,
+          y + height + 14,
+          FONT_SIZES.nodeLabel,
+          `font-size="${FONT_SIZES.nodeLabel}" text-anchor="middle" font-weight="${FONT_WEIGHTS.nodeLabel}" fill="var(--_text)"`,
+        ),
+    );
   } else {
     // Participant: rectangle box with label (supports multi-line)
-    const boxX = x - width / 2
+    const boxX = x - width / 2;
     parts.push(
-      `  <rect x="${boxX}" y="${y}" width="${width}" height="${height}" rx="4" ry="4" ` +
-      `fill="var(--_node-fill)" stroke="var(--_node-stroke)" stroke-width="${STROKE_WIDTHS.outerBox}" />`
-    )
+      f`  <rect x="${boxX}" y="${y}" width="${width}" height="${height}" rx="4" ry="4" ` +
+        `fill="var(--_node-fill)" stroke="var(--_node-stroke)" stroke-width="${STROKE_WIDTHS.outerBox}" />`,
+    );
     parts.push(
-      '  ' + renderMultilineText(label, x, y + height / 2, FONT_SIZES.nodeLabel,
-        `font-size="${FONT_SIZES.nodeLabel}" text-anchor="middle" font-weight="${FONT_WEIGHTS.nodeLabel}" fill="var(--_text)"`)
-    )
+      '  ' +
+        renderMultilineText(
+          label,
+          x,
+          y + height / 2,
+          FONT_SIZES.nodeLabel,
+          `font-size="${FONT_SIZES.nodeLabel}" text-anchor="middle" font-weight="${FONT_WEIGHTS.nodeLabel}" fill="var(--_text)"`,
+        ),
+    );
   }
 
-  parts.push('</g>')
-  return parts.join('\n')
+  parts.push('</g>');
+  return parts.join('\n');
 }
 
 /**
@@ -161,9 +189,9 @@ function renderActor(actor: PositionedActor): string {
 function renderLifeline(lifeline: Lifeline): string {
   return (
     `<line class="lifeline" data-actor="${escapeAttr(lifeline.actorId)}" ` +
-    `x1="${lifeline.x}" y1="${lifeline.topY}" x2="${lifeline.x}" y2="${lifeline.bottomY}" ` +
+    f`x1="${lifeline.x}" y1="${lifeline.topY}" x2="${lifeline.x}" y2="${lifeline.bottomY}" ` +
     `stroke="var(--_line)" stroke-width="0.75" stroke-dasharray="6 4" />`
-  )
+  );
 }
 
 /**
@@ -173,9 +201,9 @@ function renderLifeline(lifeline: Lifeline): string {
 function renderActivation(activation: Activation): string {
   return (
     `<rect class="activation" data-actor="${escapeAttr(activation.actorId)}" ` +
-    `x="${activation.x}" y="${activation.topY}" width="${activation.width}" height="${activation.bottomY - activation.topY}" ` +
+    f`x="${activation.x}" y="${activation.topY}" width="${activation.width}" height="${activation.bottomY - activation.topY}" ` +
     `fill="var(--_node-fill)" stroke="var(--_node-stroke)" stroke-width="${STROKE_WIDTHS.innerBox}" />`
-  )
+  );
 }
 
 /**
@@ -183,48 +211,60 @@ function renderActivation(activation: Activation): string {
  * Wrapped in <g class="message"> with semantic data attributes.
  */
 function renderMessage(msg: PositionedMessage): string {
-  const parts: string[] = []
-  const dashArray = msg.lineStyle === 'dashed' ? ' stroke-dasharray="6 4"' : ''
-  const markerId = msg.arrowHead === 'filled' ? 'seq-arrow' : 'seq-arrow-open'
+  const parts: string[] = [];
+  const dashArray = msg.lineStyle === 'dashed' ? ' stroke-dasharray="6 4"' : '';
+  const markerId = msg.arrowHead === 'filled' ? 'seq-arrow' : 'seq-arrow-open';
 
   // Semantic wrapper with message metadata
   parts.push(
     `<g class="message" data-from="${escapeAttr(msg.from)}" data-to="${escapeAttr(msg.to)}" ` +
-    `data-label="${escapeAttr(msg.label)}" data-line-style="${msg.lineStyle}" ` +
-    `data-arrow-head="${msg.arrowHead}" data-self="${msg.isSelf}">`
-  )
+      `data-label="${escapeAttr(msg.label)}" data-line-style="${msg.lineStyle}" ` +
+      `data-arrow-head="${msg.arrowHead}" data-self="${msg.isSelf}">`,
+  );
 
   if (msg.isSelf) {
     // Self-message: curved loop going right and back
     // Loop dimensions - loopH is fixed, loopW provides minimum clearance
-    const loopW = 30
-    const loopH = 20
-    const labelPadding = 8 // Space between loop and label
+    const loopW = 30;
+    const loopH = 20;
+    const labelPadding = 8; // Space between loop and label
     parts.push(
-      `  <polyline points="${msg.x1},${msg.y} ${msg.x1 + loopW},${msg.y} ${msg.x1 + loopW},${msg.y + loopH} ${msg.x2},${msg.y + loopH}" ` +
-      `fill="none" stroke="var(--_line)" stroke-width="${STROKE_WIDTHS.connector}"${dashArray} marker-end="url(#${markerId})" />`
-    )
+      f`  <polyline points="${msg.x1},${msg.y} ${msg.x1 + loopW},${msg.y} ${msg.x1 + loopW},${msg.y + loopH} ${msg.x2},${msg.y + loopH}" ` +
+        `fill="none" stroke="var(--_line)" stroke-width="${STROKE_WIDTHS.connector}"${dashArray} marker-end="url(#${markerId})" />`,
+    );
     // Label to the right of the loop (supports multi-line)
     parts.push(
-      '  ' + renderMultilineText(msg.label, msg.x1 + loopW + labelPadding, msg.y + loopH / 2, FONT_SIZES.edgeLabel,
-        `font-size="${FONT_SIZES.edgeLabel}" text-anchor="start" font-weight="${FONT_WEIGHTS.edgeLabel}" fill="var(--_text-muted)"`)
-    )
+      '  ' +
+        renderMultilineText(
+          msg.label,
+          msg.x1 + loopW + labelPadding,
+          msg.y + loopH / 2,
+          FONT_SIZES.edgeLabel,
+          `font-size="${FONT_SIZES.edgeLabel}" text-anchor="start" font-weight="${FONT_WEIGHTS.edgeLabel}" fill="var(--_text-muted)"`,
+        ),
+    );
   } else {
     // Normal message: horizontal arrow
     parts.push(
-      `  <line x1="${msg.x1}" y1="${msg.y}" x2="${msg.x2}" y2="${msg.y}" ` +
-      `stroke="var(--_line)" stroke-width="${STROKE_WIDTHS.connector}"${dashArray} marker-end="url(#${markerId})" />`
-    )
+      f`  <line x1="${msg.x1}" y1="${msg.y}" x2="${msg.x2}" y2="${msg.y}" ` +
+        `stroke="var(--_line)" stroke-width="${STROKE_WIDTHS.connector}"${dashArray} marker-end="url(#${markerId})" />`,
+    );
     // Label above the arrow, centered (supports multi-line)
-    const midX = (msg.x1 + msg.x2) / 2
+    const midX = (msg.x1 + msg.x2) / 2;
     parts.push(
-      '  ' + renderMultilineText(msg.label, midX, msg.y - 10, FONT_SIZES.edgeLabel,
-        `font-size="${FONT_SIZES.edgeLabel}" text-anchor="middle" font-weight="${FONT_WEIGHTS.edgeLabel}" fill="var(--_text-muted)"`)
-    )
+      '  ' +
+        renderMultilineText(
+          msg.label,
+          midX,
+          msg.y - 10,
+          FONT_SIZES.edgeLabel,
+          `font-size="${FONT_SIZES.edgeLabel}" text-anchor="middle" font-weight="${FONT_WEIGHTS.edgeLabel}" fill="var(--_text-muted)"`,
+        ),
+    );
   }
 
-  parts.push('</g>')
-  return parts.join('\n')
+  parts.push('</g>');
+  return parts.join('\n');
 }
 
 /**
@@ -232,59 +272,65 @@ function renderMessage(msg: PositionedMessage): string {
  * Wrapped in <g class="block"> with semantic data attributes.
  */
 function renderBlock(block: PositionedBlock): string {
-  const parts: string[] = []
+  const parts: string[] = [];
 
   // Semantic wrapper with block metadata
-  const labelAttr = block.label ? ` data-label="${escapeAttr(block.label)}"` : ''
-  parts.push(
-    `<g class="block" data-type="${escapeAttr(block.type)}"${labelAttr}>`
-  )
+  const labelAttr = block.label ? ` data-label="${escapeAttr(block.label)}"` : '';
+  parts.push(`<g class="block" data-type="${escapeAttr(block.type)}"${labelAttr}>`);
 
   // Outer rectangle
   parts.push(
-    `  <rect x="${block.x}" y="${block.y}" width="${block.width}" height="${block.height}" ` +
-    `rx="0" ry="0" fill="none" stroke="var(--_node-stroke)" stroke-width="${STROKE_WIDTHS.outerBox}" />`
-  )
+    f`  <rect x="${block.x}" y="${block.y}" width="${block.width}" height="${block.height}" ` +
+      `rx="0" ry="0" fill="none" stroke="var(--_node-stroke)" stroke-width="${STROKE_WIDTHS.outerBox}" />`,
+  );
 
   // Type label tab (top-left corner)
   // For multi-line block labels, we use the first line for the tab but show full label
-  const labelText = `${block.type}${block.label ? ` [${block.label}]` : ''}`
-  const firstLine = labelText.split('\n')[0]!
-  const tabWidth = estimateTextWidth(firstLine, FONT_SIZES.edgeLabel, FONT_WEIGHTS.groupHeader) + 16
-  const tabHeight = 18
+  const labelText = `${block.type}${block.label ? ` [${block.label}]` : ''}`;
+  const firstLine = labelText.split('\n')[0]!;
+  const tabWidth =
+    estimateTextWidth(firstLine, FONT_SIZES.edgeLabel, FONT_WEIGHTS.groupHeader) + 16;
+  const tabHeight = 18;
 
   parts.push(
-    `  <rect x="${block.x}" y="${block.y}" width="${tabWidth}" height="${tabHeight}" ` +
-    `fill="var(--_group-hdr)" stroke="var(--_node-stroke)" stroke-width="${STROKE_WIDTHS.outerBox}" />`
-  )
+    f`  <rect x="${block.x}" y="${block.y}" width="${tabWidth}" height="${tabHeight}" ` +
+      `fill="var(--_group-hdr)" stroke="var(--_node-stroke)" stroke-width="${STROKE_WIDTHS.outerBox}" />`,
+  );
   // Block type label (supports multi-line via <br> tags)
   parts.push(
-    '  ' + renderMultilineText(
-      labelText,
-      block.x + 6,
-      block.y + tabHeight / 2,
-      FONT_SIZES.edgeLabel,
-      `font-size="${FONT_SIZES.edgeLabel}" font-weight="${FONT_WEIGHTS.groupHeader}" fill="var(--_text-sec)"`
-    )
-  )
+    '  ' +
+      renderMultilineText(
+        labelText,
+        block.x + 6,
+        block.y + tabHeight / 2,
+        FONT_SIZES.edgeLabel,
+        `font-size="${FONT_SIZES.edgeLabel}" font-weight="${FONT_WEIGHTS.groupHeader}" fill="var(--_text-sec)"`,
+      ),
+  );
 
   // Divider lines (for alt/else, par/and)
   for (const divider of block.dividers) {
     parts.push(
-      `  <line x1="${block.x}" y1="${divider.y}" x2="${block.x + block.width}" y2="${divider.y}" ` +
-      `stroke="var(--_line)" stroke-width="0.75" stroke-dasharray="6 4" />`
-    )
+      f`  <line x1="${block.x}" y1="${divider.y}" x2="${block.x + block.width}" y2="${divider.y}" ` +
+        `stroke="var(--_line)" stroke-width="0.75" stroke-dasharray="6 4" />`,
+    );
     if (divider.label) {
       // Divider label supports multi-line
       parts.push(
-        '  ' + renderMultilineText(`[${divider.label}]`, block.x + 8, divider.y + 14, FONT_SIZES.edgeLabel,
-          `font-size="${FONT_SIZES.edgeLabel}" text-anchor="start" font-weight="${FONT_WEIGHTS.edgeLabel}" fill="var(--_text-muted)"`)
-      )
+        '  ' +
+          renderMultilineText(
+            `[${divider.label}]`,
+            block.x + 8,
+            divider.y + 14,
+            FONT_SIZES.edgeLabel,
+            `font-size="${FONT_SIZES.edgeLabel}" text-anchor="start" font-weight="${FONT_WEIGHTS.edgeLabel}" fill="var(--_text-muted)"`,
+          ),
+      );
     }
   }
 
-  parts.push('</g>')
-  return parts.join('\n')
+  parts.push('</g>');
+  return parts.join('\n');
 }
 
 /**
@@ -293,24 +339,25 @@ function renderBlock(block: PositionedBlock): string {
  */
 function renderNote(note: PositionedNote): string {
   // Dog-ear note: polygon with clipped top-right corner + fold triangle
-  const foldSize = 6
-  const { x, y, width: w, height: h } = note
+  const foldSize = 6;
+  const { x, y, width: w, height: h } = note;
 
   // Build actor reference attribute if present
-  const actorsAttr = note.actors && note.actors.length > 0
-    ? ` data-actors="${note.actors.map(escapeAttr).join(',')}"`
-    : ''
-  const positionAttr = note.position ? ` data-position="${escapeAttr(note.position)}"` : ''
+  const actorsAttr =
+    note.actors && note.actors.length > 0
+      ? ` data-actors="${note.actors.map(escapeAttr).join(',')}"`
+      : '';
+  const positionAttr = note.position ? ` data-position="${escapeAttr(note.position)}"` : '';
 
   // Note body: polygon with top-right corner cut off
   //   (x,y) → (x+w-fold,y) → (x+w,y+fold) → (x+w,y+h) → (x,y+h)
   const bodyPoints = [
-    `${x},${y}`,
-    `${x + w - foldSize},${y}`,
-    `${x + w},${y + foldSize}`,
-    `${x + w},${y + h}`,
-    `${x},${y + h}`,
-  ].join(' ')
+    f`${x},${y}`,
+    f`${x + w - foldSize},${y}`,
+    f`${x + w},${y + foldSize}`,
+    f`${x + w},${y + h}`,
+    f`${x},${y + h}`,
+  ].join(' ');
 
   return (
     `<g class="note"${positionAttr}${actorsAttr}>` +
@@ -318,13 +365,18 @@ function renderNote(note: PositionedNote): string {
     `\n  <polygon points="${bodyPoints}" ` +
     `fill="var(--bg)" stroke="var(--_node-stroke)" stroke-width="${STROKE_WIDTHS.innerBox}" />` +
     // Fold triangle (the folded-over corner)
-    `\n  <polygon points="${x + w - foldSize},${y} ${x + w},${y + foldSize} ${x + w - foldSize},${y + foldSize}" ` +
+    f`\n  <polygon points="${x + w - foldSize},${y} ${x + w},${y + foldSize} ${x + w - foldSize},${y + foldSize}" ` +
     `fill="var(--_inner-stroke)" stroke="var(--_node-stroke)" stroke-width="${STROKE_WIDTHS.innerBox}" />` +
     // Note text (supports multi-line)
-    `\n  ${renderMultilineText(note.text, x + w / 2, y + h / 2, FONT_SIZES.edgeLabel,
-      `font-size="${FONT_SIZES.edgeLabel}" text-anchor="middle" font-weight="${FONT_WEIGHTS.edgeLabel}" fill="var(--_text-muted)"`)}` +
+    `\n  ${renderMultilineText(
+      note.text,
+      x + w / 2,
+      y + h / 2,
+      FONT_SIZES.edgeLabel,
+      `font-size="${FONT_SIZES.edgeLabel}" text-anchor="middle" font-weight="${FONT_WEIGHTS.edgeLabel}" fill="var(--_text-muted)"`,
+    )}` +
     `\n</g>`
-  )
+  );
 }
 
 // ============================================================================
@@ -332,7 +384,7 @@ function renderNote(note: PositionedNote): string {
 // ============================================================================
 
 // Use shared escapeXml from multiline-utils
-const escapeXml = escapeXmlUtil
+const escapeXml = escapeXmlUtil;
 
 /**
  * Escape a string for use as an XML/HTML attribute value.
@@ -342,5 +394,5 @@ function escapeAttr(value: string): string {
     .replace(/&/g, '&amp;')
     .replace(/"/g, '&quot;')
     .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
+    .replace(/>/g, '&gt;');
 }

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -15,6 +15,7 @@
 // Types
 // ============================================================================
 
+
 /**
  * Diagram color configuration.
  *
@@ -298,7 +299,7 @@ export function svgOpenTag(
   const bgStyle = transparent ? '' : ';background:var(--bg)'
 
   return (
-    `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${width} ${height}" ` +
-    `width="${width}" height="${height}" style="${vars}${bgStyle}">`
+    f`<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${width} ${height}" ` +
+    f`width="${width}" height="${height}" style="${vars}${bgStyle}">`
   )
 }

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -11,10 +11,11 @@
 // colors, and the SVG adapts. No light/dark mode detection needed.
 // ============================================================================
 
+import { f } from './render-utils.ts';
+
 // ============================================================================
 // Types
 // ============================================================================
-
 
 /**
  * Diagram color configuration.
@@ -26,22 +27,22 @@
  */
 export interface DiagramColors {
   /** Background color → CSS variable --bg */
-  bg: string
+  bg: string;
   /** Foreground / primary text color → CSS variable --fg */
-  fg: string
+  fg: string;
 
   // -- Optional enrichment (each falls back to color-mix from bg+fg) --
 
   /** Edge/connector color → CSS variable --line */
-  line?: string
+  line?: string;
   /** Arrow heads, highlights, special nodes → CSS variable --accent */
-  accent?: string
+  accent?: string;
   /** Secondary text, edge labels → CSS variable --muted */
-  muted?: string
+  muted?: string;
   /** Node/box fill tint → CSS variable --surface */
-  surface?: string
+  surface?: string;
   /** Node/group stroke color → CSS variable --border */
-  border?: string
+  border?: string;
 }
 
 // ============================================================================
@@ -52,7 +53,7 @@ export interface DiagramColors {
 export const DEFAULTS: Readonly<{ bg: string; fg: string }> = {
   bg: '#FFFFFF',
   fg: '#27272A',
-} as const
+} as const;
 
 // ============================================================================
 // color-mix() weights for derived CSS variables
@@ -64,28 +65,28 @@ export const DEFAULTS: Readonly<{ bg: string; fg: string }> = {
 
 export const MIX = {
   /** Primary text: near-full fg */
-  text:         100, // just use --fg directly
+  text: 100, // just use --fg directly
   /** Secondary text (group headers): fg mixed at 60% */
-  textSec:      60,
+  textSec: 60,
   /** Muted text (edge labels, notes): fg mixed at 40% */
-  textMuted:    40,
+  textMuted: 40,
   /** Faint text (de-emphasized): fg mixed at 25% */
-  textFaint:    25,
+  textFaint: 25,
   /** Edge/connector lines: fg mixed at 50% for clear visibility */
-  line:         50,
+  line: 50,
   /** Arrow head fill: fg mixed at 85% for clear visibility */
-  arrow:        85,
+  arrow: 85,
   /** Node fill tint: fg mixed at 3% */
-  nodeFill:     3,
+  nodeFill: 3,
   /** Node/group stroke: fg mixed at 20% */
-  nodeStroke:   20,
+  nodeStroke: 20,
   /** Group header band tint: fg mixed at 5% */
-  groupHeader:  5,
+  groupHeader: 5,
   /** Inner divider strokes: fg mixed at 12% */
-  innerStroke:  12,
+  innerStroke: 12,
   /** Key badge background opacity (ER diagrams) */
-  keyBadge:     10,
-} as const
+  keyBadge: 10,
+} as const;
 
 // ============================================================================
 // Well-known theme palettes
@@ -96,66 +97,107 @@ export const MIX = {
 
 export const THEMES: Record<string, DiagramColors> = {
   'zinc-light': {
-    bg: '#FFFFFF', fg: '#27272A',
+    bg: '#FFFFFF',
+    fg: '#27272A',
   },
   'zinc-dark': {
-    bg: '#18181B', fg: '#FAFAFA',
+    bg: '#18181B',
+    fg: '#FAFAFA',
   },
   'tokyo-night': {
-    bg: '#1a1b26', fg: '#a9b1d6',
-    line: '#3d59a1', accent: '#7aa2f7', muted: '#565f89',
+    bg: '#1a1b26',
+    fg: '#a9b1d6',
+    line: '#3d59a1',
+    accent: '#7aa2f7',
+    muted: '#565f89',
   },
   'tokyo-night-storm': {
-    bg: '#24283b', fg: '#a9b1d6',
-    line: '#3d59a1', accent: '#7aa2f7', muted: '#565f89',
+    bg: '#24283b',
+    fg: '#a9b1d6',
+    line: '#3d59a1',
+    accent: '#7aa2f7',
+    muted: '#565f89',
   },
   'tokyo-night-light': {
-    bg: '#d5d6db', fg: '#343b58',
-    line: '#34548a', accent: '#34548a', muted: '#9699a3',
+    bg: '#d5d6db',
+    fg: '#343b58',
+    line: '#34548a',
+    accent: '#34548a',
+    muted: '#9699a3',
   },
   'catppuccin-mocha': {
-    bg: '#1e1e2e', fg: '#cdd6f4',
-    line: '#585b70', accent: '#cba6f7', muted: '#6c7086',
+    bg: '#1e1e2e',
+    fg: '#cdd6f4',
+    line: '#585b70',
+    accent: '#cba6f7',
+    muted: '#6c7086',
   },
   'catppuccin-latte': {
-    bg: '#eff1f5', fg: '#4c4f69',
-    line: '#9ca0b0', accent: '#8839ef', muted: '#9ca0b0',
+    bg: '#eff1f5',
+    fg: '#4c4f69',
+    line: '#9ca0b0',
+    accent: '#8839ef',
+    muted: '#9ca0b0',
   },
-  'nord': {
-    bg: '#2e3440', fg: '#d8dee9',
-    line: '#4c566a', accent: '#88c0d0', muted: '#616e88',
+  nord: {
+    bg: '#2e3440',
+    fg: '#d8dee9',
+    line: '#4c566a',
+    accent: '#88c0d0',
+    muted: '#616e88',
   },
   'nord-light': {
-    bg: '#eceff4', fg: '#2e3440',
-    line: '#aab1c0', accent: '#5e81ac', muted: '#7b88a1',
+    bg: '#eceff4',
+    fg: '#2e3440',
+    line: '#aab1c0',
+    accent: '#5e81ac',
+    muted: '#7b88a1',
   },
-  'dracula': {
-    bg: '#282a36', fg: '#f8f8f2',
-    line: '#6272a4', accent: '#bd93f9', muted: '#6272a4',
+  dracula: {
+    bg: '#282a36',
+    fg: '#f8f8f2',
+    line: '#6272a4',
+    accent: '#bd93f9',
+    muted: '#6272a4',
   },
   'github-light': {
-    bg: '#ffffff', fg: '#1f2328',
-    line: '#d1d9e0', accent: '#0969da', muted: '#59636e',
+    bg: '#ffffff',
+    fg: '#1f2328',
+    line: '#d1d9e0',
+    accent: '#0969da',
+    muted: '#59636e',
   },
   'github-dark': {
-    bg: '#0d1117', fg: '#e6edf3',
-    line: '#3d444d', accent: '#4493f8', muted: '#9198a1',
+    bg: '#0d1117',
+    fg: '#e6edf3',
+    line: '#3d444d',
+    accent: '#4493f8',
+    muted: '#9198a1',
   },
   'solarized-light': {
-    bg: '#fdf6e3', fg: '#657b83',
-    line: '#93a1a1', accent: '#268bd2', muted: '#93a1a1',
+    bg: '#fdf6e3',
+    fg: '#657b83',
+    line: '#93a1a1',
+    accent: '#268bd2',
+    muted: '#93a1a1',
   },
   'solarized-dark': {
-    bg: '#002b36', fg: '#839496',
-    line: '#586e75', accent: '#268bd2', muted: '#586e75',
+    bg: '#002b36',
+    fg: '#839496',
+    line: '#586e75',
+    accent: '#268bd2',
+    muted: '#586e75',
   },
   'one-dark': {
-    bg: '#282c34', fg: '#abb2bf',
-    line: '#4b5263', accent: '#c678dd', muted: '#5c6370',
+    bg: '#282c34',
+    fg: '#abb2bf',
+    line: '#4b5263',
+    accent: '#c678dd',
+    muted: '#5c6370',
   },
-} as const
+} as const;
 
-export type ThemeName = keyof typeof THEMES
+export type ThemeName = keyof typeof THEMES;
 
 // ============================================================================
 // Shiki theme extraction
@@ -169,12 +211,12 @@ export type ThemeName = keyof typeof THEMES
  * We don't import from shiki to avoid a hard dependency.
  */
 interface ShikiThemeLike {
-  type?: string
-  colors?: Record<string, string>
+  type?: string;
+  colors?: Record<string, string>;
   tokenColors?: Array<{
-    scope?: string | string[]
-    settings?: { foreground?: string }
-  }>
+    scope?: string | string[];
+    settings?: { foreground?: string };
+  }>;
 }
 
 /**
@@ -201,24 +243,24 @@ interface ShikiThemeLike {
  * ```
  */
 export function fromShikiTheme(theme: ShikiThemeLike): DiagramColors {
-  const c = theme.colors ?? {}
-  const dark = theme.type === 'dark'
+  const c = theme.colors ?? {};
+  const dark = theme.type === 'dark';
 
   // Helper: find a token color by scope name
   const tokenColor = (scope: string): string | undefined =>
-    theme.tokenColors?.find(t =>
-      Array.isArray(t.scope) ? t.scope.includes(scope) : t.scope === scope
-    )?.settings?.foreground
+    theme.tokenColors?.find((t) =>
+      Array.isArray(t.scope) ? t.scope.includes(scope) : t.scope === scope,
+    )?.settings?.foreground;
 
   return {
     bg: c['editor.background'] ?? (dark ? '#1e1e1e' : '#ffffff'),
     fg: c['editor.foreground'] ?? (dark ? '#d4d4d4' : '#333333'),
-    line:    c['editorLineNumber.foreground'] ?? undefined,
-    accent:  c['focusBorder'] ?? tokenColor('keyword') ?? undefined,
-    muted:   tokenColor('comment') ?? c['editorLineNumber.foreground'] ?? undefined,
+    line: c['editorLineNumber.foreground'] ?? undefined,
+    accent: c['focusBorder'] ?? tokenColor('keyword') ?? undefined,
+    muted: tokenColor('comment') ?? c['editorLineNumber.foreground'] ?? undefined,
     surface: c['editor.selectionBackground'] ?? undefined,
-    border:  c['editorWidget.border'] ?? undefined,
-  }
+    border: c['editorWidget.border'] ?? undefined,
+  };
 }
 
 // ============================================================================
@@ -240,9 +282,11 @@ export function buildStyleBlock(font: string, hasMonoFont: boolean): string {
   const fontImports = [
     `@import url('https://fonts.googleapis.com/css2?family=${encodeURIComponent(font)}:wght@400;500;600;700&amp;display=swap');`,
     ...(hasMonoFont
-      ? [`@import url('https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500&amp;display=swap');`]
+      ? [
+          `@import url('https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500&amp;display=swap');`,
+        ]
       : []),
-  ]
+  ];
 
   // Derived CSS variables: use override if set, else mix from bg+fg.
   // The --_ prefix signals "private/derived" — not meant for external override.
@@ -259,17 +303,21 @@ export function buildStyleBlock(font: string, hasMonoFont: boolean): string {
     --_group-fill:    var(--bg);
     --_group-hdr:     color-mix(in srgb, var(--fg) ${MIX.groupHeader}%, var(--bg));
     --_inner-stroke:  color-mix(in srgb, var(--fg) ${MIX.innerStroke}%, var(--bg));
-    --_key-badge:     color-mix(in srgb, var(--fg) ${MIX.keyBadge}%, var(--bg));`
+    --_key-badge:     color-mix(in srgb, var(--fg) ${MIX.keyBadge}%, var(--bg));`;
 
   return [
     '<style>',
     `  ${fontImports.join('\n  ')}`,
     `  text { font-family: '${font}', system-ui, sans-serif; }`,
-    ...(hasMonoFont ? [`  .mono { font-family: 'JetBrains Mono', 'SF Mono', 'Fira Code', ui-monospace, monospace; }`] : []),
+    ...(hasMonoFont
+      ? [
+          `  .mono { font-family: 'JetBrains Mono', 'SF Mono', 'Fira Code', ui-monospace, monospace; }`,
+        ]
+      : []),
     `  svg {${derivedVars}`,
     `  }`,
     '</style>',
-  ].join('\n')
+  ].join('\n');
 }
 
 /**
@@ -289,17 +337,19 @@ export function svgOpenTag(
   const vars = [
     `--bg:${colors.bg}`,
     `--fg:${colors.fg}`,
-    colors.line    ? `--line:${colors.line}` : '',
-    colors.accent  ? `--accent:${colors.accent}` : '',
-    colors.muted   ? `--muted:${colors.muted}` : '',
+    colors.line ? `--line:${colors.line}` : '',
+    colors.accent ? `--accent:${colors.accent}` : '',
+    colors.muted ? `--muted:${colors.muted}` : '',
     colors.surface ? `--surface:${colors.surface}` : '',
-    colors.border  ? `--border:${colors.border}` : '',
-  ].filter(Boolean).join(';')
+    colors.border ? `--border:${colors.border}` : '',
+  ]
+    .filter(Boolean)
+    .join(';');
 
-  const bgStyle = transparent ? '' : ';background:var(--bg)'
+  const bgStyle = transparent ? '' : ';background:var(--bg)';
 
   return (
     f`<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${width} ${height}" ` +
     f`width="${width}" height="${height}" style="${vars}${bgStyle}">`
-  )
+  );
 }

--- a/src/xychart/renderer.ts
+++ b/src/xychart/renderer.ts
@@ -110,7 +110,7 @@ export function renderXYChartSvg(
   const yStart = yAnchor - Math.ceil((yAnchor - plotArea.y) / yGap) * yGap;
   for (let y = yStart; y <= plotArea.y + plotArea.height + 0.5; y += yGap) {
     for (let x = xStart; x <= plotArea.x + plotArea.width + 0.5; x += xGap) {
-      parts.push(`<circle cx="${r(x)}" cy="${r(y)}" r="1.5" class="xychart-grid"/>`);
+      parts.push(f`<circle cx="${x}" cy="${y}" r="1.5" class="xychart-grid"/>`);
     }
   }
 
@@ -131,7 +131,7 @@ export function renderXYChartSvg(
       const tip = tooltipAbove(bar.x + bar.width / 2, bar.y, tipText);
       barOverlay.push(
         `<g class="xychart-bar-group">` +
-          `<rect x="${r(bar.x)}" y="${r(bar.y)}" width="${r(bar.width)}" height="${r(bar.height)}" fill="transparent"/>` +
+          f`<rect x="${bar.x}" y="${bar.y}" width="${bar.width}" height="${bar.height}" fill="transparent"/>` +
           `<title>${escapeXml(tipTitle)}</title>` +
           tip +
           `</g>`,
@@ -170,7 +170,7 @@ export function renderXYChartSvg(
 
     for (const line of chart.lines) {
       for (const p of line.points) {
-        const key = r(p.x);
+        const key = f`${p.x}`;
         if (!columns.has(key)) columns.set(key, []);
         columns.get(key)!.push({
           x: p.x,
@@ -191,7 +191,7 @@ export function renderXYChartSvg(
         const topY = Math.min(...entries.map((e) => e.y));
         const botY = Math.max(...entries.map((e) => e.y));
         const hitPad = CHART_FONT.dotRadius * 3;
-        const hitArea = `<rect x="${r(cx - hitPad)}" y="${r(topY - hitPad)}" width="${r(hitPad * 2)}" height="${r(botY - topY + hitPad * 2)}" fill="transparent" class="xychart-hit"/>`;
+        const hitArea = f`<rect x="${cx - hitPad}" y="${topY - hitPad}" width="${hitPad * 2}" height="${botY - topY + hitPad * 2}" fill="transparent" class="xychart-hit"/>`;
         const tipEntries = entries.map((e) => ({
           text: formatTipValue(e.value),
           legendLabel: lineLegendLabels.get(e.seriesIndex) || `Line ${e.seriesIndex + 1}`,
@@ -203,7 +203,7 @@ export function renderXYChartSvg(
         let group = `<g class="xychart-dot-group">${hitArea}`;
         for (const e of entries) {
           const dataAttrs = ` data-value="${e.value}"${e.label ? ` data-label="${escapeXml(e.label)}"` : ''}`;
-          group += `<circle cx="${r(e.x)}" cy="${r(e.y)}" r="${CHART_FONT.dotRadius}" class="xychart-dot xychart-color-${e.colorIndex}"${dataAttrs}/>`;
+          group += f`<circle cx="${e.x}" cy="${e.y}" r="${CHART_FONT.dotRadius}" class="xychart-dot xychart-color-${e.colorIndex}"${dataAttrs}/>`;
         }
         group += `<title>${escapeXml(titleText)}</title>${tip}</g>`;
         dotOverlay.push(group);
@@ -214,11 +214,11 @@ export function renderXYChartSvg(
         const tipTitle = e.label ? `${e.label}: ${tipText}` : tipText;
         const tip = tooltipAbove(cx, e.y - CHART_FONT.dotRadius, tipText);
         const hitArea = sparse
-          ? `<circle cx="${r(cx)}" cy="${r(e.y)}" r="${CHART_FONT.dotRadius * 3}" fill="transparent" class="xychart-hit"/>`
+          ? f`<circle cx="${cx}" cy="${e.y}" r="${CHART_FONT.dotRadius * 3}" fill="transparent" class="xychart-hit"/>`
           : '';
         dotOverlay.push(
           `<g class="xychart-dot-group">${hitArea}` +
-            `<circle cx="${r(e.x)}" cy="${r(e.y)}" r="${CHART_FONT.dotRadius}" class="xychart-dot xychart-color-${e.colorIndex}"${dataAttrs}/>` +
+            f`<circle cx="${e.x}" cy="${e.y}" r="${CHART_FONT.dotRadius}" class="xychart-dot xychart-color-${e.colorIndex}"${dataAttrs}/>` +
             `<title>${escapeXml(tipTitle)}</title>${tip}</g>`,
         );
       } else {
@@ -226,7 +226,7 @@ export function renderXYChartSvg(
         for (const e of entries) {
           const dataAttrs = ` data-value="${e.value}"${e.label ? ` data-label="${escapeXml(e.label)}"` : ''}`;
           parts.push(
-            `<circle cx="${r(e.x)}" cy="${r(e.y)}" r="${CHART_FONT.dotRadius}" class="xychart-dot xychart-color-${e.colorIndex}"${dataAttrs}/>`,
+            f`<circle cx="${e.x}" cy="${e.y}" r="${CHART_FONT.dotRadius}" class="xychart-dot xychart-color-${e.colorIndex}"${dataAttrs}/>`,
           );
         }
       }
@@ -392,17 +392,17 @@ ${seriesRules.join('\n')}${tipRules}
 function roundedTopBarPath(x: number, y: number, w: number, h: number, radius: number): string {
   const rr = Math.min(radius, w / 2, h / 2);
   if (rr <= 0) {
-    return `M${r(x)},${r(y)} h${r(w)} v${r(h)} h${r(-w)} Z`;
+    return f`M${x},${y} h${w} v${h} h${-w} Z`;
   }
   return [
-    `M${r(x)},${r(y + rr)}`, // start below top-left
-    `Q${r(x)},${r(y)} ${r(x + rr)},${r(y)}`, // top-left
-    `L${r(x + w - rr)},${r(y)}`, // top edge
-    `Q${r(x + w)},${r(y)} ${r(x + w)},${r(y + rr)}`, // top-right
-    `L${r(x + w)},${r(y + h - rr)}`, // right edge
-    `Q${r(x + w)},${r(y + h)} ${r(x + w - rr)},${r(y + h)}`, // bottom-right
-    `L${r(x + rr)},${r(y + h)}`, // bottom edge
-    `Q${r(x)},${r(y + h)} ${r(x)},${r(y + h - rr)}`, // bottom-left
+    f`M${x},${y + rr}`, // start below top-left
+    f`Q${x},${y} ${x + rr},${y}`, // top-left
+    f`L${x + w - rr},${y}`, // top edge
+    f`Q${x + w},${y} ${x + w},${y + rr}`, // top-right
+    f`L${x + w},${y + h - rr}`, // right edge
+    f`Q${x + w},${y + h} ${x + w - rr},${y + h}`, // bottom-right
+    f`L${x + rr},${y + h}`, // bottom edge
+    f`Q${x},${y + h} ${x},${y + h - rr}`, // bottom-left
     'Z',
   ].join(' ');
 }
@@ -414,18 +414,18 @@ function roundedTopBarPath(x: number, y: number, w: number, h: number, radius: n
 function roundedRightBarPath(x: number, y: number, w: number, h: number, radius: number): string {
   const rr = Math.min(radius, w / 2, h / 2);
   if (rr <= 0) {
-    return `M${r(x)},${r(y)} h${r(w)} v${r(h)} h${r(-w)} Z`;
+    return f`M${x},${y} h${w} v${h} h${-w} Z`;
   }
   return [
-    `M${r(x + rr)},${r(y)}`, // start after top-left
-    `L${r(x + w - rr)},${r(y)}`, // top edge
-    `Q${r(x + w)},${r(y)} ${r(x + w)},${r(y + rr)}`, // top-right
-    `L${r(x + w)},${r(y + h - rr)}`, // right edge
-    `Q${r(x + w)},${r(y + h)} ${r(x + w - rr)},${r(y + h)}`, // bottom-right
-    `L${r(x + rr)},${r(y + h)}`, // bottom edge
-    `Q${r(x)},${r(y + h)} ${r(x)},${r(y + h - rr)}`, // bottom-left
-    `L${r(x)},${r(y + rr)}`, // left edge
-    `Q${r(x)},${r(y)} ${r(x + rr)},${r(y)}`, // top-left
+    f`M${x + rr},${y}`, // start after top-left
+    f`L${x + w - rr},${y}`, // top edge
+    f`Q${x + w},${y} ${x + w},${y + rr}`, // top-right
+    f`L${x + w},${y + h - rr}`, // right edge
+    f`Q${x + w},${y + h} ${x + w - rr},${y + h}`, // bottom-right
+    f`L${x + rr},${y + h}`, // bottom edge
+    f`Q${x},${y + h} ${x},${y + h - rr}`, // bottom-left
+    f`L${x},${y + rr}`, // left edge
+    f`Q${x},${y} ${x + rr},${y}`, // top-left
     'Z',
   ].join(' ');
 }
@@ -443,9 +443,9 @@ function roundedRightBarPath(x: number, y: number, w: number, h: number, radius:
 
 function smoothCurvePath(points: Array<{ x: number; y: number }>): string {
   if (points.length === 0) return '';
-  if (points.length === 1) return `M${r(points[0]!.x)},${r(points[0]!.y)}`;
+  if (points.length === 1) return f`M${points[0]!.x},${points[0]!.y}`;
   if (points.length === 2) {
-    return `M${r(points[0]!.x)},${r(points[0]!.y)} L${r(points[1]!.x)},${r(points[1]!.y)}`;
+    return f`M${points[0]!.x},${points[0]!.y} L${points[1]!.x},${points[1]!.y}`;
   }
 
   const n = points.length;
@@ -491,14 +491,14 @@ function smoothCurvePath(points: Array<{ x: number; y: number }>): string {
   slopes[n - 1] = delta[n - 2]! + (h[n - 2]! * c[n - 2]!) / 3;
 
   // 4. Convert to cubic Bezier — control points strictly between endpoints in x
-  let path = `M${r(points[0]!.x)},${r(points[0]!.y)}`;
+  let path = f`M${points[0]!.x},${points[0]!.y}`;
   for (let i = 0; i < n - 1; i++) {
     const seg = h[i]! / 3;
     const cp1x = points[i]!.x + seg;
     const cp1y = points[i]!.y + slopes[i]! * seg;
     const cp2x = points[i + 1]!.x - seg;
     const cp2y = points[i + 1]!.y - slopes[i + 1]! * seg;
-    path += ` C${r(cp1x)},${r(cp1y)} ${r(cp2x)},${r(cp2y)} ${r(points[i + 1]!.x)},${r(points[i + 1]!.y)}`;
+    path += f` C${cp1x},${cp1y} ${cp2x},${cp2y} ${points[i + 1]!.x},${points[i + 1]!.y}`;
   }
 
   return path;
@@ -537,22 +537,22 @@ function multiTooltipAbove(
   const ptrX = cx;
   const ptrY = tipY + bgH;
   const ps = TIP.pointerSize;
-  const pointer = `<polygon points="${r(ptrX - ps)},${r(ptrY)} ${r(ptrX + ps)},${r(ptrY)} ${r(ptrX)},${r(ptrY + ps)}" class="xychart-tip xychart-tip-ptr"/>`;
+  const pointer = f`<polygon points="${ptrX - ps},${ptrY} ${ptrX + ps},${ptrY} ${ptrX},${ptrY + ps}" class="xychart-tip xychart-tip-ptr"/>`;
 
-  let svg = `<rect x="${r(bgX)}" y="${r(tipY)}" width="${r(bgW)}" height="${bgH}" rx="${TIP.rx}" class="xychart-tip xychart-tip-bg"/>`;
+  let svg = f`<rect x="${bgX}" y="${tipY}" width="${bgW}" height="${bgH}" rx="${TIP.rx}" class="xychart-tip xychart-tip-bg"/>`;
   svg += pointer;
 
   // Category label (bold, centered)
   let textY = tipY + padY + lineH / 2;
-  svg += `<text x="${r(cx)}" y="${r(textY)}" text-anchor="middle" font-weight="600" font-size="${TIP.fontSize}" dy="${TEXT_BASELINE_SHIFT}" class="xychart-tip xychart-tip-text">${escapeXml(label)}</text>`;
+  svg += f`<text x="${cx}" y="${textY}" text-anchor="middle" font-weight="600" font-size="${TIP.fontSize}" dy="${TEXT_BASELINE_SHIFT}" class="xychart-tip xychart-tip-text">${escapeXml(label)}</text>`;
 
   // Value lines: legend label left-aligned, value right-aligned
   const rowLeft = bgX + TIP.padX;
   const rowRight = bgX + bgW - TIP.padX;
   for (const entry of entries) {
     textY += lineH;
-    svg += `<text x="${r(rowLeft)}" y="${r(textY)}" text-anchor="start" font-size="${TIP.fontSize}" font-weight="${TIP.fontWeight}" dy="${TEXT_BASELINE_SHIFT}" class="xychart-tip xychart-tip-text">${escapeXml(entry.legendLabel)}</text>`;
-    svg += `<text x="${r(rowRight)}" y="${r(textY)}" text-anchor="end" font-size="${TIP.fontSize}" font-weight="${TIP.fontWeight}" dy="${TEXT_BASELINE_SHIFT}" class="xychart-tip xychart-tip-text">${escapeXml(entry.text)}</text>`;
+    svg += f`<text x="${rowLeft}" y="${textY}" text-anchor="start" font-size="${TIP.fontSize}" font-weight="${TIP.fontWeight}" dy="${TEXT_BASELINE_SHIFT}" class="xychart-tip xychart-tip-text">${escapeXml(entry.legendLabel)}</text>`;
+    svg += f`<text x="${rowRight}" y="${textY}" text-anchor="end" font-size="${TIP.fontSize}" font-weight="${TIP.fontWeight}" dy="${TEXT_BASELINE_SHIFT}" class="xychart-tip xychart-tip-text">${escapeXml(entry.text)}</text>`;
   }
 
   return svg;
@@ -570,22 +570,18 @@ function tooltipAbove(cx: number, topY: number, text: string): string {
   const ptrX = cx;
   const ptrY = tipY + bgH;
   const ps = TIP.pointerSize;
-  const pointer = `<polygon points="${r(ptrX - ps)},${r(ptrY)} ${r(ptrX + ps)},${r(ptrY)} ${r(ptrX)},${r(ptrY + ps)}" class="xychart-tip xychart-tip-ptr"/>`;
+  const pointer = f`<polygon points="${ptrX - ps},${ptrY} ${ptrX + ps},${ptrY} ${ptrX},${ptrY + ps}" class="xychart-tip xychart-tip-ptr"/>`;
 
   return (
-    `<rect x="${r(bgX)}" y="${r(tipY)}" width="${r(bgW)}" height="${bgH}" rx="${TIP.rx}" class="xychart-tip xychart-tip-bg"/>` +
+    f`<rect x="${bgX}" y="${tipY}" width="${bgW}" height="${bgH}" rx="${TIP.rx}" class="xychart-tip xychart-tip-bg"/>` +
     pointer +
-    `<text x="${r(textX)}" y="${r(textY)}" text-anchor="middle" dy="${TEXT_BASELINE_SHIFT}" class="xychart-tip xychart-tip-text">${escapeXml(text)}</text>`
+    f`<text x="${textX}" y="${textY}" text-anchor="middle" dy="${TEXT_BASELINE_SHIFT}" class="xychart-tip xychart-tip-text">${escapeXml(text)}</text>`
   );
 }
 
 function formatTipValue(v: number): string {
   if (Number.isInteger(v)) return v.toLocaleString('en-US');
   return v.toFixed(Math.abs(v) < 10 ? 1 : 0);
-}
-
-function r(n: number): string {
-  return f`${n}`;
 }
 
 function escapeXml(text: string): string {

--- a/src/xychart/renderer.ts
+++ b/src/xychart/renderer.ts
@@ -1,8 +1,9 @@
-import type { PositionedXYChart } from './types.ts'
-import type { DiagramColors } from '../theme.ts'
-import { svgOpenTag, buildStyleBlock } from '../theme.ts'
-import { TEXT_BASELINE_SHIFT, estimateTextWidth } from '../styles.ts'
-import { getSeriesColor, CHART_ACCENT_FALLBACK } from './colors.ts'
+import type { PositionedXYChart } from './types.ts';
+import type { DiagramColors } from '../theme.ts';
+import { svgOpenTag, buildStyleBlock } from '../theme.ts';
+import { TEXT_BASELINE_SHIFT, estimateTextWidth } from '../styles.ts';
+import { getSeriesColor, CHART_ACCENT_FALLBACK } from './colors.ts';
+import { f } from '../render-utils.ts';
 
 // ============================================================================
 // XY Chart SVG renderer
@@ -39,7 +40,7 @@ const CHART_FONT = {
   dotRadius: 5,
   lineWidth: 2.5,
   barRadius: 8,
-} as const
+} as const;
 
 const TIP = {
   fontSize: 15,
@@ -50,7 +51,7 @@ const TIP = {
   rx: 8,
   minY: 4,
   pointerSize: 6,
-} as const
+} as const;
 
 /**
  * Render a positioned XY chart as an SVG string.
@@ -62,145 +63,171 @@ export function renderXYChartSvg(
   transparent: boolean = false,
   interactive: boolean = false,
 ): string {
-  const parts: string[] = []
+  const parts: string[] = [];
 
   // SVG root + base styles
   // Stamp data-xychart-colors so theme-switching JS knows how many series color vars to update
-  const maxColorIdx = Math.max(0, ...chart.bars.map(b => b.colorIndex), ...chart.lines.map(l => l.colorIndex))
-  const svgTag = svgOpenTag(chart.width, chart.height, colors, transparent)
-    .replace('<svg ', `<svg data-xychart-colors="${maxColorIdx}" `)
-  parts.push(svgTag)
-  parts.push(buildStyleBlock(font, false))
+  const maxColorIdx = Math.max(
+    0,
+    ...chart.bars.map((b) => b.colorIndex),
+    ...chart.lines.map((l) => l.colorIndex),
+  );
+  const svgTag = svgOpenTag(chart.width, chart.height, colors, transparent).replace(
+    '<svg ',
+    `<svg data-xychart-colors="${maxColorIdx}" `,
+  );
+  parts.push(svgTag);
+  parts.push(buildStyleBlock(font, false));
 
   // Sparse lines (≤12 points) show dots by default
-  const maxLinePoints = Math.max(...chart.lines.map(l => l.points.length), 0)
-  const sparse = maxLinePoints > 0 && maxLinePoints <= 12
+  const maxLinePoints = Math.max(...chart.lines.map((l) => l.points.length), 0);
+  const sparse = maxLinePoints > 0 && maxLinePoints <= 12;
 
   // Chart-specific styles + gradient defs
-  const { style: chartCss, defs: chartDefs } = chartStyles(chart, interactive, sparse, colors.accent, colors.bg)
-  parts.push(chartCss)
-  if (chartDefs) parts.push(chartDefs)
+  const { style: chartCss, defs: chartDefs } = chartStyles(
+    chart,
+    interactive,
+    sparse,
+    colors.accent,
+    colors.bg,
+  );
+  parts.push(chartCss);
+  if (chartDefs) parts.push(chartDefs);
 
   // 1. Dot grid (dense dots across plot area, aligned to tick spacing)
-  const { plotArea } = chart
-  const xTicks = chart.xAxis.ticks.map(t => t.x)
+  const { plotArea } = chart;
+  const xTicks = chart.xAxis.ticks.map((t) => t.x);
   const yVals = chart.horizontal
-    ? chart.yAxis.ticks.map(t => t.y)
-    : chart.gridLines.map(g => g.y1)
-  const xBase = xTicks.length > 1 ? Math.abs(xTicks[1]! - xTicks[0]!) : plotArea.width / 6
-  const yBase = yVals.length > 1 ? Math.abs(yVals[1]! - yVals[0]!) : plotArea.height / 6
-  const xGap = xBase / Math.max(1, Math.round(xBase / 20))
-  const yGap = yBase / Math.max(1, Math.round(yBase / 20))
-  const xAnchor = xTicks[0] ?? plotArea.x
-  const yAnchor = yVals[0] ?? plotArea.y
-  const xStart = xAnchor - Math.ceil((xAnchor - plotArea.x) / xGap) * xGap
-  const yStart = yAnchor - Math.ceil((yAnchor - plotArea.y) / yGap) * yGap
+    ? chart.yAxis.ticks.map((t) => t.y)
+    : chart.gridLines.map((g) => g.y1);
+  const xBase = xTicks.length > 1 ? Math.abs(xTicks[1]! - xTicks[0]!) : plotArea.width / 6;
+  const yBase = yVals.length > 1 ? Math.abs(yVals[1]! - yVals[0]!) : plotArea.height / 6;
+  const xGap = xBase / Math.max(1, Math.round(xBase / 20));
+  const yGap = yBase / Math.max(1, Math.round(yBase / 20));
+  const xAnchor = xTicks[0] ?? plotArea.x;
+  const yAnchor = yVals[0] ?? plotArea.y;
+  const xStart = xAnchor - Math.ceil((xAnchor - plotArea.x) / xGap) * xGap;
+  const yStart = yAnchor - Math.ceil((yAnchor - plotArea.y) / yGap) * yGap;
   for (let y = yStart; y <= plotArea.y + plotArea.height + 0.5; y += yGap) {
     for (let x = xStart; x <= plotArea.x + plotArea.width + 0.5; x += xGap) {
-      parts.push(`<circle cx="${r(x)}" cy="${r(y)}" r="1.5" class="xychart-grid"/>`)
+      parts.push(`<circle cx="${r(x)}" cy="${r(y)}" r="1.5" class="xychart-grid"/>`);
     }
   }
 
   // 2. Bars — always render bar paths inline (before lines for correct z-order)
   //    Interactive: also build overlay groups with transparent hit-areas + tooltips (deferred to step 9)
-  const barOverlay: string[] = []
+  const barOverlay: string[] = [];
   for (const bar of chart.bars) {
-    const dataAttrs = ` data-value="${bar.value}"${bar.label ? ` data-label="${escapeXml(bar.label)}"` : ''}`
+    const dataAttrs = ` data-value="${bar.value}"${bar.label ? ` data-label="${escapeXml(bar.label)}"` : ''}`;
     const barPath = chart.horizontal
       ? roundedRightBarPath(bar.x, bar.y, bar.width, bar.height, CHART_FONT.barRadius)
-      : roundedTopBarPath(bar.x, bar.y, bar.width, bar.height, CHART_FONT.barRadius)
+      : roundedTopBarPath(bar.x, bar.y, bar.width, bar.height, CHART_FONT.barRadius);
     parts.push(
-      `<path d="${barPath}" class="xychart-bar xychart-color-${bar.colorIndex}"${dataAttrs}/>`
-    )
+      `<path d="${barPath}" class="xychart-bar xychart-color-${bar.colorIndex}"${dataAttrs}/>`,
+    );
     if (interactive) {
-      const tipText = formatTipValue(bar.value)
-      const tipTitle = bar.label ? `${bar.label}: ${tipText}` : tipText
-      const tip = tooltipAbove(bar.x + bar.width / 2, bar.y, tipText)
+      const tipText = formatTipValue(bar.value);
+      const tipTitle = bar.label ? `${bar.label}: ${tipText}` : tipText;
+      const tip = tooltipAbove(bar.x + bar.width / 2, bar.y, tipText);
       barOverlay.push(
         `<g class="xychart-bar-group">` +
-        `<rect x="${r(bar.x)}" y="${r(bar.y)}" width="${r(bar.width)}" height="${r(bar.height)}" fill="transparent"/>` +
-        `<title>${escapeXml(tipTitle)}</title>` +
-        tip +
-        `</g>`
-      )
+          `<rect x="${r(bar.x)}" y="${r(bar.y)}" width="${r(bar.width)}" height="${r(bar.height)}" fill="transparent"/>` +
+          `<title>${escapeXml(tipTitle)}</title>` +
+          tip +
+          `</g>`,
+      );
     }
   }
 
   // 3. Lines — shadow first (wider, low opacity), then crisp line on top
   for (const line of chart.lines) {
-    if (line.points.length === 0) continue
-    const d = smoothCurvePath(line.points)
-    parts.push(`<path d="${d}" class="xychart-line-shadow xychart-color-${line.colorIndex}" transform="translate(0,2)"/>`)
-    parts.push(`<path d="${d}" class="xychart-line xychart-color-${line.colorIndex}"/>`)
+    if (line.points.length === 0) continue;
+    const d = smoothCurvePath(line.points);
+    parts.push(
+      `<path d="${d}" class="xychart-line-shadow xychart-color-${line.colorIndex}" transform="translate(0,2)"/>`,
+    );
+    parts.push(`<path d="${d}" class="xychart-line xychart-color-${line.colorIndex}"/>`);
   }
 
   // 4. Dots — grouped by x-position; interactive groups deferred to overlay
-  const dotOverlay: string[] = []
+  const dotOverlay: string[] = [];
   if (interactive || sparse) {
     // Build legend label lookup: line seriesIndex → "Line 1", "Line 2", etc.
-    const lineLegendLabels = new Map<number, string>()
+    const lineLegendLabels = new Map<number, string>();
     for (const item of chart.legend) {
-      if (item.type === 'line') lineLegendLabels.set(item.seriesIndex, item.label)
+      if (item.type === 'line') lineLegendLabels.set(item.seriesIndex, item.label);
     }
 
-    type DotEntry = { x: number; y: number; value: number; label?: string; seriesIndex: number; colorIndex: number }
-    const columns = new Map<string, DotEntry[]>()
+    type DotEntry = {
+      x: number;
+      y: number;
+      value: number;
+      label?: string;
+      seriesIndex: number;
+      colorIndex: number;
+    };
+    const columns = new Map<string, DotEntry[]>();
 
     for (const line of chart.lines) {
       for (const p of line.points) {
-        const key = r(p.x)
-        if (!columns.has(key)) columns.set(key, [])
-        columns.get(key)!.push({ x: p.x, y: p.y, value: p.value, label: p.label, seriesIndex: line.seriesIndex, colorIndex: line.colorIndex })
+        const key = r(p.x);
+        if (!columns.has(key)) columns.set(key, []);
+        columns.get(key)!.push({
+          x: p.x,
+          y: p.y,
+          value: p.value,
+          label: p.label,
+          seriesIndex: line.seriesIndex,
+          colorIndex: line.colorIndex,
+        });
       }
     }
 
     for (const entries of columns.values()) {
-      const cx = entries[0]!.x
-      const label = entries[0]!.label || ''
+      const cx = entries[0]!.x;
+      const label = entries[0]!.label || '';
 
       if (interactive && entries.length > 1) {
-        const topY = Math.min(...entries.map(e => e.y))
-        const botY = Math.max(...entries.map(e => e.y))
-        const hitPad = CHART_FONT.dotRadius * 3
-        const hitArea = `<rect x="${r(cx - hitPad)}" y="${r(topY - hitPad)}" width="${r(hitPad * 2)}" height="${r(botY - topY + hitPad * 2)}" fill="transparent" class="xychart-hit"/>`
-        const tipEntries = entries.map(e => ({
+        const topY = Math.min(...entries.map((e) => e.y));
+        const botY = Math.max(...entries.map((e) => e.y));
+        const hitPad = CHART_FONT.dotRadius * 3;
+        const hitArea = `<rect x="${r(cx - hitPad)}" y="${r(topY - hitPad)}" width="${r(hitPad * 2)}" height="${r(botY - topY + hitPad * 2)}" fill="transparent" class="xychart-hit"/>`;
+        const tipEntries = entries.map((e) => ({
           text: formatTipValue(e.value),
           legendLabel: lineLegendLabels.get(e.seriesIndex) || `Line ${e.seriesIndex + 1}`,
-        }))
-        const tip = multiTooltipAbove(cx, topY - CHART_FONT.dotRadius, label, tipEntries)
-        const valStrs = tipEntries.map(e => e.text)
-        const titleText = label ? `${label}: ${valStrs.join(' · ')}` : valStrs.join(' · ')
+        }));
+        const tip = multiTooltipAbove(cx, topY - CHART_FONT.dotRadius, label, tipEntries);
+        const valStrs = tipEntries.map((e) => e.text);
+        const titleText = label ? `${label}: ${valStrs.join(' · ')}` : valStrs.join(' · ');
 
-        let group = `<g class="xychart-dot-group">${hitArea}`
+        let group = `<g class="xychart-dot-group">${hitArea}`;
         for (const e of entries) {
-          const dataAttrs = ` data-value="${e.value}"${e.label ? ` data-label="${escapeXml(e.label)}"` : ''}`
-          group += `<circle cx="${r(e.x)}" cy="${r(e.y)}" r="${CHART_FONT.dotRadius}" class="xychart-dot xychart-color-${e.colorIndex}"${dataAttrs}/>`
+          const dataAttrs = ` data-value="${e.value}"${e.label ? ` data-label="${escapeXml(e.label)}"` : ''}`;
+          group += `<circle cx="${r(e.x)}" cy="${r(e.y)}" r="${CHART_FONT.dotRadius}" class="xychart-dot xychart-color-${e.colorIndex}"${dataAttrs}/>`;
         }
-        group += `<title>${escapeXml(titleText)}</title>${tip}</g>`
-        dotOverlay.push(group)
-
+        group += `<title>${escapeXml(titleText)}</title>${tip}</g>`;
+        dotOverlay.push(group);
       } else if (interactive) {
-        const e = entries[0]!
-        const dataAttrs = ` data-value="${e.value}"${e.label ? ` data-label="${escapeXml(e.label)}"` : ''}`
-        const tipText = formatTipValue(e.value)
-        const tipTitle = e.label ? `${e.label}: ${tipText}` : tipText
-        const tip = tooltipAbove(cx, e.y - CHART_FONT.dotRadius, tipText)
+        const e = entries[0]!;
+        const dataAttrs = ` data-value="${e.value}"${e.label ? ` data-label="${escapeXml(e.label)}"` : ''}`;
+        const tipText = formatTipValue(e.value);
+        const tipTitle = e.label ? `${e.label}: ${tipText}` : tipText;
+        const tip = tooltipAbove(cx, e.y - CHART_FONT.dotRadius, tipText);
         const hitArea = sparse
           ? `<circle cx="${r(cx)}" cy="${r(e.y)}" r="${CHART_FONT.dotRadius * 3}" fill="transparent" class="xychart-hit"/>`
-          : ''
+          : '';
         dotOverlay.push(
           `<g class="xychart-dot-group">${hitArea}` +
-          `<circle cx="${r(e.x)}" cy="${r(e.y)}" r="${CHART_FONT.dotRadius}" class="xychart-dot xychart-color-${e.colorIndex}"${dataAttrs}/>` +
-          `<title>${escapeXml(tipTitle)}</title>${tip}</g>`
-        )
-
+            `<circle cx="${r(e.x)}" cy="${r(e.y)}" r="${CHART_FONT.dotRadius}" class="xychart-dot xychart-color-${e.colorIndex}"${dataAttrs}/>` +
+            `<title>${escapeXml(tipTitle)}</title>${tip}</g>`,
+        );
       } else {
         // Sparse, not interactive: static dots render inline
         for (const e of entries) {
-          const dataAttrs = ` data-value="${e.value}"${e.label ? ` data-label="${escapeXml(e.label)}"` : ''}`
+          const dataAttrs = ` data-value="${e.value}"${e.label ? ` data-label="${escapeXml(e.label)}"` : ''}`;
           parts.push(
-            `<circle cx="${r(e.x)}" cy="${r(e.y)}" r="${CHART_FONT.dotRadius}" class="xychart-dot xychart-color-${e.colorIndex}"${dataAttrs}/>`
-          )
+            `<circle cx="${r(e.x)}" cy="${r(e.y)}" r="${CHART_FONT.dotRadius}" class="xychart-dot xychart-color-${e.colorIndex}"${dataAttrs}/>`,
+          );
         }
       }
     }
@@ -210,121 +237,138 @@ export function renderXYChartSvg(
   for (const tick of chart.xAxis.ticks) {
     parts.push(
       `<text x="${tick.labelX}" y="${tick.labelY}" text-anchor="${tick.textAnchor}" ` +
-      `font-size="${CHART_FONT.labelSize}" font-weight="${CHART_FONT.labelWeight}" ` +
-      `dy="${TEXT_BASELINE_SHIFT}" class="xychart-label">${escapeXml(tick.label)}</text>`
-    )
+        `font-size="${CHART_FONT.labelSize}" font-weight="${CHART_FONT.labelWeight}" ` +
+        `dy="${TEXT_BASELINE_SHIFT}" class="xychart-label">${escapeXml(tick.label)}</text>`,
+    );
   }
   for (const tick of chart.yAxis.ticks) {
     parts.push(
       `<text x="${tick.labelX}" y="${tick.labelY}" text-anchor="${tick.textAnchor}" ` +
-      `font-size="${CHART_FONT.labelSize}" font-weight="${CHART_FONT.labelWeight}" ` +
-      `dy="${TEXT_BASELINE_SHIFT}" class="xychart-label">${escapeXml(tick.label)}</text>`
-    )
+        `font-size="${CHART_FONT.labelSize}" font-weight="${CHART_FONT.labelWeight}" ` +
+        `dy="${TEXT_BASELINE_SHIFT}" class="xychart-label">${escapeXml(tick.label)}</text>`,
+    );
   }
 
   // 6. Axis titles
   if (chart.xAxis.title) {
-    const t = chart.xAxis.title
-    const transform = t.rotate ? ` transform="rotate(${t.rotate},${t.x},${t.y})"` : ''
+    const t = chart.xAxis.title;
+    const transform = t.rotate ? ` transform="rotate(${t.rotate},${t.x},${t.y})"` : '';
     parts.push(
       `<text x="${t.x}" y="${t.y}" text-anchor="middle"${transform} ` +
-      `font-size="${CHART_FONT.axisTitleSize}" font-weight="${CHART_FONT.axisTitleWeight}" ` +
-      `dy="${TEXT_BASELINE_SHIFT}" class="xychart-axis-title">${escapeXml(t.text)}</text>`
-    )
+        `font-size="${CHART_FONT.axisTitleSize}" font-weight="${CHART_FONT.axisTitleWeight}" ` +
+        `dy="${TEXT_BASELINE_SHIFT}" class="xychart-axis-title">${escapeXml(t.text)}</text>`,
+    );
   }
   if (chart.yAxis.title) {
-    const t = chart.yAxis.title
-    const transform = t.rotate ? ` transform="rotate(${t.rotate},${t.x},${t.y})"` : ''
+    const t = chart.yAxis.title;
+    const transform = t.rotate ? ` transform="rotate(${t.rotate},${t.x},${t.y})"` : '';
     parts.push(
       `<text x="${t.x}" y="${t.y}" text-anchor="middle"${transform} ` +
-      `font-size="${CHART_FONT.axisTitleSize}" font-weight="${CHART_FONT.axisTitleWeight}" ` +
-      `dy="${TEXT_BASELINE_SHIFT}" class="xychart-axis-title">${escapeXml(t.text)}</text>`
-    )
+        `font-size="${CHART_FONT.axisTitleSize}" font-weight="${CHART_FONT.axisTitleWeight}" ` +
+        `dy="${TEXT_BASELINE_SHIFT}" class="xychart-axis-title">${escapeXml(t.text)}</text>`,
+    );
   }
 
   // 7. Chart title
   if (chart.title) {
     parts.push(
       `<text x="${chart.title.x}" y="${chart.title.y}" text-anchor="middle" ` +
-      `font-size="${CHART_FONT.titleSize}" font-weight="${CHART_FONT.titleWeight}" ` +
-      `dy="${TEXT_BASELINE_SHIFT}" class="xychart-title">${escapeXml(chart.title.text)}</text>`
-    )
+        `font-size="${CHART_FONT.titleSize}" font-weight="${CHART_FONT.titleWeight}" ` +
+        `dy="${TEXT_BASELINE_SHIFT}" class="xychart-title">${escapeXml(chart.title.text)}</text>`,
+    );
   }
 
   // 8. Legend
   for (const item of chart.legend) {
-    const swatchW = 14, swatchH = 14
-    const gap = 6
+    const swatchW = 14,
+      swatchH = 14;
+    const gap = 6;
     if (item.type === 'bar') {
       parts.push(
         `<rect x="${item.x}" y="${item.y - swatchH / 2}" width="${swatchW}" height="${swatchH}" rx="3" ` +
-        `class="xychart-bar xychart-color-${item.colorIndex}"/>`
-      )
+          `class="xychart-bar xychart-color-${item.colorIndex}"/>`,
+      );
     } else {
-      const ly = item.y
+      const ly = item.y;
       parts.push(
         `<line x1="${item.x}" y1="${ly}" x2="${item.x + swatchW}" y2="${ly}" ` +
-        `stroke-width="${CHART_FONT.lineWidth}" stroke-linecap="round" class="xychart-legend-line xychart-color-${item.colorIndex}"/>`
-      )
+          `stroke-width="${CHART_FONT.lineWidth}" stroke-linecap="round" class="xychart-legend-line xychart-color-${item.colorIndex}"/>`,
+      );
     }
     parts.push(
       `<text x="${item.x + swatchW + gap}" y="${item.y}" text-anchor="start" ` +
-      `font-size="${CHART_FONT.legendSize}" font-weight="${CHART_FONT.legendWeight}" ` +
-      `dy="${TEXT_BASELINE_SHIFT}" class="xychart-label">${escapeXml(item.label)}</text>`
-    )
+        `font-size="${CHART_FONT.legendSize}" font-weight="${CHART_FONT.legendWeight}" ` +
+        `dy="${TEXT_BASELINE_SHIFT}" class="xychart-label">${escapeXml(item.label)}</text>`,
+    );
   }
 
   // 9. Interactive overlay — rendered last so tooltips are always on top
-  for (const g of barOverlay) parts.push(g)
-  for (const g of dotOverlay) parts.push(g)
+  for (const g of barOverlay) parts.push(g);
+  for (const g of dotOverlay) parts.push(g);
 
-  parts.push('</svg>')
-  return parts.join('\n')
+  parts.push('</svg>');
+  return parts.join('\n');
 }
 
 // ============================================================================
 // Chart-specific CSS styles
 // ============================================================================
 
-function chartStyles(chart: PositionedXYChart, interactive: boolean, sparse: boolean, themeAccent?: string, bgColor?: string): { style: string; defs: string } {
-  const accentHex = themeAccent ?? CHART_ACCENT_FALLBACK
+function chartStyles(
+  chart: PositionedXYChart,
+  interactive: boolean,
+  sparse: boolean,
+  themeAccent?: string,
+  bgColor?: string,
+): { style: string; defs: string } {
+  const accentHex = themeAccent ?? CHART_ACCENT_FALLBACK;
 
   // Collect all unique global color indices from bars + lines
-  const colorIndices = new Set<number>()
-  for (const b of chart.bars) colorIndices.add(b.colorIndex)
-  for (const l of chart.lines) colorIndices.add(l.colorIndex)
+  const colorIndices = new Set<number>();
+  for (const b of chart.bars) colorIndices.add(b.colorIndex);
+  for (const l of chart.lines) colorIndices.add(l.colorIndex);
 
   // Define --xychart-color-N CSS custom properties (updatable by theme-switching JS)
   // Also define --xychart-bar-fill-N via color-mix() so it stays dynamic on theme change
-  const colorVarDefs: string[] = []
+  const colorVarDefs: string[] = [];
   for (const idx of [...colorIndices].sort((a, b) => a - b)) {
-    const value = idx === 0
-      ? `var(--accent, ${CHART_ACCENT_FALLBACK})`
-      : getSeriesColor(idx, accentHex, bgColor)
-    colorVarDefs.push(`    --xychart-color-${idx}: ${value};`)
-    colorVarDefs.push(`    --xychart-bar-fill-${idx}: color-mix(in srgb, var(--bg) 75%, var(--xychart-color-${idx}) 25%);`)
+    const value =
+      idx === 0
+        ? `var(--accent, ${CHART_ACCENT_FALLBACK})`
+        : getSeriesColor(idx, accentHex, bgColor);
+    colorVarDefs.push(`    --xychart-color-${idx}: ${value};`);
+    colorVarDefs.push(
+      `    --xychart-bar-fill-${idx}: color-mix(in srgb, var(--bg) 75%, var(--xychart-color-${idx}) 25%);`,
+    );
   }
 
   // Generate unified color rules — one per global index, referencing the CSS vars
-  const seriesRules: string[] = []
+  const seriesRules: string[] = [];
   for (const idx of [...colorIndices].sort((a, b) => a - b)) {
-    const color = `var(--xychart-color-${idx})`
+    const color = `var(--xychart-color-${idx})`;
     // Bar-specific: stroke + solid blended fill (no opacity)
-    seriesRules.push(`  .xychart-bar.xychart-color-${idx} { stroke: ${color}; fill: var(--xychart-bar-fill-${idx}); }`)
+    seriesRules.push(
+      `  .xychart-bar.xychart-color-${idx} { stroke: ${color}; fill: var(--xychart-bar-fill-${idx}); }`,
+    );
     // Line/dot-specific: stroke for paths, fill for circles
-    seriesRules.push(`  path.xychart-color-${idx}, line.xychart-color-${idx} { stroke: ${color}; }`)
-    seriesRules.push(`  circle.xychart-color-${idx} { fill: ${color}; }`)
+    seriesRules.push(
+      `  path.xychart-color-${idx}, line.xychart-color-${idx} { stroke: ${color}; }`,
+    );
+    seriesRules.push(`  circle.xychart-color-${idx} { fill: ${color}; }`);
   }
 
-  const tipRules = interactive ? `
+  const tipRules = interactive
+    ? `
   .xychart-tip { opacity: 0; pointer-events: none; }
   .xychart-tip-bg { fill: var(--_text); filter: drop-shadow(0 1px 3px color-mix(in srgb, var(--fg) 20%, transparent)); }
   .xychart-tip-text { fill: var(--bg); font-size: ${TIP.fontSize}px; font-weight: ${TIP.fontWeight}; }
   .xychart-tip-ptr { fill: var(--_text); }
   .xychart-bar-group:hover .xychart-tip,
-  .xychart-dot-group:hover .xychart-tip { opacity: 1; }` : ''
+  .xychart-dot-group:hover .xychart-tip { opacity: 1; }`
+    : '';
 
-  const colorVarsBlock = colorVarDefs.length > 0 ? `\n  svg {\n${colorVarDefs.join('\n')}\n  }` : ''
+  const colorVarsBlock =
+    colorVarDefs.length > 0 ? `\n  svg {\n${colorVarDefs.join('\n')}\n  }` : '';
 
   const style = `<style>
   .xychart-grid { fill: var(--_inner-stroke); stroke: none; opacity: 0.65; }
@@ -336,32 +380,31 @@ function chartStyles(chart: PositionedXYChart, interactive: boolean, sparse: boo
   .xychart-axis-title { fill: var(--_text-sec); }
   .xychart-title { fill: var(--_text); }${colorVarsBlock}
 ${seriesRules.join('\n')}${tipRules}
-</style>`
+</style>`;
 
-  return { style, defs: '' }
+  return { style, defs: '' };
 }
-
 
 // ============================================================================
 // Bar path with all corners rounded
 // ============================================================================
 
 function roundedTopBarPath(x: number, y: number, w: number, h: number, radius: number): string {
-  const rr = Math.min(radius, w / 2, h / 2)
+  const rr = Math.min(radius, w / 2, h / 2);
   if (rr <= 0) {
-    return `M${r(x)},${r(y)} h${r(w)} v${r(h)} h${r(-w)} Z`
+    return `M${r(x)},${r(y)} h${r(w)} v${r(h)} h${r(-w)} Z`;
   }
   return [
-    `M${r(x)},${r(y + rr)}`,                                   // start below top-left
-    `Q${r(x)},${r(y)} ${r(x + rr)},${r(y)}`,                   // top-left
-    `L${r(x + w - rr)},${r(y)}`,                                // top edge
-    `Q${r(x + w)},${r(y)} ${r(x + w)},${r(y + rr)}`,           // top-right
-    `L${r(x + w)},${r(y + h - rr)}`,                            // right edge
-    `Q${r(x + w)},${r(y + h)} ${r(x + w - rr)},${r(y + h)}`,   // bottom-right
-    `L${r(x + rr)},${r(y + h)}`,                                // bottom edge
-    `Q${r(x)},${r(y + h)} ${r(x)},${r(y + h - rr)}`,           // bottom-left
+    `M${r(x)},${r(y + rr)}`, // start below top-left
+    `Q${r(x)},${r(y)} ${r(x + rr)},${r(y)}`, // top-left
+    `L${r(x + w - rr)},${r(y)}`, // top edge
+    `Q${r(x + w)},${r(y)} ${r(x + w)},${r(y + rr)}`, // top-right
+    `L${r(x + w)},${r(y + h - rr)}`, // right edge
+    `Q${r(x + w)},${r(y + h)} ${r(x + w - rr)},${r(y + h)}`, // bottom-right
+    `L${r(x + rr)},${r(y + h)}`, // bottom edge
+    `Q${r(x)},${r(y + h)} ${r(x)},${r(y + h - rr)}`, // bottom-left
     'Z',
-  ].join(' ')
+  ].join(' ');
 }
 
 // ============================================================================
@@ -369,22 +412,22 @@ function roundedTopBarPath(x: number, y: number, w: number, h: number, radius: n
 // ============================================================================
 
 function roundedRightBarPath(x: number, y: number, w: number, h: number, radius: number): string {
-  const rr = Math.min(radius, w / 2, h / 2)
+  const rr = Math.min(radius, w / 2, h / 2);
   if (rr <= 0) {
-    return `M${r(x)},${r(y)} h${r(w)} v${r(h)} h${r(-w)} Z`
+    return `M${r(x)},${r(y)} h${r(w)} v${r(h)} h${r(-w)} Z`;
   }
   return [
-    `M${r(x + rr)},${r(y)}`,                                    // start after top-left
-    `L${r(x + w - rr)},${r(y)}`,                                // top edge
-    `Q${r(x + w)},${r(y)} ${r(x + w)},${r(y + rr)}`,           // top-right
-    `L${r(x + w)},${r(y + h - rr)}`,                            // right edge
-    `Q${r(x + w)},${r(y + h)} ${r(x + w - rr)},${r(y + h)}`,   // bottom-right
-    `L${r(x + rr)},${r(y + h)}`,                                // bottom edge
-    `Q${r(x)},${r(y + h)} ${r(x)},${r(y + h - rr)}`,           // bottom-left
-    `L${r(x)},${r(y + rr)}`,                                    // left edge
-    `Q${r(x)},${r(y)} ${r(x + rr)},${r(y)}`,                   // top-left
+    `M${r(x + rr)},${r(y)}`, // start after top-left
+    `L${r(x + w - rr)},${r(y)}`, // top edge
+    `Q${r(x + w)},${r(y)} ${r(x + w)},${r(y + rr)}`, // top-right
+    `L${r(x + w)},${r(y + h - rr)}`, // right edge
+    `Q${r(x + w)},${r(y + h)} ${r(x + w - rr)},${r(y + h)}`, // bottom-right
+    `L${r(x + rr)},${r(y + h)}`, // bottom edge
+    `Q${r(x)},${r(y + h)} ${r(x)},${r(y + h - rr)}`, // bottom-left
+    `L${r(x)},${r(y + rr)}`, // left edge
+    `Q${r(x)},${r(y)} ${r(x + rr)},${r(y)}`, // top-left
     'Z',
-  ].join(' ')
+  ].join(' ');
 }
 
 // ============================================================================
@@ -399,66 +442,66 @@ function roundedRightBarPath(x: number, y: number, w: number, h: number, radius:
 // ============================================================================
 
 function smoothCurvePath(points: Array<{ x: number; y: number }>): string {
-  if (points.length === 0) return ''
-  if (points.length === 1) return `M${r(points[0]!.x)},${r(points[0]!.y)}`
+  if (points.length === 0) return '';
+  if (points.length === 1) return `M${r(points[0]!.x)},${r(points[0]!.y)}`;
   if (points.length === 2) {
-    return `M${r(points[0]!.x)},${r(points[0]!.y)} L${r(points[1]!.x)},${r(points[1]!.y)}`
+    return `M${r(points[0]!.x)},${r(points[0]!.y)} L${r(points[1]!.x)},${r(points[1]!.y)}`;
   }
 
-  const n = points.length
+  const n = points.length;
 
   // 1. Interval widths and secant slopes
-  const h: number[] = []
-  const delta: number[] = []
+  const h: number[] = [];
+  const delta: number[] = [];
   for (let i = 0; i < n - 1; i++) {
-    h.push(points[i + 1]!.x - points[i]!.x)
-    delta.push(h[i]! === 0 ? 0 : (points[i + 1]!.y - points[i]!.y) / h[i]!)
+    h.push(points[i + 1]!.x - points[i]!.x);
+    delta.push(h[i]! === 0 ? 0 : (points[i + 1]!.y - points[i]!.y) / h[i]!);
   }
 
   // 2. Solve tridiagonal system for second derivatives c[] (natural boundary: c[0] = c[n-1] = 0)
-  const c = new Array<number>(n).fill(0)
+  const c = new Array<number>(n).fill(0);
   if (n > 2) {
     // Forward elimination
-    const cp = new Array<number>(n).fill(0) // modified upper diagonal
-    const dp = new Array<number>(n).fill(0) // modified right-hand side
+    const cp = new Array<number>(n).fill(0); // modified upper diagonal
+    const dp = new Array<number>(n).fill(0); // modified right-hand side
     for (let i = 1; i < n - 1; i++) {
-      const diag = 2 * (h[i - 1]! + h[i]!)
-      const rhs = 3 * (delta[i]! - delta[i - 1]!)
+      const diag = 2 * (h[i - 1]! + h[i]!);
+      const rhs = 3 * (delta[i]! - delta[i - 1]!);
       if (i === 1) {
-        cp[i] = h[i]! / diag
-        dp[i] = rhs / diag
+        cp[i] = h[i]! / diag;
+        dp[i] = rhs / diag;
       } else {
-        const w = diag - h[i - 1]! * cp[i - 1]!
-        cp[i] = h[i]! / w
-        dp[i] = (rhs - h[i - 1]! * dp[i - 1]!) / w
+        const w = diag - h[i - 1]! * cp[i - 1]!;
+        cp[i] = h[i]! / w;
+        dp[i] = (rhs - h[i - 1]! * dp[i - 1]!) / w;
       }
     }
     // Back substitution
     for (let i = n - 2; i >= 1; i--) {
-      c[i] = dp[i]! - cp[i]! * c[i + 1]!
+      c[i] = dp[i]! - cp[i]! * c[i + 1]!;
     }
   }
 
   // 3. Compute first derivatives (slopes) at each knot
-  const slopes = new Array<number>(n).fill(0)
+  const slopes = new Array<number>(n).fill(0);
   for (let i = 0; i < n - 1; i++) {
-    slopes[i] = delta[i]! - h[i]! * (2 * c[i]! + c[i + 1]!) / 3
+    slopes[i] = delta[i]! - (h[i]! * (2 * c[i]! + c[i + 1]!)) / 3;
   }
   // Slope at last point: derivative of last segment at its end
-  slopes[n - 1] = delta[n - 2]! + h[n - 2]! * (c[n - 2]!) / 3
+  slopes[n - 1] = delta[n - 2]! + (h[n - 2]! * c[n - 2]!) / 3;
 
   // 4. Convert to cubic Bezier — control points strictly between endpoints in x
-  let path = `M${r(points[0]!.x)},${r(points[0]!.y)}`
+  let path = `M${r(points[0]!.x)},${r(points[0]!.y)}`;
   for (let i = 0; i < n - 1; i++) {
-    const seg = h[i]! / 3
-    const cp1x = points[i]!.x + seg
-    const cp1y = points[i]!.y + slopes[i]! * seg
-    const cp2x = points[i + 1]!.x - seg
-    const cp2y = points[i + 1]!.y - slopes[i + 1]! * seg
-    path += ` C${r(cp1x)},${r(cp1y)} ${r(cp2x)},${r(cp2y)} ${r(points[i + 1]!.x)},${r(points[i + 1]!.y)}`
+    const seg = h[i]! / 3;
+    const cp1x = points[i]!.x + seg;
+    const cp1y = points[i]!.y + slopes[i]! * seg;
+    const cp2x = points[i + 1]!.x - seg;
+    const cp2y = points[i + 1]!.y - slopes[i + 1]! * seg;
+    path += ` C${r(cp1x)},${r(cp1y)} ${r(cp2x)},${r(cp2y)} ${r(points[i + 1]!.x)},${r(points[i + 1]!.y)}`;
   }
 
-  return path
+  return path;
 }
 
 // ============================================================================
@@ -468,74 +511,81 @@ function smoothCurvePath(points: Array<{ x: number; y: number }>): string {
 /**
  * Multi-value tooltip: category label on top, each series value below with legend text label.
  */
-function multiTooltipAbove(cx: number, topY: number, label: string, entries: Array<{ text: string; legendLabel: string }>): string {
-  const lineH = 20
-  const padY = 6
-  const labelGap = 10
-  const headingW = estimateTextWidth(label, TIP.fontSize, 600)
-  const maxRowW = Math.max(...entries.map(e => {
-    const legendW = estimateTextWidth(e.legendLabel, TIP.fontSize, TIP.fontWeight)
-    const valW = estimateTextWidth(e.text, TIP.fontSize, TIP.fontWeight)
-    return legendW + labelGap + valW
-  }))
-  const bgW = Math.max(headingW, maxRowW) + TIP.padX * 2
-  const bgH = padY + lineH + entries.length * lineH + padY
+function multiTooltipAbove(
+  cx: number,
+  topY: number,
+  label: string,
+  entries: Array<{ text: string; legendLabel: string }>,
+): string {
+  const lineH = 20;
+  const padY = 6;
+  const labelGap = 10;
+  const headingW = estimateTextWidth(label, TIP.fontSize, 600);
+  const maxRowW = Math.max(
+    ...entries.map((e) => {
+      const legendW = estimateTextWidth(e.legendLabel, TIP.fontSize, TIP.fontWeight);
+      const valW = estimateTextWidth(e.text, TIP.fontSize, TIP.fontWeight);
+      return legendW + labelGap + valW;
+    }),
+  );
+  const bgW = Math.max(headingW, maxRowW) + TIP.padX * 2;
+  const bgH = padY + lineH + entries.length * lineH + padY;
 
-  const tipY = Math.max(TIP.minY, topY - TIP.offsetY - bgH - TIP.pointerSize)
-  const bgX = cx - bgW / 2
+  const tipY = Math.max(TIP.minY, topY - TIP.offsetY - bgH - TIP.pointerSize);
+  const bgX = cx - bgW / 2;
 
-  const ptrX = cx
-  const ptrY = tipY + bgH
-  const ps = TIP.pointerSize
-  const pointer = `<polygon points="${r(ptrX - ps)},${r(ptrY)} ${r(ptrX + ps)},${r(ptrY)} ${r(ptrX)},${r(ptrY + ps)}" class="xychart-tip xychart-tip-ptr"/>`
+  const ptrX = cx;
+  const ptrY = tipY + bgH;
+  const ps = TIP.pointerSize;
+  const pointer = `<polygon points="${r(ptrX - ps)},${r(ptrY)} ${r(ptrX + ps)},${r(ptrY)} ${r(ptrX)},${r(ptrY + ps)}" class="xychart-tip xychart-tip-ptr"/>`;
 
-  let svg = `<rect x="${r(bgX)}" y="${r(tipY)}" width="${r(bgW)}" height="${bgH}" rx="${TIP.rx}" class="xychart-tip xychart-tip-bg"/>`
-  svg += pointer
+  let svg = `<rect x="${r(bgX)}" y="${r(tipY)}" width="${r(bgW)}" height="${bgH}" rx="${TIP.rx}" class="xychart-tip xychart-tip-bg"/>`;
+  svg += pointer;
 
   // Category label (bold, centered)
-  let textY = tipY + padY + lineH / 2
-  svg += `<text x="${r(cx)}" y="${r(textY)}" text-anchor="middle" font-weight="600" font-size="${TIP.fontSize}" dy="${TEXT_BASELINE_SHIFT}" class="xychart-tip xychart-tip-text">${escapeXml(label)}</text>`
+  let textY = tipY + padY + lineH / 2;
+  svg += `<text x="${r(cx)}" y="${r(textY)}" text-anchor="middle" font-weight="600" font-size="${TIP.fontSize}" dy="${TEXT_BASELINE_SHIFT}" class="xychart-tip xychart-tip-text">${escapeXml(label)}</text>`;
 
   // Value lines: legend label left-aligned, value right-aligned
-  const rowLeft = bgX + TIP.padX
-  const rowRight = bgX + bgW - TIP.padX
+  const rowLeft = bgX + TIP.padX;
+  const rowRight = bgX + bgW - TIP.padX;
   for (const entry of entries) {
-    textY += lineH
-    svg += `<text x="${r(rowLeft)}" y="${r(textY)}" text-anchor="start" font-size="${TIP.fontSize}" font-weight="${TIP.fontWeight}" dy="${TEXT_BASELINE_SHIFT}" class="xychart-tip xychart-tip-text">${escapeXml(entry.legendLabel)}</text>`
-    svg += `<text x="${r(rowRight)}" y="${r(textY)}" text-anchor="end" font-size="${TIP.fontSize}" font-weight="${TIP.fontWeight}" dy="${TEXT_BASELINE_SHIFT}" class="xychart-tip xychart-tip-text">${escapeXml(entry.text)}</text>`
+    textY += lineH;
+    svg += `<text x="${r(rowLeft)}" y="${r(textY)}" text-anchor="start" font-size="${TIP.fontSize}" font-weight="${TIP.fontWeight}" dy="${TEXT_BASELINE_SHIFT}" class="xychart-tip xychart-tip-text">${escapeXml(entry.legendLabel)}</text>`;
+    svg += `<text x="${r(rowRight)}" y="${r(textY)}" text-anchor="end" font-size="${TIP.fontSize}" font-weight="${TIP.fontWeight}" dy="${TEXT_BASELINE_SHIFT}" class="xychart-tip xychart-tip-text">${escapeXml(entry.text)}</text>`;
   }
 
-  return svg
+  return svg;
 }
 
 function tooltipAbove(cx: number, topY: number, text: string): string {
-  const textW = estimateTextWidth(text, TIP.fontSize, TIP.fontWeight)
-  const bgW = textW + TIP.padX * 2
-  const bgH = TIP.height
-  const tipY = Math.max(TIP.minY, topY - TIP.offsetY - bgH - TIP.pointerSize)
-  const bgX = cx - bgW / 2
-  const textX = cx
-  const textY = tipY + bgH / 2
+  const textW = estimateTextWidth(text, TIP.fontSize, TIP.fontWeight);
+  const bgW = textW + TIP.padX * 2;
+  const bgH = TIP.height;
+  const tipY = Math.max(TIP.minY, topY - TIP.offsetY - bgH - TIP.pointerSize);
+  const bgX = cx - bgW / 2;
+  const textX = cx;
+  const textY = tipY + bgH / 2;
 
-  const ptrX = cx
-  const ptrY = tipY + bgH
-  const ps = TIP.pointerSize
-  const pointer = `<polygon points="${r(ptrX - ps)},${r(ptrY)} ${r(ptrX + ps)},${r(ptrY)} ${r(ptrX)},${r(ptrY + ps)}" class="xychart-tip xychart-tip-ptr"/>`
+  const ptrX = cx;
+  const ptrY = tipY + bgH;
+  const ps = TIP.pointerSize;
+  const pointer = `<polygon points="${r(ptrX - ps)},${r(ptrY)} ${r(ptrX + ps)},${r(ptrY)} ${r(ptrX)},${r(ptrY + ps)}" class="xychart-tip xychart-tip-ptr"/>`;
 
   return (
     `<rect x="${r(bgX)}" y="${r(tipY)}" width="${r(bgW)}" height="${bgH}" rx="${TIP.rx}" class="xychart-tip xychart-tip-bg"/>` +
     pointer +
     `<text x="${r(textX)}" y="${r(textY)}" text-anchor="middle" dy="${TEXT_BASELINE_SHIFT}" class="xychart-tip xychart-tip-text">${escapeXml(text)}</text>`
-  )
+  );
 }
 
 function formatTipValue(v: number): string {
-  if (Number.isInteger(v)) return v.toLocaleString('en-US')
-  return v.toFixed(Math.abs(v) < 10 ? 1 : 0)
+  if (Number.isInteger(v)) return v.toLocaleString('en-US');
+  return v.toFixed(Math.abs(v) < 10 ? 1 : 0);
 }
 
 function r(n: number): string {
-  return String(Math.round(n * 10) / 10)
+  return f`${n}`;
 }
 
 function escapeXml(text: string): string {
@@ -543,7 +593,5 @@ function escapeXml(text: string): string {
     .replace(/&/g, '&amp;')
     .replace(/</g, '&lt;')
     .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
+    .replace(/"/g, '&quot;');
 }
-
-


### PR DESCRIPTION
Hi there! My attempt at fixing one of the points mentioned in #76: rounding all numbers to 2 dp. This PR was produced in a semi-automated fashion, with assistance from Copilot:

- me: architect and reviewer — designed the `f` tagged template approach, named the function, directed which files to modify, identified the redundant `r()` wrapper in xychart, and validated results.
- Copilot: Implementer — created the tests, applied `f` across all 9 files, debugged a missing import in `theme.ts`, and ran the test suite to confirm zero regressions.

During the implementation I noticed that a similar effort was started in xychart; I tasked copilot to replace the existing `r` function with the new `f` function

`f` because `r` is sometimes used for `radius`

The diff is very large because the repo is missing a code formatting setup, if provided with instructions I can re-format the code properly
