### PR TITLE
fix: support --o and --x flowchart edge markers (closes #109)

### DIFF
--- a/src/__tests__/ascii-edge-styles.test.ts
+++ b/src/__tests__/ascii-edge-styles.test.ts
@@ -131,4 +131,95 @@ describe('ASCII edge styles', () => {
       expect(result).toContain('D')
     })
   })
+
+  // ==========================================================================
+  // Circle and cross endpoint markers (`--o`, `--x`, `o--o`, `x--x`, ...)
+  // Regression test for https://github.com/lukilabs/beautiful-mermaid/issues/109
+  // ==========================================================================
+
+  describe('open circle endpoints (--o)', () => {
+    it('renders --o with ◯ marker and keeps the target node', () => {
+      const result = renderMermaidAscii(`
+        graph LR
+          A --o B
+      `)
+      expect(result).toContain('◯')
+      expect(result).toContain('A')
+      expect(result).toContain('B')
+    })
+
+    it('renders --o with o marker in ascii mode', () => {
+      const result = renderMermaidAscii(`
+        graph LR
+          A --o B
+      `, { useAscii: true })
+      expect(result).toContain('o')
+      expect(result).toContain('B')
+    })
+
+    it('renders o--o with circles on both endpoints', () => {
+      const result = renderMermaidAscii(`
+        graph LR
+          A o--o B
+      `)
+      expect((result.match(/◯/g) ?? []).length).toBe(2)
+    })
+
+    it('renders vertical --o (TD direction) with the target below', () => {
+      const result = renderMermaidAscii(`
+        graph TD
+          A --o B
+      `)
+      expect(result).toContain('◯')
+      expect(result).toContain('B')
+    })
+  })
+
+  describe('cross endpoints (--x)', () => {
+    it('renders --x with ✕ marker and keeps the target node', () => {
+      const result = renderMermaidAscii(`
+        graph LR
+          A --x B
+      `)
+      expect(result).toContain('✕')
+      expect(result).toContain('B')
+    })
+
+    it('renders --x with x marker in ascii mode', () => {
+      const result = renderMermaidAscii(`
+        graph LR
+          A --x B
+      `, { useAscii: true })
+      expect(result).toContain('x')
+      expect(result).toContain('B')
+    })
+
+    it('renders x--x with crosses on both endpoints', () => {
+      const result = renderMermaidAscii(`
+        graph LR
+          A x--x B
+      `)
+      expect((result.match(/✕/g) ?? []).length).toBe(2)
+    })
+  })
+
+  describe('mixed circle/cross endpoints', () => {
+    it('renders o--x with circle at source and cross at target', () => {
+      const result = renderMermaidAscii(`
+        graph LR
+          A o--x B
+      `)
+      expect(result).toContain('◯')
+      expect(result).toContain('✕')
+    })
+
+    it('renders x--o with cross at source and circle at target', () => {
+      const result = renderMermaidAscii(`
+        graph LR
+          A x--o B
+      `)
+      expect(result).toContain('✕')
+      expect(result).toContain('◯')
+    })
+  })
 })

--- a/src/__tests__/parser.test.ts
+++ b/src/__tests__/parser.test.ts
@@ -329,6 +329,88 @@ describe('parseMermaid – bidirectional arrows', () => {
 })
 
 // ============================================================================
+// Circle / cross endpoint markers (`--o`, `--x`, `o--o`, `x--x`, `o--x`, `x--o`)
+// Regression: https://github.com/lukilabs/beautiful-mermaid/issues/109
+// ============================================================================
+
+describe('parseMermaid – circle/cross endpoint markers', () => {
+  it('parses --o as solid edge with circle end marker', () => {
+    const g = parseMermaid('graph LR\n  A --o B')
+    expect(g.nodes.size).toBe(2)
+    expect(g.edges).toHaveLength(1)
+    const e = g.edges[0]!
+    expect(e.source).toBe('A')
+    expect(e.target).toBe('B')
+    expect(e.style).toBe('solid')
+    expect(e.hasArrowEnd).toBe(true)
+    expect(e.hasArrowStart).toBe(false)
+    expect(e.endMarker).toBe('circle')
+    expect(e.startMarker).toBeUndefined()
+  })
+
+  it('parses --x as solid edge with cross end marker', () => {
+    const g = parseMermaid('graph LR\n  A --x B')
+    expect(g.nodes.size).toBe(2)
+    expect(g.edges).toHaveLength(1)
+    const e = g.edges[0]!
+    expect(e.endMarker).toBe('cross')
+    expect(e.hasArrowEnd).toBe(true)
+  })
+
+  it('parses o--o as bidirectional circles', () => {
+    const g = parseMermaid('graph LR\n  A o--o B')
+    expect(g.edges).toHaveLength(1)
+    const e = g.edges[0]!
+    expect(e.hasArrowStart).toBe(true)
+    expect(e.hasArrowEnd).toBe(true)
+    expect(e.startMarker).toBe('circle')
+    expect(e.endMarker).toBe('circle')
+  })
+
+  it('parses x--x as bidirectional crosses', () => {
+    const g = parseMermaid('graph LR\n  A x--x B')
+    const e = g.edges[0]!
+    expect(e.startMarker).toBe('cross')
+    expect(e.endMarker).toBe('cross')
+  })
+
+  it('parses o--x as circle start + cross end', () => {
+    const g = parseMermaid('graph LR\n  A o--x B')
+    const e = g.edges[0]!
+    expect(e.startMarker).toBe('circle')
+    expect(e.endMarker).toBe('cross')
+  })
+
+  it('parses x--o as cross start + circle end', () => {
+    const g = parseMermaid('graph LR\n  A x--o B')
+    const e = g.edges[0]!
+    expect(e.startMarker).toBe('cross')
+    expect(e.endMarker).toBe('circle')
+  })
+
+  it('keeps existing --> arrow operator with arrow marker', () => {
+    const g = parseMermaid('graph LR\n  A --> B')
+    const e = g.edges[0]!
+    expect(e.endMarker).toBe('arrow')
+    expect(e.startMarker).toBeUndefined()
+  })
+
+  it('keeps existing <--> bidirectional arrow with arrow markers', () => {
+    const g = parseMermaid('graph LR\n  A <--> B')
+    const e = g.edges[0]!
+    expect(e.startMarker).toBe('arrow')
+    expect(e.endMarker).toBe('arrow')
+  })
+
+  it('parses --o with a label: --o|maybe| B', () => {
+    const g = parseMermaid('graph LR\n  A --o|maybe| B')
+    const e = g.edges[0]!
+    expect(e.label).toBe('maybe')
+    expect(e.endMarker).toBe('circle')
+  })
+})
+
+// ============================================================================
 // Text-embedded edge labels (fixes #32)
 // Based on PR #36 by @liuxiaopai-ai
 // ============================================================================

--- a/src/__tests__/renderer.test.ts
+++ b/src/__tests__/renderer.test.ts
@@ -324,6 +324,51 @@ describe('renderSvg – edges', () => {
     expect(svg).toContain('marker-end="url(#arrowhead)"')
     expect(svg).toContain('marker-start="url(#arrowhead-start)"')
   })
+
+  // --------------------------------------------------------------------------
+  // Circle / cross endpoint markers (`--o`, `--x`, `o--o`, `x--x`, ...)
+  // Regression: https://github.com/lukilabs/beautiful-mermaid/issues/109
+  // --------------------------------------------------------------------------
+
+  it('renders --o edge with circlehead end marker and defines the circle marker', () => {
+    const edge = makeEdge({ hasArrowEnd: true, endMarker: 'circle' })
+    const graph = makeGraph({ edges: [edge] })
+    const svg = renderSvg(graph, lightColors)
+    expect(svg).toContain('marker-end="url(#circlehead)"')
+    expect(svg).toContain('<marker id="circlehead"')
+    expect(svg).toContain('data-marker-end="circle"')
+  })
+
+  it('renders --x edge with crosshead end marker and defines the cross marker', () => {
+    const edge = makeEdge({ hasArrowEnd: true, endMarker: 'cross' })
+    const graph = makeGraph({ edges: [edge] })
+    const svg = renderSvg(graph, lightColors)
+    expect(svg).toContain('marker-end="url(#crosshead)"')
+    expect(svg).toContain('<marker id="crosshead"')
+    expect(svg).toContain('data-marker-end="cross"')
+  })
+
+  it('renders o--o edge with circlehead markers at both ends', () => {
+    const edge = makeEdge({
+      hasArrowStart: true,
+      hasArrowEnd: true,
+      startMarker: 'circle',
+      endMarker: 'circle',
+    })
+    const graph = makeGraph({ edges: [edge] })
+    const svg = renderSvg(graph, lightColors)
+    expect(svg).toContain('marker-start="url(#circlehead-start)"')
+    expect(svg).toContain('marker-end="url(#circlehead)"')
+    expect(svg).toContain('<marker id="circlehead-start"')
+  })
+
+  it('does not emit circle/cross <marker> defs when no edge needs them', () => {
+    const edge = makeEdge({ hasArrowEnd: true })
+    const graph = makeGraph({ edges: [edge] })
+    const svg = renderSvg(graph, lightColors)
+    expect(svg).not.toContain('<marker id="circlehead"')
+    expect(svg).not.toContain('<marker id="crosshead"')
+  })
 })
 
 // ============================================================================

--- a/src/ascii/converter.ts
+++ b/src/ascii/converter.ts
@@ -68,6 +68,8 @@ export function convertToAsciiGraph(parsed: MermaidGraph, config: AsciiConfig): 
       style: mEdge.style,
       hasArrowStart: mEdge.hasArrowStart,
       hasArrowEnd: mEdge.hasArrowEnd,
+      startMarker: mEdge.startMarker,
+      endMarker: mEdge.endMarker,
     })
   }
 

--- a/src/ascii/draw.ts
+++ b/src/ascii/draw.ts
@@ -8,7 +8,7 @@
 
 import type {
   Canvas, DrawingCoord, GridCoord, Direction,
-  AsciiGraph, AsciiNode, AsciiEdge, AsciiSubgraph, AsciiEdgeStyle, EdgeBundle,
+  AsciiGraph, AsciiNode, AsciiEdge, AsciiSubgraph, AsciiEdgeStyle, EdgeBundle, EdgeMarker,
 } from './types.ts'
 import {
   Up, Down, Left, Right, UpperLeft, UpperRight, LowerLeft, LowerRight, Middle,
@@ -390,21 +390,22 @@ export function drawArrow(
   const [pathCanvas, linesDrawn, lineDirs] = drawPath(graph, edge.path, edge.style)
   const boxStartCanvas = drawBoxStart(graph, edge.path, linesDrawn[0]!, edge.from.shape)
 
-  // Draw end arrowhead only if hasArrowEnd is true (default behavior)
+  // Draw end marker only if hasArrowEnd is true (default behavior)
   let arrowHeadEndCanvas: Canvas
   if (edge.hasArrowEnd) {
-    arrowHeadEndCanvas = drawArrowHead(
+    arrowHeadEndCanvas = drawEndpointMarker(
       graph,
       linesDrawn[linesDrawn.length - 1]!,
       lineDirs[lineDirs.length - 1]!,
+      edge.endMarker,
     )
   } else {
     arrowHeadEndCanvas = copyCanvas(graph.canvas)
   }
 
-  // Draw start arrowhead for bidirectional edges
-  // The start arrowhead needs to be at the box connector position (one step back
-  // from the first line point), pointing into the source node.
+  // Draw start marker for bidirectional / o--o / x--x edges.
+  // The marker sits at the box connector position (one step back from the
+  // first line point), pointing into the source node.
   let arrowHeadStartCanvas: Canvas
   if (edge.hasArrowStart && linesDrawn.length > 0) {
     const firstLine = linesDrawn[0]!
@@ -418,9 +419,9 @@ export function drawArrow(
     else if (dirEquals(lineDirs[0]!, Down)) arrowPos.y = firstPoint.y - 1
     else if (dirEquals(lineDirs[0]!, Up)) arrowPos.y = firstPoint.y + 1
 
-    // Create a synthetic line ending at the arrow position for drawArrowHead
+    // Synthetic line ending at the marker position so direction is preserved
     const syntheticLine: DrawingCoord[] = [firstPoint, arrowPos]
-    arrowHeadStartCanvas = drawArrowHead(graph, syntheticLine, startDir)
+    arrowHeadStartCanvas = drawEndpointMarker(graph, syntheticLine, startDir, edge.startMarker)
   } else {
     arrowHeadStartCanvas = copyCanvas(graph.canvas)
   }
@@ -514,6 +515,37 @@ function drawBoxStart(
  * Draw the arrowhead at the end of an edge path.
  * Uses triangular Unicode symbols (▲▼◄►) or ASCII symbols (^v<>).
  */
+/**
+ * Pick the marker glyph for an open-circle (`--o`) or cross (`--x`) endpoint.
+ * These are direction-independent, unlike triangular arrowheads.
+ */
+function circleOrCrossChar(marker: 'circle' | 'cross', useAscii: boolean): string {
+  if (useAscii) return marker === 'circle' ? 'o' : 'x'
+  return marker === 'circle' ? '◯' : '✕'
+}
+
+/**
+ * Draw the marker at an edge endpoint. Dispatches on marker type:
+ *   - undefined or 'arrow' → triangular arrowhead (existing behavior)
+ *   - 'circle'             → ◯ / o
+ *   - 'cross'              → ✕ / x
+ */
+function drawEndpointMarker(
+  graph: AsciiGraph,
+  lastLine: DrawingCoord[],
+  fallbackDir: Direction,
+  marker: EdgeMarker | undefined,
+): Canvas {
+  if (marker === 'circle' || marker === 'cross') {
+    const canvas = copyCanvas(graph.canvas)
+    if (lastLine.length === 0) return canvas
+    const lastPos = lastLine[lastLine.length - 1]!
+    canvas[lastPos.x]![lastPos.y] = circleOrCrossChar(marker, graph.config.useAscii)
+    return canvas
+  }
+  return drawArrowHead(graph, lastLine, fallbackDir)
+}
+
 function drawArrowHead(
   graph: AsciiGraph,
   lastLine: DrawingCoord[],
@@ -926,24 +958,31 @@ function drawBundleArrowhead(graph: AsciiGraph, bundle: EdgeBundle): Canvas {
   if (graphDir === 'TD') dc.y -= 1
   else dc.x -= 1
 
-  // Draw arrowhead
-  let char: string
-  if (!graph.config.useAscii) {
-    if (dirEquals(dir, Up)) char = '▲'
-    else if (dirEquals(dir, Down)) char = '▼'
-    else if (dirEquals(dir, Left)) char = '◄'
-    else if (dirEquals(dir, Right)) char = '►'
-    else char = '▼'  // default
-  } else {
-    if (dirEquals(dir, Up)) char = '^'
-    else if (dirEquals(dir, Down)) char = 'v'
-    else if (dirEquals(dir, Left)) char = '<'
-    else if (dirEquals(dir, Right)) char = '>'
-    else char = 'v'  // default
-  }
-
-  canvas[dc.x]![dc.y] = char
+  // Draw arrowhead — markers default to triangle arrows; fan-in bundles
+  // collapse multiple incoming edges into one head, so we just pick the first
+  // edge's endMarker as the representative for circle/cross variants.
+  const marker = bundle.edges[0]?.endMarker
+  canvas[dc.x]![dc.y] = bundleMarkerChar(marker, dir, graph.config.useAscii)
   return canvas
+}
+
+/** Pick the glyph for a fan-in / fan-out bundle arrowhead. */
+function bundleMarkerChar(marker: EdgeMarker | undefined, dir: Direction, useAscii: boolean): string {
+  if (marker === 'circle' || marker === 'cross') {
+    return circleOrCrossChar(marker, useAscii)
+  }
+  if (!useAscii) {
+    if (dirEquals(dir, Up)) return '▲'
+    if (dirEquals(dir, Down)) return '▼'
+    if (dirEquals(dir, Left)) return '◄'
+    if (dirEquals(dir, Right)) return '►'
+    return '▼'
+  }
+  if (dirEquals(dir, Up)) return '^'
+  if (dirEquals(dir, Down)) return 'v'
+  if (dirEquals(dir, Left)) return '<'
+  if (dirEquals(dir, Right)) return '>'
+  return 'v'
 }
 
 /**
@@ -968,23 +1007,7 @@ function drawBundledEdgeArrowhead(graph: AsciiGraph, edge: AsciiEdge): Canvas {
   if (graphDir === 'TD') dc.y -= 1
   else dc.x -= 1
 
-  // Draw arrowhead
-  let char: string
-  if (!graph.config.useAscii) {
-    if (dirEquals(dir, Up)) char = '▲'
-    else if (dirEquals(dir, Down)) char = '▼'
-    else if (dirEquals(dir, Left)) char = '◄'
-    else if (dirEquals(dir, Right)) char = '►'
-    else char = '▼'  // default
-  } else {
-    if (dirEquals(dir, Up)) char = '^'
-    else if (dirEquals(dir, Down)) char = 'v'
-    else if (dirEquals(dir, Left)) char = '<'
-    else if (dirEquals(dir, Right)) char = '>'
-    else char = 'v'  // default
-  }
-
-  canvas[dc.x]![dc.y] = char
+  canvas[dc.x]![dc.y] = bundleMarkerChar(edge.endMarker, dir, graph.config.useAscii)
   return canvas
 }
 

--- a/src/ascii/types.ts
+++ b/src/ascii/types.ts
@@ -6,10 +6,10 @@
 // and graph structures used by the ASCII/Unicode renderer.
 // ============================================================================
 
-import type { NodeShape } from '../types.ts'
+import type { NodeShape, EdgeMarker } from '../types.ts'
 
 // Re-export NodeShape for convenience
-export type { NodeShape }
+export type { NodeShape, EdgeMarker }
 
 /**
  * Shape type for ASCII rendering — maps parser shapes to ASCII renderers.
@@ -101,10 +101,14 @@ export interface AsciiEdge {
   endDir: Direction
   /** Line style: solid (default), dotted (-.->) or thick (==>) */
   style: AsciiEdgeStyle
-  /** Whether to render an arrowhead at the start (source end) of the edge */
+  /** Whether to render a marker at the start (source end) of the edge */
   hasArrowStart: boolean
-  /** Whether to render an arrowhead at the end (target end) of the edge */
+  /** Whether to render a marker at the end (target end) of the edge */
   hasArrowEnd: boolean
+  /** Marker shape at start when hasArrowStart=true. Defaults to 'arrow' if undefined. */
+  startMarker?: EdgeMarker
+  /** Marker shape at end when hasArrowEnd=true. Defaults to 'arrow' if undefined. */
+  endMarker?: EdgeMarker
   /** Bundle this edge belongs to (if any). Set during bundling analysis. */
   bundle?: EdgeBundle
   /**

--- a/src/layout-engine.ts
+++ b/src/layout-engine.ts
@@ -782,6 +782,8 @@ function extractEdgesRecursively(
       style: originalEdge.style,
       hasArrowStart: originalEdge.hasArrowStart,
       hasArrowEnd: originalEdge.hasArrowEnd,
+      startMarker: originalEdge.startMarker,
+      endMarker: originalEdge.endMarker,
       points: orthogonalPoints,
       labelPosition,
       inlineStyle: resolveEdgeStyle(edgeIndex, graph),

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1,4 +1,4 @@
-import type { MermaidGraph, MermaidNode, MermaidEdge, MermaidSubgraph, Direction, NodeShape, EdgeStyle } from './types.ts'
+import type { MermaidGraph, MermaidNode, MermaidEdge, MermaidSubgraph, Direction, NodeShape, EdgeStyle, EdgeMarker } from './types.ts'
 import { normalizeBrTags } from './multiline-utils.ts'
 
 // ============================================================================
@@ -393,10 +393,12 @@ function parseStyleProps(propsStr: string): Record<string, string> {
  *   -.-> -.-       dotted arrow / dotted line
  *   ==>  ===       thick arrow / thick line
  *   <--> <-.-> <==>  bidirectional variants
+ *   --o  --x       solid line ending in open circle / cross marker
+ *   o--o o--x x--o x--x  bidirectional circle/cross variants
  *
  * Optional label: -->|label text|
  */
-const ARROW_REGEX = /^(<)?(-->|-.->|==>|---|-\.-|===)(?:\|([^|]*)\|)?/
+const ARROW_REGEX = /^(<)?(-->|-.->|==>|---|-\.-|===|--o|--x|o--o|o--x|x--o|x--x)(?:\|([^|]*)\|)?/
 
 /**
  * Text-embedded label regex — matches "-- label -->", "-. label .->", "== label ==>" syntax.
@@ -466,17 +468,21 @@ function parseEdgeLine(
     let hasArrowStart: boolean
     let style: EdgeStyle
     let hasArrowEnd: boolean
+    let startMarker: EdgeMarker | undefined
+    let endMarker: EdgeMarker | undefined
     let edgeLabel: string | undefined
 
     const arrowMatch = remaining.match(ARROW_REGEX)
     if (arrowMatch) {
-      hasArrowStart = Boolean(arrowMatch[1])
       const arrowOp = arrowMatch[2]!
       const rawEdgeLabel = arrowMatch[3]?.trim()
       edgeLabel = rawEdgeLabel ? normalizeBrTags(rawEdgeLabel) : undefined
       remaining = remaining.slice(arrowMatch[0].length).trim()
       style = arrowStyleFromOp(arrowOp)
-      hasArrowEnd = arrowOp.endsWith('>')
+      startMarker = startMarkerForOp(arrowOp, Boolean(arrowMatch[1]))
+      endMarker = endMarkerForOp(arrowOp)
+      hasArrowStart = startMarker !== undefined
+      hasArrowEnd = endMarker !== undefined
     } else {
       // Fallback: text-embedded label syntax (-- Yes -->, -. Maybe .->, == Sure ==>)
       const textMatch = remaining.match(TEXT_ARROW_REGEX)
@@ -489,6 +495,8 @@ function parseEdgeLine(
       remaining = remaining.slice(textMatch[0].length).trim()
       style = textArrowStyleFromOps(openOp, closeOp)
       hasArrowEnd = closeOp.endsWith('>')
+      startMarker = hasArrowStart ? 'arrow' : undefined
+      endMarker = hasArrowEnd ? 'arrow' : undefined
     }
 
     // Parse the next node group
@@ -507,6 +515,8 @@ function parseEdgeLine(
           style,
           hasArrowStart,
           hasArrowEnd,
+          startMarker,
+          endMarker,
         })
       }
     }
@@ -642,4 +652,30 @@ function textArrowStyleFromOps(openOp: string, closeOp: string): EdgeStyle {
   if (openOp === '-.' || closeOp === '.->' || closeOp === '-.-') return 'dotted'
   if (openOp === '==' || closeOp === '==>' || closeOp === '===') return 'thick'
   return 'solid'
+}
+
+/**
+ * Determine the start (source-side) marker for an arrow operator.
+ * `<--*`, `<-.-*`, `<==*` produce a triangle arrow at the start.
+ * `o--*` / `x--*` operators produce a circle / cross at the start.
+ * Returns undefined when there is no start marker.
+ */
+function startMarkerForOp(op: string, hasLeftAngle: boolean): EdgeMarker | undefined {
+  if (hasLeftAngle) return 'arrow'
+  if (op.startsWith('o')) return 'circle'
+  if (op.startsWith('x')) return 'cross'
+  return undefined
+}
+
+/**
+ * Determine the end (target-side) marker for an arrow operator.
+ * Operators ending in `>` produce a triangle arrow; in `o` an open circle;
+ * in `x` a cross. The bare line operators (`---`, `-.-`, `===`) have no end marker.
+ */
+function endMarkerForOp(op: string): EdgeMarker | undefined {
+  const last = op[op.length - 1]
+  if (last === '>') return 'arrow'
+  if (last === 'o') return 'circle'
+  if (last === 'x') return 'cross'
+  return undefined
 }

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -1,4 +1,4 @@
-import type { PositionedGraph, PositionedNode, PositionedEdge, PositionedGroup, Point } from './types.ts'
+import type { PositionedGraph, PositionedNode, PositionedEdge, PositionedGroup, Point, EdgeMarker } from './types.ts'
 import type { DiagramColors } from './theme.ts'
 import { svgOpenTag, buildStyleBlock } from './theme.ts'
 import { FONT_SIZES, FONT_WEIGHTS, STROKE_WIDTHS, ARROW_HEAD, estimateTextWidth, TEXT_BASELINE_SHIFT } from './styles.ts'
@@ -45,15 +45,28 @@ export function renderSvg(
   parts.push(buildStyleBlock(font, false))
   parts.push('<defs>')
   parts.push(arrowMarkerDefs())
-  // Per-color arrow markers for edges with custom stroke via linkStyle
+
+  // Walk edges once: collect both custom stroke colors and which marker
+  // families (circle/cross) any edge needs, so we can emit only the defs
+  // actually referenced by this diagram.
   const customStrokeColors = new Set<string>()
+  let needsCircle = false
+  let needsCross = false
   for (const edge of graph.edges) {
-    if (edge.inlineStyle?.stroke) {
-      customStrokeColors.add(edge.inlineStyle.stroke)
-    }
+    if (edge.inlineStyle?.stroke) customStrokeColors.add(edge.inlineStyle.stroke)
+    if (edge.startMarker === 'circle' || edge.endMarker === 'circle') needsCircle = true
+    if (edge.startMarker === 'cross' || edge.endMarker === 'cross') needsCross = true
   }
+
+  if (needsCircle) parts.push(circleFamilyDefs(null))
+  if (needsCross) parts.push(crossFamilyDefs(null))
+
+  // Per-color marker variants for edges with custom stroke via linkStyle.
+  // Only emit the families actually used in the diagram.
   for (const color of customStrokeColors) {
     parts.push(arrowMarkerDefsForColor(color))
+    if (needsCircle) parts.push(circleFamilyDefs(color))
+    if (needsCross) parts.push(crossFamilyDefs(color))
   }
   parts.push('</defs>')
 
@@ -96,22 +109,7 @@ export function renderSvg(
  * Arrow color uses var(--_arrow) CSS variable.
  */
 function arrowMarkerDefs(): string {
-  const w = ARROW_HEAD.width
-  const h = ARROW_HEAD.height
-  // Arrow polygons have both fill and a thin stroke for better definition at small sizes
-  const arrowStyle = 'fill="var(--_arrow)" stroke="var(--_arrow)" stroke-width="0.75" stroke-linejoin="round"'
-  // Pull arrowhead back slightly (refX = w - 1) to prevent clipping at node boundaries
-  const refX = w - 1
-  return (
-    // Forward arrow (marker-end) — orient="auto" ensures arrow points along line direction
-    `  <marker id="arrowhead" markerWidth="${w}" markerHeight="${h}" refX="${refX}" refY="${h / 2}" orient="auto">` +
-    `\n    <polygon points="0 0, ${w} ${h / 2}, 0 ${h}" ${arrowStyle} />` +
-    `\n  </marker>` +
-    // Reverse arrow (marker-start) — refX=1 so it sits at the line start with slight offset, auto-start-reverse flips it
-    `\n  <marker id="arrowhead-start" markerWidth="${w}" markerHeight="${h}" refX="1" refY="${h / 2}" orient="auto-start-reverse">` +
-    `\n    <polygon points="${w} 0, 0 ${h / 2}, ${w} ${h}" ${arrowStyle} />` +
-    `\n  </marker>`
-  )
+  return arrowFamilyDefs(null)
 }
 
 /**
@@ -119,20 +117,79 @@ function arrowMarkerDefs(): string {
  * IDs are suffixed with a sanitized color string to avoid collisions.
  */
 function arrowMarkerDefsForColor(color: string): string {
+  return arrowFamilyDefs(color)
+}
+
+/** Triangle arrow markers — end + start variants, for one color (or default). */
+function arrowFamilyDefs(color: string | null): string {
   const w = ARROW_HEAD.width
   const h = ARROW_HEAD.height
-  const escaped = escapeAttr(color)
-  const arrowStyle = `fill="${escaped}" stroke="${escaped}" stroke-width="0.75" stroke-linejoin="round"`
+  const fillRef = color === null ? 'var(--_arrow)' : escapeAttr(color)
+  const style = `fill="${fillRef}" stroke="${fillRef}" stroke-width="0.75" stroke-linejoin="round"`
   const refX = w - 1
-  const suffix = markerSuffix(color)
+  const suffix = color === null ? '' : `-${markerSuffix(color)}`
   return (
-    `  <marker id="arrowhead-${suffix}" markerWidth="${w}" markerHeight="${h}" refX="${refX}" refY="${h / 2}" orient="auto">` +
-    `\n    <polygon points="0 0, ${w} ${h / 2}, 0 ${h}" ${arrowStyle} />` +
+    `  <marker id="arrowhead${suffix}" markerWidth="${w}" markerHeight="${h}" refX="${refX}" refY="${h / 2}" orient="auto">` +
+    `\n    <polygon points="0 0, ${w} ${h / 2}, 0 ${h}" ${style} />` +
     `\n  </marker>` +
-    `\n  <marker id="arrowhead-start-${suffix}" markerWidth="${w}" markerHeight="${h}" refX="1" refY="${h / 2}" orient="auto-start-reverse">` +
-    `\n    <polygon points="${w} 0, 0 ${h / 2}, ${w} ${h}" ${arrowStyle} />` +
+    `\n  <marker id="arrowhead-start${suffix}" markerWidth="${w}" markerHeight="${h}" refX="1" refY="${h / 2}" orient="auto-start-reverse">` +
+    `\n    <polygon points="${w} 0, 0 ${h / 2}, ${w} ${h}" ${style} />` +
     `\n  </marker>`
   )
+}
+
+/**
+ * Diameter of `--o` / `--x` endpoint markers in SVG user units. Sized to roughly
+ * match the visual weight of the triangular arrowhead (8px wide).
+ */
+const CIRCLE_MARKER_SIZE = 8
+const CROSS_MARKER_SIZE = 8
+
+/** Open-circle (`--o`, `o--`) markers — end + start variants, for one color. */
+function circleFamilyDefs(color: string | null): string {
+  const size = CIRCLE_MARKER_SIZE
+  const r = size / 2 - 0.75
+  const strokeRef = color === null ? 'var(--_arrow)' : escapeAttr(color)
+  const style = `fill="none" stroke="${strokeRef}" stroke-width="1"`
+  const suffix = color === null ? '' : `-${markerSuffix(color)}`
+  // End marker sits with its trailing edge at the line endpoint;
+  // start marker with its leading edge — same as triangle arrows.
+  return (
+    `  <marker id="circlehead${suffix}" markerWidth="${size}" markerHeight="${size}" refX="${size - 0.5}" refY="${size / 2}" orient="auto">` +
+    `\n    <circle cx="${size / 2}" cy="${size / 2}" r="${r}" ${style} />` +
+    `\n  </marker>` +
+    `\n  <marker id="circlehead-start${suffix}" markerWidth="${size}" markerHeight="${size}" refX="0.5" refY="${size / 2}" orient="auto-start-reverse">` +
+    `\n    <circle cx="${size / 2}" cy="${size / 2}" r="${r}" ${style} />` +
+    `\n  </marker>`
+  )
+}
+
+/** Cross (`--x`, `x--`) markers — end + start variants, for one color. */
+function crossFamilyDefs(color: string | null): string {
+  const size = CROSS_MARKER_SIZE
+  const pad = 1.25
+  const strokeRef = color === null ? 'var(--_arrow)' : escapeAttr(color)
+  const style = `stroke="${strokeRef}" stroke-width="1.25" stroke-linecap="round"`
+  const suffix = color === null ? '' : `-${markerSuffix(color)}`
+  const a = pad
+  const b = size - pad
+  return (
+    `  <marker id="crosshead${suffix}" markerWidth="${size}" markerHeight="${size}" refX="${size / 2}" refY="${size / 2}" orient="auto">` +
+    `\n    <line x1="${a}" y1="${a}" x2="${b}" y2="${b}" ${style} />` +
+    `\n    <line x1="${a}" y1="${b}" x2="${b}" y2="${a}" ${style} />` +
+    `\n  </marker>` +
+    `\n  <marker id="crosshead-start${suffix}" markerWidth="${size}" markerHeight="${size}" refX="${size / 2}" refY="${size / 2}" orient="auto-start-reverse">` +
+    `\n    <line x1="${a}" y1="${a}" x2="${b}" y2="${b}" ${style} />` +
+    `\n    <line x1="${a}" y1="${b}" x2="${b}" y2="${a}" ${style} />` +
+    `\n  </marker>`
+  )
+}
+
+/** Map an edge marker kind to its SVG <marker> id prefix. */
+function markerIdPrefix(marker: EdgeMarker): string {
+  if (marker === 'circle') return 'circlehead'
+  if (marker === 'cross') return 'crosshead'
+  return 'arrowhead'
 }
 
 /** Sanitize a color value into a collision-free SVG ID suffix.
@@ -203,18 +260,27 @@ function renderEdge(edge: PositionedEdge): string {
   const strokeColor = escapeAttr(edge.inlineStyle?.stroke ?? 'var(--_line)')
   const strokeWidth = escapeAttr(edge.inlineStyle?.['stroke-width'] ?? String(baseStrokeWidth))
 
-  // Build marker attributes based on arrow direction flags
-  // Use color-specific markers when edge has a custom stroke from linkStyle
+  // Build marker attributes based on arrow direction flags.
+  // The marker family (arrow / circle / cross) is picked from edge.endMarker
+  // and edge.startMarker, falling back to triangle arrows for legacy callers.
+  // Use color-specific markers when edge has a custom stroke from linkStyle.
   const suffix = edge.inlineStyle?.stroke ? `-${markerSuffix(edge.inlineStyle.stroke)}` : ''
   let markers = ''
-  if (edge.hasArrowEnd) markers += ` marker-end="url(#arrowhead${suffix})"`
-  if (edge.hasArrowStart) markers += ` marker-start="url(#arrowhead-start${suffix})"`
+  if (edge.hasArrowEnd) {
+    const prefix = markerIdPrefix(edge.endMarker ?? 'arrow')
+    markers += ` marker-end="url(#${prefix}${suffix})"`
+  }
+  if (edge.hasArrowStart) {
+    const prefix = markerIdPrefix(edge.startMarker ?? 'arrow')
+    markers += ` marker-start="url(#${prefix}-start${suffix})"`
+  }
 
   // Semantic data attributes for edge identification and inspection:
   // - class="edge": CSS targeting and type identification
   // - data-from/data-to: source and target node IDs
   // - data-style: edge style (solid, dotted, thick)
   // - data-arrow-start/end: arrow presence flags
+  // - data-marker-start/end: marker shape (arrow|circle|cross) when present
   // - data-label: edge label if present (for quick lookup without traversing DOM)
   const dataAttrs = [
     'class="edge"',
@@ -224,6 +290,12 @@ function renderEdge(edge: PositionedEdge): string {
     `data-arrow-start="${edge.hasArrowStart}"`,
     `data-arrow-end="${edge.hasArrowEnd}"`,
   ]
+  if (edge.hasArrowStart) {
+    dataAttrs.push(`data-marker-start="${edge.startMarker ?? 'arrow'}"`)
+  }
+  if (edge.hasArrowEnd) {
+    dataAttrs.push(`data-marker-end="${edge.endMarker ?? 'arrow'}"`)
+  }
   if (edge.label) {
     dataAttrs.push(`data-label="${escapeAttr(edge.label)}"`)
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -48,13 +48,20 @@ export interface MermaidEdge {
   target: string
   label?: string
   style: EdgeStyle
-  /** Whether to render an arrowhead at the start (source end) of the edge */
+  /** Whether to render a marker at the start (source end) of the edge */
   hasArrowStart: boolean
-  /** Whether to render an arrowhead at the end (target end) of the edge */
+  /** Whether to render a marker at the end (target end) of the edge */
   hasArrowEnd: boolean
+  /** Marker shape at start when hasArrowStart=true. Defaults to 'arrow' if undefined. */
+  startMarker?: EdgeMarker
+  /** Marker shape at end when hasArrowEnd=true. Defaults to 'arrow' if undefined. */
+  endMarker?: EdgeMarker
 }
 
 export type EdgeStyle = 'solid' | 'dotted' | 'thick'
+
+/** Edge endpoint marker shape: triangle arrow (default), open circle, or cross. */
+export type EdgeMarker = 'arrow' | 'circle' | 'cross'
 
 export interface MermaidSubgraph {
   id: string
@@ -96,6 +103,10 @@ export interface PositionedEdge {
   style: EdgeStyle
   hasArrowStart: boolean
   hasArrowEnd: boolean
+  /** Marker shape at start when hasArrowStart=true. Defaults to 'arrow' if undefined. */
+  startMarker?: EdgeMarker
+  /** Marker shape at end when hasArrowEnd=true. Defaults to 'arrow' if undefined. */
+  endMarker?: EdgeMarker
   /** Full path including bends — array of {x, y} points */
   points: Point[]
   /** Layout-computed label center position (avoids label-label collisions) */


### PR DESCRIPTION
## Summary

- Extends the flowchart parser to recognize the `--o`, `--x`, `o--o`, `x--x`, `o--x`, and `x--o` arrow operators from Mermaid's [new arrow types](https://mermaid.js.org/syntax/flowchart.html#new-arrow-types). Before this change, lines using these operators dropped the target node and edge entirely.
- ASCII renderer draws `◯` / `✕` (unicode) or `o` / `x` (ascii mode) at the edge endpoint instead of the triangle arrowhead. Works for end-only, start-only, and bidirectional combinations.
- SVG renderer emits new `circlehead` / `crosshead` `<marker>` defs — only when an edge actually uses them, so diagrams that don't use the new operators are byte-for-byte unchanged. Per-color variants are emitted for edges with `linkStyle` stroke overrides, matching the existing `arrowhead-{suffix}` scheme.

Fixes #109.

### Before

```
graph LR
  A --o B
```

```
┌───┐
│   │
│ A │
│   │
└───┘
```

### After

```
┌───┐     ┌───┐
│   │     │   │
│ A ├────◯│ B │
│   │     │   │
└───┘     └───┘
```

## Design notes

- A new `EdgeMarker = 'arrow' | 'circle' | 'cross'` type is added to `types.ts`; `MermaidEdge`, `PositionedEdge`, and `AsciiEdge` each gain optional `startMarker` / `endMarker` fields that describe the *shape* of the marker. The existing `hasArrowStart` / `hasArrowEnd` booleans now mean "there is a marker at this end" (true for any of arrow/circle/cross) and remain the canonical "is there a marker?" check.
- When `hasArrowEnd` is true and `endMarker` is undefined (the existing state diagram code path), the renderer defaults to the triangle arrow — so callers that pre-date this change keep their current output.
- The ASCII bundled-edge code paths (`drawBundleArrowhead` / `drawBundledEdgeArrowhead`) honor the marker as well, via a shared `bundleMarkerChar` helper.

## Test plan

- [x] `bun test src/__tests__/` — 733 pass (22 new tests covering parser, ASCII rendering, and SVG rendering)
- [x] `bun x tsc --noEmit` clean
- [x] `bun run build` clean
- [x] Manual: rendered `A --o B`, `A --x B`, `A o--o B`, `A x--x B`, `A o--x B`, `A x--o B`, both `graph LR` and `graph TD`, in both unicode and `useAscii: true` modes
- [x] Manual: SVG output for `linkStyle 0 stroke:#ff0000` on a `--o` edge correctly emits per-color `circlehead-23ff0000` marker