### PR TITLE
ui: add Editor button to hero, fix button row alignment

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1106,11 +1106,14 @@ async function generateHtml(): Promise<string> {
       padding: 0.75rem 1.25rem;
       font-size: 0.875rem;
       font-weight: 500;
+      line-height: 1.25;
       border-radius: 12px;
       text-decoration: none;
       transition: opacity 0.15s, transform 0.1s;
       cursor: pointer;
       border: none;
+      margin: 0;
+      box-sizing: border-box;
       font-family: inherit;
     }
     .hero-btn:hover {

--- a/index.ts
+++ b/index.ts
@@ -1091,7 +1091,7 @@ async function generateHtml(): Promise<string> {
     .hero-buttons {
       display: flex;
       flex-wrap: wrap;
-      align-items: flex-start;
+      align-items: center;
       gap: 0.5rem;
     }
     @media (max-width: 768px) {
@@ -1262,6 +1262,10 @@ async function generateHtml(): Promise<string> {
       <a href="https://agents.craft.do" target="_blank" rel="noopener" class="hero-btn hero-btn-primary">
         <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><g transform="translate(3.4502, 3)" fill="currentColor"><path d="M3.17890888,3.6 L3.17890888,0 L16,0 L16,3.6 L3.17890888,3.6 Z M9.642,7.2 L9.64218223,10.8 L0,10.8 L0,3.6 L16,3.6 L16,7.2 L9.642,7.2 Z M3.17890888,18 L3.178,14.4 L0,14.4 L0,10.8 L16,10.8 L16,18 L3.17890888,18 Z" fill-rule="nonzero"></path></g></svg>
         Use in Craft Agents
+      </a>
+      <a href="editor" class="hero-btn hero-btn-secondary">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20h9"/><path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4L16.5 3.5z"/></svg>
+        Editor
       </a>
       <a href="https://github.com/lukilabs/beautiful-mermaid" target="_blank" rel="noopener" class="hero-btn hero-btn-secondary">
         <svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/></svg>


### PR DESCRIPTION
## Summary
- Add an **Editor** button to the hero section linking to the live editor (`/editor`).
- Fix subtle vertical drift between `<a>` and `<button>` buttons in the hero row by switching `.hero-buttons` `align-items: flex-start` → `center`.

## Implementation notes
- Editor link uses a relative `href="editor"` so it resolves correctly under both `/` (direct Pages URL) and `/mermaid/` (when proxied through `agents-router`).
- Button order: Use in Craft Agents → Editor → GitHub → Random Theme.

## Test plan
- [x] Local rebuild verified — `site/index.html` contains the new button and updated `align-items: center`.
- [x] Visual check on preview deploy.

🤖 Generated with [Craft Agent](https://craft.do)