### PR TITLE
fix: rewrite Editor link path resolution without regex

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1514,9 +1514,18 @@ ${bundleJs}
   // -- Random theme button --
   // Resolve the Editor link against the current path so it works under both
   // / (direct Pages URL) and /mermaid (Worker proxy, with or without trailing slash).
+  // Note: this script is embedded inside a TypeScript template literal, so regex
+  // backslashes get consumed during string interpolation. We use endsWith/slice
+  // here instead of a regex literal to avoid escaping pitfalls.
   var editorLink = document.getElementById('editor-link');
   if (editorLink) {
-    var basePath = location.pathname.replace(/\/index\.html$|\/$/, '');
+    var basePath = location.pathname;
+    if (basePath.indexOf('/index.html', basePath.length - 11) !== -1) {
+      basePath = basePath.slice(0, basePath.length - 11);
+    }
+    if (basePath.charAt(basePath.length - 1) === '/') {
+      basePath = basePath.slice(0, basePath.length - 1);
+    }
     editorLink.href = basePath + '/editor';
   }
 


### PR DESCRIPTION
## Bug
PR #105 added an inline `<script type="module">` snippet using a regex literal:
```js
location.pathname.replace(/\/index\.html$|\/$/, '')
```
That snippet lives inside the surrounding TypeScript template literal that builds the whole HTML page, so the backslashes were consumed during string interpolation. The deployed JS ended up as:
```js
location.pathname.replace(//index.html$|/$/, '')
```
The `//` is a line comment in JavaScript, so the parser saw an unclosed `replace(` and bailed. **All inline scripts on the page (Editor link, Random Theme, theme pills, mega-menu, etc.) silently stopped working.** Verified in the browser console: `Uncaught SyntaxError: missing ) after argument list`.

## Fix
Rewrote the path resolution with `indexOf` + `slice` — no regex, no escaping. Added a comment above the snippet documenting the template-literal pitfall so we don't make the same mistake again.

## Test plan
- [x] Local build verified — no `//` artifact in deployed JS.
- [x] After deploy, browser console clean of syntax errors.
- [x] Editor button at `agents.craft.do/mermaid` resolves to `/mermaid/editor`.
- [x] Random Theme button works again.

🤖 Generated with [Craft Agent](https://craft.do)