### PR TITLE
fix: sequence diagram layout and node stroke rendering

### DIFF
--- a/src/ascii/ansi.ts
+++ b/src/ascii/ansi.ts
@@ -52,7 +52,7 @@ function mixColors(fg: string, bg: string, pct: number): string {
  */
 export function diagramColorsToAsciiTheme(colors: DiagramColors): AsciiTheme {
   const line = colors.line ?? mixColors(colors.fg, colors.bg, MIX.line)
-  const border = colors.border ?? mixColors(colors.fg, colors.bg, MIX.nodeStroke)
+  const border = colors.border ?? mixColors(line, colors.bg, 60)
   return {
     fg:       colors.fg,
     border,

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -475,26 +475,27 @@ function renderHexagon(x: number, y: number, w: number, h: number, fill: string,
 
 // --- Batch 2 shapes ---
 
-/** Cylinder / database: top ellipse cap + body rect + bottom ellipse */
+/** Cylinder / database: top ellipse cap + body rect + bottom front arc */
 function renderCylinder(x: number, y: number, w: number, h: number, fill: string, stroke: string, sw: string): string {
   const ry = 7 // ellipse vertical radius for the cap
   const cx = x + w / 2
+  const rx = w / 2
   const bodyTop = y + ry
   const bodyH = h - 2 * ry
+  const bottomY = y + h - ry
 
   return (
-    // Body rectangle (no top border — covered by top ellipse)
-    `<rect x="${x}" y="${bodyTop}" width="${w}" height="${bodyH}" ` +
-    `fill="${fill}" stroke="none" />` +
+    // Bottom ellipse fill (back arc hidden by body rect on top)
+    `<ellipse cx="${cx}" cy="${bottomY}" rx="${rx}" ry="${ry}" fill="${fill}" stroke="none" />` +
+    // Body rectangle (covers back arc of bottom ellipse)
+    `\n<rect x="${x}" y="${bodyTop}" width="${w}" height="${bodyH}" fill="${fill}" stroke="none" />` +
+    // Bottom front arc (only the visible outline)
+    `\n<path d="M ${x} ${bottomY} A ${rx} ${ry} 0 0 0 ${x + w} ${bottomY}" fill="none" stroke="${stroke}" stroke-width="${sw}" />` +
     // Left and right body borders
-    `\n<line x1="${x}" y1="${bodyTop}" x2="${x}" y2="${bodyTop + bodyH}" stroke="${stroke}" stroke-width="${sw}" />` +
-    `\n<line x1="${x + w}" y1="${bodyTop}" x2="${x + w}" y2="${bodyTop + bodyH}" stroke="${stroke}" stroke-width="${sw}" />` +
-    // Bottom ellipse (half visible)
-    `\n<ellipse cx="${cx}" cy="${y + h - ry}" rx="${w / 2}" ry="${ry}" ` +
-    `fill="${fill}" stroke="${stroke}" stroke-width="${sw}" />` +
+    `\n<line x1="${x}" y1="${bodyTop}" x2="${x}" y2="${bottomY}" stroke="${stroke}" stroke-width="${sw}" />` +
+    `\n<line x1="${x + w}" y1="${bodyTop}" x2="${x + w}" y2="${bottomY}" stroke="${stroke}" stroke-width="${sw}" />` +
     // Top ellipse (full, on top)
-    `\n<ellipse cx="${cx}" cy="${bodyTop}" rx="${w / 2}" ry="${ry}" ` +
-    `fill="${fill}" stroke="${stroke}" stroke-width="${sw}" />`
+    `\n<ellipse cx="${cx}" cy="${bodyTop}" rx="${rx}" ry="${ry}" fill="${fill}" stroke="${stroke}" stroke-width="${sw}" />`
   )
 }
 
@@ -572,7 +573,8 @@ function renderNodeLabel(node: PositionedNode, font: string): string {
   }
 
   const cx = node.x + node.width / 2
-  const cy = node.y + node.height / 2
+  // Cylinder body center is shifted down by the top ellipse cap height
+  const cy = node.y + node.height / 2 + (node.shape === 'cylinder' ? 4 : 0)
 
   // Resolve text color — inline styles can override the CSS variable default
   const textColor = escapeAttr(node.inlineStyle?.color ?? 'var(--_text)')

--- a/src/sequence/layout.ts
+++ b/src/sequence/layout.ts
@@ -1,6 +1,7 @@
 import type { SequenceDiagram, PositionedSequenceDiagram, PositionedActor, Lifeline, PositionedMessage, Activation, PositionedBlock, PositionedNote } from './types.ts'
 import type { RenderOptions } from '../types.ts'
 import { estimateTextWidth, FONT_SIZES, FONT_WEIGHTS } from '../styles.ts'
+import { LINE_HEIGHT_RATIO } from '../text-metrics.ts'
 
 // ============================================================================
 // Sequence diagram layout engine
@@ -43,8 +44,8 @@ const SEQ = {
   dividerExtra: 24,
   /** Note dimensions */
   noteWidth: 60,
-  notePadX: 12,
-  notePadY: 6,
+  notePadX: 14,
+  notePadY: 10,
   noteGap: 10,
 } as const
 
@@ -57,7 +58,7 @@ export function layoutSequenceDiagram(
   _options: RenderOptions = {}
 ): PositionedSequenceDiagram {
   if (diagram.actors.length === 0) {
-    return { width: 0, height: 0, actors: [], lifelines: [], messages: [], activations: [], blocks: [], notes: [] }
+    return { width: 0, height: 0, actors: [], bottomActors: [], lifelines: [], messages: [], activations: [], blocks: [], notes: [] }
   }
 
   // 1. Calculate actor widths and assign horizontal positions (center X)
@@ -96,7 +97,13 @@ export function layoutSequenceDiagram(
   }))
 
   // 3. Stack messages vertically
-  let messageY = actorY + SEQ.actorHeight + SEQ.headerGap
+  //
+  // actor-type participants render their label BELOW the icon at
+  // actorY + actorHeight + 14. That label bleeds into headerGap and collides
+  // with the first message label. Add enough room to clear it.
+  const hasActorType = diagram.actors.some(a => a.type === 'actor')
+  const actorLabelExtra = hasActorType ? (FONT_SIZES.nodeLabel + 16) : 0
+  let messageY = actorY + SEQ.actorHeight + SEQ.headerGap + actorLabelExtra
   const messages: PositionedMessage[] = []
 
   // Pre-scan blocks to determine which message indices need extra vertical
@@ -113,6 +120,26 @@ export function layoutSequenceDiagram(
     for (const div of block.dividers) {
       const prevDiv = extraSpaceBefore.get(div.index) ?? 0
       extraSpaceBefore.set(div.index, Math.max(prevDiv, SEQ.dividerExtra))
+    }
+  }
+
+  // Pre-scan messages: labels are bottom-aligned so the last line sits
+  // LABEL_ARROW_GAP above msg.y. The top of a k-line label is at
+  //   msg.y - LABEL_ARROW_GAP - (k-1) * edgeLineHeight
+  // We must ensure this doesn't overlap the element above (actor boxes for
+  // the first message, or previous arrow for subsequent ones).
+  const edgeLineHeight = FONT_SIZES.edgeLabel * LINE_HEIGHT_RATIO
+  const LABEL_ARROW_GAP = 20  // must match renderer.ts constant
+  for (let mi = 0; mi < diagram.messages.length; mi++) {
+    const msg = diagram.messages[mi]!
+    const lines = msg.label ? msg.label.split('\n').length : 1
+    if (lines > 1) {
+      // For the first message, the effective gap includes the actor label extra.
+      const baseGap = mi === 0 ? SEQ.headerGap + actorLabelExtra : SEQ.messageRowHeight
+      // Keep LABEL_ARROW_GAP clearance above the label top as well (symmetric).
+      const extraNeeded = Math.max(0, Math.ceil((lines - 1) * edgeLineHeight - (baseGap - 2 * LABEL_ARROW_GAP)))
+      const prev = extraSpaceBefore.get(mi) ?? 0
+      extraSpaceBefore.set(mi, Math.max(prev, extraNeeded))
     }
   }
 
@@ -199,11 +226,13 @@ export function layoutSequenceDiagram(
       let noteY = messages[msgIdx]!.y + selfLoopExtra + 8
 
       for (const note of notesForMsg) {
-        const noteW = Math.max(
-          SEQ.noteWidth,
-          estimateTextWidth(note.text, FONT_SIZES.edgeLabel, FONT_WEIGHTS.edgeLabel) + SEQ.notePadX * 2
-        )
-        const noteH = FONT_SIZES.edgeLabel + SEQ.notePadY * 2
+        const noteLines = note.text.split('\n')
+        const maxLineW = Math.max(...noteLines.map(l => estimateTextWidth(l, FONT_SIZES.edgeLabel, FONT_WEIGHTS.edgeLabel)))
+        const noteW = Math.max(SEQ.noteWidth, maxLineW + SEQ.notePadX * 2)
+        const noteLH = FONT_SIZES.edgeLabel * LINE_HEIGHT_RATIO
+        const noteH = noteLines.length === 1
+          ? FONT_SIZES.edgeLabel + SEQ.notePadY * 2
+          : (noteLines.length - 1) * noteLH + FONT_SIZES.edgeLabel + SEQ.notePadY * 2
 
         // X positioning based on actor position and note type
         const firstActorIdx = actorIndex.get(note.actorIds[0] ?? '') ?? 0
@@ -262,7 +291,17 @@ export function layoutSequenceDiagram(
     // Block spans from the Y of startIndex to endIndex messages
     const startMsg = messages[block.startIndex]
     const endMsg = messages[block.endIndex]
-    const blockTop = (startMsg?.y ?? messageY) - SEQ.blockPadTop
+    const startMsgY = startMsg?.y ?? messageY
+
+    // Ensure the block tab never overlaps the first message's label.
+    // Tab box occupies [blockTop, blockTop + TAB_HEIGHT].
+    // Label top sits at startMsgY - LABEL_ARROW_GAP - (k-1)*lineHeight.
+    // We need tab bottom ≤ label top - 4 (4 px clearance).
+    const TAB_HEIGHT = 18 // must match tabHeight in renderer.ts renderBlock()
+    const firstMsgLines = startMsg?.label ? startMsg.label.split('\n').length : 1
+    const labelSpaceNeeded = LABEL_ARROW_GAP + Math.max(0, firstMsgLines - 1) * edgeLineHeight
+    const minBlockTop = startMsgY - TAB_HEIGHT - labelSpaceNeeded - 4
+    const blockTop = Math.min(startMsgY - SEQ.blockPadTop, minBlockTop)
     const blockBottom = (endMsg?.y ?? messageY) + SEQ.blockPadBottom + 12
 
     // Block width spans all actors involved in its messages
@@ -284,41 +323,20 @@ export function layoutSequenceDiagram(
     const blockRight = actorCenterX[maxIdx]! + actorWidths[maxIdx]! / 2 + SEQ.blockPadX
 
     // Position dividers — offset from message Y so the divider label text
-    // (rendered at divider.y + 14 in the renderer) clears the message label
-    // (rendered at msg.y - 6).
+    // (rendered at divider.y + 14 in the renderer) clears the message label.
     //
-    // Default offset 28 gives ~8px baseline clearance, which is sufficient
-    // when the divider label (left-aligned at block edge) and message label
-    // (centered between actors) don't share horizontal space. When they DO
-    // overlap horizontally (e.g. long divider labels like "[Account locked]"
-    // next to centered message labels like "403 Forbidden"), we increase the
-    // offset to 36 so text bounding boxes have ~5px visual clearance.
+    // Message labels are bottom-aligned: label top = msgY - RENDERER_LABEL_GAP - (k-1)*lineHeight.
+    // Divider label baseline = msgY - offset + 14.
+    // We need:  baseline + DIVIDER_CLEARANCE ≤ label_top
+    //   → offset ≥ 14 + RENDERER_LABEL_GAP + (k-1)*lineHeight + DIVIDER_CLEARANCE
+    const RENDERER_LABEL_GAP = 10  // must match LABEL_ARROW_GAP in renderer.ts
+    const DIVIDER_CLEARANCE = 30   // px gap between divider label baseline and msg label top
     const dividers = block.dividers.map(d => {
       const msg = messages[d.index]
       const msgY = msg?.y ?? messageY
-      let offset = 28
-
-      // Dynamic overlap detection: increase offset when the divider label
-      // and message label occupy the same horizontal region, which would
-      // cause vertical text overlap at the default 8px baseline gap.
-      if (d.label && msg?.label) {
-        const divLabelText = `[${d.label}]`
-        const divLabelW = estimateTextWidth(divLabelText, FONT_SIZES.edgeLabel, FONT_WEIGHTS.edgeLabel)
-        const divLabelLeft = blockLeft + 8
-        const divLabelRight = divLabelLeft + divLabelW
-
-        const msgLabelW = estimateTextWidth(msg.label, FONT_SIZES.edgeLabel, FONT_WEIGHTS.edgeLabel)
-        // Self-messages render labels at x1 + 36 (left-aligned); normal
-        // messages center the label between the two actor lifelines.
-        const msgLabelLeft = msg.isSelf
-          ? msg.x1 + 36
-          : (msg.x1 + msg.x2) / 2 - msgLabelW / 2
-        const msgLabelRight = msgLabelLeft + msgLabelW
-
-        if (divLabelRight > msgLabelLeft && divLabelLeft < msgLabelRight) {
-          offset = 36
-        }
-      }
+      const msgLines = msg?.label ? msg.label.split('\n').length : 1
+      const msgLabelTopOffset = RENDERER_LABEL_GAP + Math.max(0, msgLines - 1) * edgeLineHeight
+      const offset = Math.ceil(14 + msgLabelTopOffset + DIVIDER_CLEARANCE)
 
       return { y: msgY - offset, label: d.label }
     })
@@ -386,21 +404,31 @@ export function layoutSequenceDiagram(
   }
 
   // 7. Calculate final lifelines (after shift so X positions are correct)
+  // Lifelines end above the bottom actor row, leaving room for their boxes.
+  const bottomActorY = diagramBottom  // bottom actors start here
   const lifelines: Lifeline[] = diagram.actors.map((a, i) => ({
     actorId: a.id,
     x: actorCenterX[i]!,
     topY: actorY + SEQ.actorHeight,
-    bottomY: diagramBottom - SEQ.padding,
+    bottomY: bottomActorY,
   }))
 
-  // 8. Calculate diagram dimensions from the bounding box
+  // 8. Bottom actor boxes — same actors mirrored at the bottom of the diagram
+  const bottomActors: typeof actors = actors.map(a => ({
+    ...a,
+    y: bottomActorY,
+  }))
+
+  // 9. Calculate diagram dimensions from the bounding box
+  // Height extends past bottom actor boxes.
   const diagramWidth = globalMaxX + shiftX + SEQ.padding
-  const diagramHeight = diagramBottom
+  const diagramHeight = bottomActorY + SEQ.actorHeight + SEQ.padding
 
   return {
     width: Math.max(diagramWidth, 200),
     height: Math.max(diagramHeight, 100),
     actors,
+    bottomActors,
     lifelines,
     messages,
     activations,

--- a/src/sequence/renderer.ts
+++ b/src/sequence/renderer.ts
@@ -3,6 +3,10 @@ import type { DiagramColors } from '../theme.ts'
 import { svgOpenTag, buildStyleBlock } from '../theme.ts'
 import { FONT_SIZES, FONT_WEIGHTS, STROKE_WIDTHS, ARROW_HEAD, estimateTextWidth, TEXT_BASELINE_SHIFT } from '../styles.ts'
 import { renderMultilineText, escapeXml as escapeXmlUtil } from '../multiline-utils.ts'
+import { LINE_HEIGHT_RATIO } from '../text-metrics.ts'
+
+/** Gap in px between the last label line's baseline and the arrow line. */
+const LABEL_ARROW_GAP = 10
 
 // ============================================================================
 // Sequence diagram SVG renderer
@@ -69,6 +73,11 @@ export function renderSequenceSvg(
 
   // 6. Actor boxes at top (rendered last so they're on top)
   for (const actor of diagram.actors) {
+    parts.push(renderActor(actor))
+  }
+
+  // 7. Bottom actor boxes (mirrored at the bottom, same style)
+  for (const actor of diagram.bottomActors) {
     parts.push(renderActor(actor))
   }
 
@@ -215,10 +224,17 @@ function renderMessage(msg: PositionedMessage): string {
       `  <line x1="${msg.x1}" y1="${msg.y}" x2="${msg.x2}" y2="${msg.y}" ` +
       `stroke="var(--_line)" stroke-width="${STROKE_WIDTHS.connector}"${dashArray} marker-end="url(#${markerId})" />`
     )
-    // Label above the arrow, centered (supports multi-line)
+    // Label above the arrow, bottom-aligned so every line stays above the arrow.
+    // cy is computed so the last line's baseline lands exactly LABEL_ARROW_GAP px
+    // above msg.y, regardless of how many lines the label has.
     const midX = (msg.x1 + msg.x2) / 2
+    const labelLines = msg.label.split('\n').length
+    const edgeLH = FONT_SIZES.edgeLabel * LINE_HEIGHT_RATIO
+    const labelCY = msg.y - LABEL_ARROW_GAP
+      - FONT_SIZES.edgeLabel * 0.35
+      - ((labelLines - 1) / 2) * edgeLH
     parts.push(
-      '  ' + renderMultilineText(msg.label, midX, msg.y - 10, FONT_SIZES.edgeLabel,
+      '  ' + renderMultilineText(msg.label, midX, labelCY, FONT_SIZES.edgeLabel,
         `font-size="${FONT_SIZES.edgeLabel}" text-anchor="middle" font-weight="${FONT_WEIGHTS.edgeLabel}" fill="var(--_text-muted)"`)
     )
   }
@@ -316,13 +332,13 @@ function renderNote(note: PositionedNote): string {
     `<g class="note"${positionAttr}${actorsAttr}>` +
     // Note body with bg fill and clipped corner
     `\n  <polygon points="${bodyPoints}" ` +
-    `fill="var(--bg)" stroke="var(--_node-stroke)" stroke-width="${STROKE_WIDTHS.innerBox}" />` +
+    `fill="var(--_group-hdr)" stroke="var(--_line)" stroke-width="${STROKE_WIDTHS.innerBox}" />` +
     // Fold triangle (the folded-over corner)
     `\n  <polygon points="${x + w - foldSize},${y} ${x + w},${y + foldSize} ${x + w - foldSize},${y + foldSize}" ` +
-    `fill="var(--_inner-stroke)" stroke="var(--_node-stroke)" stroke-width="${STROKE_WIDTHS.innerBox}" />` +
+    `fill="var(--_line)" stroke="var(--_line)" stroke-width="${STROKE_WIDTHS.innerBox}" />` +
     // Note text (supports multi-line)
     `\n  ${renderMultilineText(note.text, x + w / 2, y + h / 2, FONT_SIZES.edgeLabel,
-      `font-size="${FONT_SIZES.edgeLabel}" text-anchor="middle" font-weight="${FONT_WEIGHTS.edgeLabel}" fill="var(--_text-muted)"`)}` +
+      `font-size="${FONT_SIZES.edgeLabel}" text-anchor="middle" font-weight="${FONT_WEIGHTS.edgeLabel}" fill="var(--_text-sec)"`)}` +
     `\n</g>`
   )
 }

--- a/src/sequence/types.ts
+++ b/src/sequence/types.ts
@@ -70,6 +70,8 @@ export interface PositionedSequenceDiagram {
   width: number
   height: number
   actors: PositionedActor[]
+  /** Same actors repeated at the bottom of the diagram (mermaid.live style) */
+  bottomActors: PositionedActor[]
   lifelines: Lifeline[]
   messages: PositionedMessage[]
   activations: Activation[]

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -11,18 +11,19 @@ import { measureTextWidth } from './text-metrics'
 
 /** Average character width in px at the given font size and weight (proportional font) */
 export function estimateTextWidth(text: string, fontSize: number, fontWeight: number): number {
-  // Delegate to variable-width character measurement for better accuracy
-  // with mixed character sets (Latin narrow/wide, CJK, emoji, etc.)
-  return measureTextWidth(text, fontSize, fontWeight)
+  // Multi-line labels (containing \n) must return the width of the widest line,
+  // not the combined width of all characters. Treating a newline as a letter
+  // causes massive overestimates that inflate actor widths and break layout.
+  const lines = text.split('\n')
+  if (lines.length === 1) return measureTextWidth(text, fontSize, fontWeight)
+  return Math.max(...lines.map(l => measureTextWidth(l, fontSize, fontWeight)))
 }
 
 /** Average character width in px for monospace fonts (uniform glyph width) */
 export function estimateMonoTextWidth(text: string, fontSize: number): number {
-  // Monospace fonts have uniform character width — 0.6 of fontSize matches actual
-  // glyph widths for JetBrains Mono / SF Mono / Fira Code at small sizes (11px).
-  // Previous value of 0.55 underestimated widths, causing class member labels to
-  // extend beyond their box boundaries.
-  return text.length * fontSize * 0.6
+  // Multi-line: return width of widest line.
+  const lines = text.split('\n')
+  return Math.max(...lines.map(l => l.length * fontSize * 0.6))
 }
 
 /** Monospace font family used for code-like text (class members, types) */

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -76,8 +76,6 @@ export const MIX = {
   arrow:        85,
   /** Node fill tint: fg mixed at 3% */
   nodeFill:     3,
-  /** Node/group stroke: fg mixed at 20% */
-  nodeStroke:   20,
   /** Group header band tint: fg mixed at 5% */
   groupHeader:  5,
   /** Inner divider strokes: fg mixed at 12% */
@@ -254,7 +252,7 @@ export function buildStyleBlock(font: string, hasMonoFont: boolean): string {
     --_line:          var(--line, color-mix(in srgb, var(--fg) ${MIX.line}%, var(--bg)));
     --_arrow:         var(--accent, color-mix(in srgb, var(--fg) ${MIX.arrow}%, var(--bg)));
     --_node-fill:     var(--surface, color-mix(in srgb, var(--fg) ${MIX.nodeFill}%, var(--bg)));
-    --_node-stroke:   var(--border, color-mix(in srgb, var(--fg) ${MIX.nodeStroke}%, var(--bg)));
+    --_node-stroke:   var(--line, color-mix(in srgb, var(--fg) 30%, var(--bg)));
     --_group-fill:    var(--bg);
     --_group-hdr:     color-mix(in srgb, var(--fg) ${MIX.groupHeader}%, var(--bg));
     --_inner-stroke:  color-mix(in srgb, var(--fg) ${MIX.innerStroke}%, var(--bg));


### PR DESCRIPTION
## Summary

Rendering fixes scoped strictly to `src/` — **no editor/infra changes** (those live in a separate PR).

- **Sequence diagrams**
  - Size note boxes correctly for multi-line text.
  - Improve note visibility in light mode.
  - Improve layout spacing for multi-line labels and actor types.
- **Flowchart**
  - Derive node stroke from line color.
  - Fix cylinder rendering.

## Visual reference

Can be verified in the live editor (companion PR):

https://maatheusgois-dd.github.io/beautiful-mermaid/#eyJzb3VyY2UiOiJncmFwaCBURFxuICBBW1N0YXJ0XSAtLT4gQntEZWNpc2lvbj99XG4gIEIgLS0+fFllc3wgQ1tEbyB0aGUgdGhpbmddXG4gIEIgLS0+fE5vfCBEW1NraXAgaXRdXG4gIEMgLS0+IEVbRW5kXVxuICBEIC0tPiBFIiwidGhlbWUiOiJjYXRwcHVjY2luLW1vY2hhIn0=

## Test plan

- [ ] `bun test src/__tests__/` passes.
- [ ] Render sequence samples with multi-line labels / notes and confirm spacing.
- [ ] Render flowchart samples (incl. cylinder) and confirm stroke color matches line color.

Made with [Cursor](https://cursor.com)