### PR TITLE
fix: correct CJK/Korean double-width character alignment in ASCII renderer

### DIFF
--- a/src/ascii/canvas.ts
+++ b/src/ascii/canvas.ts
@@ -292,18 +292,24 @@ export function canvasToString(canvas: Canvas, options?: CanvasToStringOptions):
   for (let y = 0; y <= maxY; y++) {
     if (colorMode === 'none' || !roleCanvas) {
       // Plain text output — no colors
+      // '\x00' is a sentinel placed after fullwidth (CJK) characters to
+      // occupy the second terminal column; skip it during string assembly.
       let line = ''
       for (let x = 0; x <= maxX; x++) {
-        line += canvas[x]![y]!
+        const ch = canvas[x]![y]!
+        if (ch !== '\x00') line += ch
       }
       lines.push(line)
     } else {
-      // Colored output — collect chars and roles for this row
+      // Colored output — collect chars and roles for this row, skipping sentinels
       const chars: string[] = []
       const roles: (CharRole | null)[] = []
       for (let x = 0; x <= maxX; x++) {
-        chars.push(canvas[x]![y]!)
-        roles.push(roleCanvas[x]?.[y] ?? null)
+        const ch = canvas[x]![y]!
+        if (ch !== '\x00') {
+          chars.push(ch)
+          roles.push(roleCanvas[x]?.[y] ?? null)
+        }
       }
       lines.push(colorizeLine(chars, roles, theme, colorMode))
     }

--- a/src/ascii/draw.ts
+++ b/src/ascii/draw.ts
@@ -18,7 +18,7 @@ import { mkCanvas, copyCanvas, getCanvasSize, mergeCanvases, drawText, mkRoleCan
 import type { RoleCanvas, CharRole } from './types.ts'
 import { determineDirection, dirEquals } from './edge-routing.ts'
 import { gridToDrawingCoord, lineToDrawing } from './grid.ts'
-import { splitLines } from './multiline-utils.ts'
+import { splitLines, charVisualWidth, visualWidth } from './multiline-utils.ts'
 import { getCorners } from './shapes/corners.ts'
 import { getShapeAttachmentPoint } from './shapes/index.ts'
 
@@ -104,11 +104,21 @@ function drawBoxWithGridDimensions(node: AsciiNode, graph: AsciiGraph): Canvas {
 
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i]!
-    const textX = from.x + Math.floor(w / 2) - Math.ceil(line.length / 2) + 1
+    const lineVW = visualWidth(line)
+    const textX = from.x + Math.floor(w / 2) - Math.ceil(lineVW / 2) + 1
+    let vx = 0
     for (let j = 0; j < line.length; j++) {
-      if (textX + j >= 0 && textX + j < box.length && startY + i >= 0 && startY + i < box[0]!.length) {
-        box[textX + j]![startY + i] = line[j]!
+      const ch = line[j]!
+      const x = textX + vx
+      const y = startY + i
+      if (x >= 0 && x < box.length && y >= 0 && y < box[0]!.length) {
+        box[x]![y] = ch
+        // Place sentinel after fullwidth char so the second column stays blank
+        if (charVisualWidth(ch) === 2 && x + 1 < box.length) {
+          box[x + 1]![y] = '\x00'
+        }
       }
+      vx += charVisualWidth(ch)
     }
   }
 

--- a/src/ascii/multiline-utils.ts
+++ b/src/ascii/multiline-utils.ts
@@ -18,12 +18,42 @@ export function splitLines(label: string): string[] {
 }
 
 /**
+ * Return the terminal column width of a single character.
+ * CJK and other fullwidth Unicode code points occupy 2 columns;
+ * all other characters occupy 1.
+ */
+export function charVisualWidth(ch: string): number {
+  const code = ch.codePointAt(0) ?? 0
+  return (
+    (code >= 0x1100 && code <= 0x115f) ||
+    (code >= 0x2e80 && code <= 0x303f) ||
+    (code >= 0x3040 && code <= 0x33ff) ||
+    (code >= 0x3400 && code <= 0x4dbf) ||
+    (code >= 0x4e00 && code <= 0x9fff) ||
+    (code >= 0xac00 && code <= 0xd7af) ||
+    (code >= 0xf900 && code <= 0xfaff) ||
+    (code >= 0xff00 && code <= 0xff60) ||
+    code >= 0x20000
+  ) ? 2 : 1
+}
+
+/**
+ * Return the total terminal column width of a string.
+ * Each fullwidth (CJK) character counts as 2 columns.
+ */
+export function visualWidth(str: string): number {
+  let w = 0
+  for (const ch of str) w += charVisualWidth(ch)
+  return w
+}
+
+/**
  * Get the maximum line width for sizing calculations.
- * Used to determine column widths for multi-line labels.
+ * Uses visual (terminal column) width so CJK characters are measured correctly.
  */
 export function maxLineWidth(label: string): number {
   const lines = splitLines(label)
-  return Math.max(...lines.map(l => l.length), 0)
+  return Math.max(...lines.map(l => visualWidth(l)), 0)
 }
 
 /**
@@ -52,8 +82,8 @@ export function drawMultilineTextCentered(
 
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i]!
-    // Center each line horizontally
-    const startX = cx - Math.floor(line.length / 2)
+    // Center each line horizontally using visual (column) width for CJK support
+    const startX = cx - Math.floor(visualWidth(line) / 2)
     // Force overwrite for node labels (they take priority)
     drawText(canvas, { x: startX, y: startY + i }, line, true)
   }

--- a/src/ascii/shapes/rectangle.ts
+++ b/src/ascii/shapes/rectangle.ts
@@ -9,7 +9,7 @@
 import type { Canvas, DrawingCoord, Direction } from '../types.ts'
 import { Up, Down, Left, Right, UpperLeft, UpperRight, LowerLeft, LowerRight, Middle } from '../types.ts'
 import { mkCanvas } from '../canvas.ts'
-import { splitLines } from '../multiline-utils.ts'
+import { splitLines, charVisualWidth, visualWidth } from '../multiline-utils.ts'
 import type { ShapeRenderer, ShapeDimensions, ShapeRenderOptions } from './types.ts'
 import { dirEquals } from '../edge-routing.ts'
 import { type CornerChars, getCorners } from './corners.ts'
@@ -24,7 +24,7 @@ import { type CornerChars, getCorners } from './corners.ts'
  */
 export function getBoxDimensions(label: string, options: ShapeRenderOptions): ShapeDimensions {
   const lines = splitLines(label)
-  const maxLineWidth = Math.max(...lines.map(l => l.length), 0)
+  const maxLineWidth = Math.max(...lines.map(l => visualWidth(l)), 0)
   const lineCount = lines.length
 
   // Width: 2*padding + maxLineWidth + 2 border chars
@@ -108,13 +108,20 @@ export function renderBox(
 
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i]!
-    const textX = Math.floor(w / 2) - Math.ceil(line.length / 2) + 1
+    const lineVW = visualWidth(line)
+    const textX = Math.floor(w / 2) - Math.ceil(lineVW / 2) + 1
+    let vx = 0
     for (let j = 0; j < line.length; j++) {
-      const x = textX + j
+      const ch = line[j]!
+      const x = textX + vx
       const y = startY + i
       if (x >= 0 && x < canvas.length && y >= 0 && y < canvas[0]!.length) {
-        canvas[x]![y] = line[j]!
+        canvas[x]![y] = ch
+        if (charVisualWidth(ch) === 2 && x + 1 < canvas.length) {
+          canvas[x + 1]![y] = '\x00'
+        }
       }
+      vx += charVisualWidth(ch)
     }
   }
 

--- a/src/ascii/shapes/special.ts
+++ b/src/ascii/shapes/special.ts
@@ -8,7 +8,7 @@
 import type { Canvas, DrawingCoord, Direction } from '../types.ts'
 import { Up, Down, Left, Right } from '../types.ts'
 import { mkCanvas } from '../canvas.ts'
-import { splitLines } from '../multiline-utils.ts'
+import { splitLines, charVisualWidth, visualWidth } from '../multiline-utils.ts'
 import type { ShapeRenderer, ShapeDimensions, ShapeRenderOptions } from './types.ts'
 import { dirEquals } from '../edge-routing.ts'
 import { getBoxDimensions, renderBox, getBoxAttachmentPoint } from './rectangle.ts'
@@ -28,7 +28,7 @@ import { getCorners } from './corners.ts'
 export const subroutineRenderer: ShapeRenderer = {
   getDimensions(label: string, options: ShapeRenderOptions): ShapeDimensions {
     const lines = splitLines(label)
-    const maxLineWidth = Math.max(...lines.map(l => l.length), 0)
+    const maxLineWidth = Math.max(...lines.map(l => visualWidth(l)), 0)
     const lineCount = lines.length
 
     const innerWidth = 2 * options.padding + maxLineWidth
@@ -86,13 +86,20 @@ export const subroutineRenderer: ShapeRenderer = {
 
     for (let i = 0; i < lines.length; i++) {
       const line = lines[i]!
-      const textX = Math.floor(width / 2) - Math.floor(line.length / 2)
+      const lineVW = visualWidth(line)
+      const textX = Math.floor(width / 2) - Math.floor(lineVW / 2)
+      let vx = 0
       for (let j = 0; j < line.length; j++) {
-        const x = textX + j
+        const ch = line[j]!
+        const x = textX + vx
         const y = startY + i
         if (x > 1 && x < width - 2 && y > 0 && y < height - 1) {
-          canvas[x]![y] = line[j]!
+          canvas[x]![y] = ch
+          if (charVisualWidth(ch) === 2 && x + 1 < width - 2) {
+            canvas[x + 1]![y] = '\x00'
+          }
         }
+        vx += charVisualWidth(ch)
       }
     }
 
@@ -142,7 +149,7 @@ export const doublecircleRenderer: ShapeRenderer = {
 export const cylinderRenderer: ShapeRenderer = {
   getDimensions(label: string, options: ShapeRenderOptions): ShapeDimensions {
     const lines = splitLines(label)
-    const maxLineWidth = Math.max(...lines.map(l => l.length), 0)
+    const maxLineWidth = Math.max(...lines.map(l => visualWidth(l)), 0)
     const lineCount = lines.length
 
     const innerWidth = 2 * options.padding + maxLineWidth
@@ -204,13 +211,20 @@ export const cylinderRenderer: ShapeRenderer = {
 
     for (let i = 0; i < lines.length; i++) {
       const line = lines[i]!
-      const textX = Math.floor(width / 2) - Math.floor(line.length / 2)
+      const lineVW = visualWidth(line)
+      const textX = Math.floor(width / 2) - Math.floor(lineVW / 2)
+      let vx = 0
       for (let j = 0; j < line.length; j++) {
-        const x = textX + j
+        const ch = line[j]!
+        const x = textX + vx
         const y = startY + i
         if (x > 0 && x < width - 1 && y > 1 && y < height - 2) {
-          canvas[x]![y] = line[j]!
+          canvas[x]![y] = ch
+          if (charVisualWidth(ch) === 2 && x + 1 < width - 1) {
+            canvas[x + 1]![y] = '\x00'
+          }
         }
+        vx += charVisualWidth(ch)
       }
     }
 

--- a/src/ascii/shapes/stadium.ts
+++ b/src/ascii/shapes/stadium.ts
@@ -8,7 +8,7 @@
 
 import type { Canvas, DrawingCoord, Direction } from '../types.ts'
 import { mkCanvas } from '../canvas.ts'
-import { splitLines } from '../multiline-utils.ts'
+import { splitLines, charVisualWidth, visualWidth } from '../multiline-utils.ts'
 import type { ShapeRenderer, ShapeDimensions, ShapeRenderOptions } from './types.ts'
 import { getBoxAttachmentPoint } from './rectangle.ts'
 
@@ -30,7 +30,7 @@ import { getBoxAttachmentPoint } from './rectangle.ts'
 export const stadiumRenderer: ShapeRenderer = {
   getDimensions(label: string, options: ShapeRenderOptions): ShapeDimensions {
     const lines = splitLines(label)
-    const maxLineWidth = Math.max(...lines.map(l => l.length), 0)
+    const maxLineWidth = Math.max(...lines.map(l => visualWidth(l)), 0)
     const lineCount = lines.length
 
     const innerWidth = 2 * options.padding + maxLineWidth
@@ -95,13 +95,20 @@ export const stadiumRenderer: ShapeRenderer = {
 
     for (let i = 0; i < lines.length; i++) {
       const line = lines[i]!
-      const textX = Math.floor(width / 2) - Math.floor(line.length / 2)
+      const lineVW = visualWidth(line)
+      const textX = Math.floor(width / 2) - Math.floor(lineVW / 2)
+      let vx = 0
       for (let j = 0; j < line.length; j++) {
-        const x = textX + j
+        const ch = line[j]!
+        const x = textX + vx
         const y = startY + i
         if (x > 0 && x < width - 1 && y >= 0 && y < height) {
-          canvas[x]![y] = line[j]!
+          canvas[x]![y] = ch
+          if (charVisualWidth(ch) === 2 && x + 1 < width - 1) {
+            canvas[x + 1]![y] = '\x00'
+          }
         }
+        vx += charVisualWidth(ch)
       }
     }
 


### PR DESCRIPTION
## Problem

East Asian characters (CJK, Hangul) occupy **2 terminal columns** each, but `String.length` counts them as 1. This caused node labels to appear visually wider than the surrounding box borders:

```
┌──────┐
│  시작  │   ← text overflows box
└──────┘
```

## Root cause

All shape renderers and `drawBoxWithGridDimensions` used `line.length` for centering and `j` as the x-offset, both of which treat every character as 1 column wide.

## Fix

Added `charVisualWidth(ch)` and `visualWidth(str)` helpers to `multiline-utils.ts` that return correct terminal column widths (2 for CJK/Hangul, 1 otherwise). All rendering paths now:

1. Use `visualWidth()` for box sizing and horizontal centering
2. Place a `\x00` sentinel in the second canvas cell after each wide character
3. Skip `\x00` sentinels in `canvasToString` so they are not emitted as output

## Result

```
┌────────┐
│  시작  │   ← all rows vw=10 ✓
└────────┘
┌────────┐
│ 처리중 │   ← vw=10 ✓
└────────┘
```

Every row — border, content, arrow — now has identical visual width.

## Files changed

| File | Change |
|------|--------|
| `src/ascii/multiline-utils.ts` | Add `charVisualWidth`, `visualWidth`; fix `maxLineWidth`, `drawMultilineTextCentered` |
| `src/ascii/canvas.ts` | Skip `\x00` sentinels in `canvasToString` (plain and colored modes) |
| `src/ascii/draw.ts` | Fix `drawBoxWithGridDimensions` text loop — visual-width centering + sentinel placement |
| `src/ascii/shapes/rectangle.ts` | Fix `getBoxDimensions` + `renderBox` |
| `src/ascii/shapes/stadium.ts` | Fix `getDimensions` + `render` |
| `src/ascii/shapes/special.ts` | Fix `subroutineRenderer` + `cylinderRenderer` |