### PR TITLE
fix(svg): improve bidirectional arrow markers

### DIFF
--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -107,11 +107,11 @@ function arrowMarkerDefs(): string {
     `  <marker id="arrowhead" markerWidth="${w}" markerHeight="${h}" refX="${refX}" refY="${h / 2}" orient="auto">` +
     `\n    <polygon points="0 0, ${w} ${h / 2}, 0 ${h}" ${arrowStyle} />` +
     `\n  </marker>` +
-    // Reverse arrow (marker-start) — refX=1 so it sits at the line start with slight offset, auto-start-reverse flips it
-    `\n  <marker id="arrowhead-start" markerWidth="${w}" markerHeight="${h}" refX="1" refY="${h / 2}" orient="auto-start-reverse">` +
-    `\n    <polygon points="${w} 0, 0 ${h / 2}, ${w} ${h}" ${arrowStyle} />` +
+    // Reverse arrow (marker-start) — uses the same polygon and refX as marker-end, auto-start-reverse flips it automatically at the start of the line.
+    `\n  <marker id="arrowhead-start" markerWidth="${w}" markerHeight="${h}" refX="${refX}" refY="${h / 2}" orient="auto-start-reverse">` +
+    `\n    <polygon points="0 0, ${w} ${h / 2}, 0 ${h}" ${arrowStyle} />` +
     `\n  </marker>`
-  )
+  );
 }
 
 /**


### PR DESCRIPTION
Fixes #58

Summary:

- fix bidirectional arrow markers in SVG

Before:

<img width="534" height="156" alt="image" src="https://github.com/user-attachments/assets/56d6703f-1fbb-4ba6-b520-3d34b14193cc" />

After:

<img width="236" height="154" alt="image" src="https://github.com/user-attachments/assets/fb45c478-0a17-4b46-8d0b-4305799093e0" />


