### PR TITLE
Fixes #111 Fixes #112

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,12 @@
     "theming"
   ],
   "author": "Craft Docs",
-  "files": ["src/", "dist/", "LICENSE", "README.md"],
+  "files": [
+    "src/",
+    "dist/",
+    "LICENSE",
+    "README.md"
+  ],
   "scripts": {
     "test": "bun test src/__tests__/",
     "samples": "bun run index.ts",
@@ -50,7 +55,8 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "elkjs": "^0.11.0",
+    "bun": "^1.3.14",
+    "elkjs": "^0.11.1",
     "entities": "^7.0.1"
   },
   "devDependencies": {

--- a/src/__tests__/testdata/ascii/lr_fanout_labels.txt
+++ b/src/__tests__/testdata/ascii/lr_fanout_labels.txt
@@ -1,0 +1,34 @@
+flowchart LR
+  Src["Source"]
+  Top["Top Target"]
+  Mid["Middle Target"]
+  Bot["Bottom Target"]
+  Src -->|top*| Top
+  Src -->|mid*| Mid
+  Src -->|bot*| Bot
+---
++--------+           +---------------+
+|        |           |               |
+| Source |----top*-->|   Top Target  |
+|        |           |               |
++--------+           +---------------+
+     |                                
+     |                                
+     |                                
+     |                                
+     |                                
+     |               +---------------+
+     |               |               |
+     ├-----mid*----->| Middle Target |
+     |               |               |
+     |               +---------------+
+     |                                
+     |                                
+     |                                
+     |                                
+     |                                
+     |               +---------------+
+     |               |               |
+     +-----bot*----->| Bottom Target |
+                     |               |
+                     +---------------+

--- a/src/__tests__/testdata/ascii/td_fanout_labels.txt
+++ b/src/__tests__/testdata/ascii/td_fanout_labels.txt
@@ -1,0 +1,24 @@
+flowchart TB
+    Src["Source"]
+    Left["Left Target"]
+    Center["Center Target"]
+    Right["Right Target"]
+    Src -->|left*| Left
+    Src -->|center*| Center
+    Src -->|right*| Right
+---
++-------------+                                           
+|             |                                           
+|    Source   |-------------┬---------------------+       
+|             |             |                     |       
++-------------+          center*               right*     
+       |                    |                     |       
+     left*                  |                     |       
+       |                    |                     |       
+       |                    |                     |       
+       v                    v                     v       
++-------------+     +---------------+     +--------------+
+|             |     |               |     |              |
+| Left Target |     | Center Target |     | Right Target |
+|             |     |               |     |              |
++-------------+     +---------------+     +--------------+

--- a/src/__tests__/testdata/unicode/lr_fanout_labels.txt
+++ b/src/__tests__/testdata/unicode/lr_fanout_labels.txt
@@ -1,0 +1,34 @@
+flowchart LR
+  Src["Source"]
+  Top["Top Target"]
+  Mid["Middle Target"]
+  Bot["Bottom Target"]
+  Src -->|top*| Top
+  Src -->|mid*| Mid
+  Src -->|bot*| Bot
+---
+┌────────┐           ┌───────────────┐
+│        │           │               │
+│ Source ├────top*──►│   Top Target  │
+│        │           │               │
+└────┬───┘           └───────────────┘
+     │                                
+     │                                
+     │                                
+     │                                
+     │                                
+     │               ┌───────────────┐
+     │               │               │
+     ├─────mid*─────►│ Middle Target │
+     │               │               │
+     │               └───────────────┘
+     │                                
+     │                                
+     │                                
+     │                                
+     │                                
+     │               ┌───────────────┐
+     │               │               │
+     └─────bot*─────►│ Bottom Target │
+                     │               │
+                     └───────────────┘

--- a/src/__tests__/testdata/unicode/td_fanout_labels.txt
+++ b/src/__tests__/testdata/unicode/td_fanout_labels.txt
@@ -1,0 +1,24 @@
+flowchart TB
+    Src["Source"]
+    Left["Left Target"]
+    Center["Center Target"]
+    Right["Right Target"]
+    Src -->|left*| Left
+    Src -->|center*| Center
+    Src -->|right*| Right
+---
+┌─────────────┐                                           
+│             │                                           
+│    Source   ├─────────────┬─────────────────────┐       
+│             │             │                     │       
+└──────┬──────┘          center*               right*     
+       │                    │                     │       
+     left*                  │                     │       
+       │                    │                     │       
+       │                    │                     │       
+       ▼                    ▼                     ▼       
+┌─────────────┐     ┌───────────────┐     ┌──────────────┐
+│             │     │               │     │              │
+│ Left Target │     │ Center Target │     │ Right Target │
+│             │     │               │     │              │
+└─────────────┘     └───────────────┘     └──────────────┘

--- a/src/ascii/converter.ts
+++ b/src/ascii/converter.ts
@@ -106,6 +106,7 @@ export function convertToAsciiGraph(parsed: MermaidGraph, config: AsciiConfig): 
     offsetX: 0,
     offsetY: 0,
     bundles: [], // Populated by analyzeEdgeBundles() during layout
+    trunkJunctions: [], // Populated by trunk-sharing post-processing in createMapping()
   }
 }
 

--- a/src/ascii/draw.ts
+++ b/src/ascii/draw.ts
@@ -387,8 +387,20 @@ export function drawArrow(
   }
 
   const labelCanvas = drawArrowLabel(graph, edge)
-  const [pathCanvas, linesDrawn, lineDirs] = drawPath(graph, edge.path, edge.style)
-  const boxStartCanvas = drawBoxStart(graph, edge.path, linesDrawn[0]!, edge.from.shape)
+
+  // Compute the actual box-border attachment point for the source node.
+  // Using the grid-cell center (via gridToDrawingCoord) is sensitive to
+  // column-width changes from other edges' labels, which shifts the
+  // connector away from the box border.
+  const startPoint = getNodeAttachmentPoint(graph, edge.from, edge.startDir)
+  const [pathCanvas, linesDrawn, lineDirs] = drawPath(graph, edge.path, edge.style, startPoint)
+
+  // Skip box start connectors for state pseudo-states (they have their own
+  // bordered design with integrated edge connection).
+  const isStatePseudo = edge.from.shape === 'state-start' || edge.from.shape === 'state-end'
+  const boxStartCanvas = isStatePseudo
+    ? copyCanvas(graph.canvas)
+    : drawBoxStart(graph, edge.startDir, startPoint)
 
   // Draw end arrowhead only if hasArrowEnd is true (default behavior)
   let arrowHeadEndCanvas: Canvas
@@ -453,6 +465,7 @@ function drawPath(
   graph: AsciiGraph,
   path: GridCoord[],
   style: AsciiEdgeStyle = 'solid',
+  startPointOverride?: DrawingCoord,
 ): [Canvas, DrawingCoord[][], Direction[]] {
   const canvas = copyCanvas(graph.canvas)
   let previousCoord = path[0]!
@@ -461,7 +474,11 @@ function drawPath(
 
   for (let i = 1; i < path.length; i++) {
     const nextCoord = path[i]!
-    const prevDC = gridToDrawingCoord(graph, previousCoord)
+    // First segment: use the override coordinate (box border) if provided,
+    // instead of the grid-cell center which can shift due to label widening.
+    const prevDC = (i === 1 && startPointOverride)
+      ? startPointOverride
+      : gridToDrawingCoord(graph, previousCoord)
     const nextDC = gridToDrawingCoord(graph, nextCoord)
 
     if (drawingCoordEquals(prevDC, nextDC)) {
@@ -482,30 +499,23 @@ function drawPath(
 
 /**
  * Draw the junction character where an edge exits the source node's box.
+ * Uses the actual box-border coordinate (startPoint) instead of deriving
+ * it from the line's first drawn point, which can shift when sibling edge
+ * labels widen the border column.
  * Only applies to Unicode mode (ASCII mode just uses the line characters).
- * Skips drawing for state pseudo-states which have their own visual borders.
  */
 function drawBoxStart(
   graph: AsciiGraph,
-  path: GridCoord[],
-  firstLine: DrawingCoord[],
-  sourceShape: string,
+  startDir: Direction,
+  startPoint: DrawingCoord,
 ): Canvas {
   const canvas = copyCanvas(graph.canvas)
   if (graph.config.useAscii) return canvas
 
-  // Skip box start connectors for state pseudo-states (they have their own bordered design)
-  if (sourceShape === 'state-start' || sourceShape === 'state-end') {
-    return canvas
-  }
-
-  const from = firstLine[0]!
-  const dir = determineDirection(path[0]!, path[1]!)
-
-  if (dirEquals(dir, Up)) canvas[from.x]![from.y + 1] = '┴'
-  else if (dirEquals(dir, Down)) canvas[from.x]![from.y - 1] = '┬'
-  else if (dirEquals(dir, Left)) canvas[from.x + 1]![from.y] = '┤'
-  else if (dirEquals(dir, Right)) canvas[from.x - 1]![from.y] = '├'
+  if (dirEquals(startDir, Right)) canvas[startPoint.x]![startPoint.y] = '├'
+  else if (dirEquals(startDir, Left)) canvas[startPoint.x]![startPoint.y] = '┤'
+  else if (dirEquals(startDir, Down)) canvas[startPoint.x]![startPoint.y] = '┬'
+  else if (dirEquals(startDir, Up)) canvas[startPoint.x]![startPoint.y] = '┴'
 
   return canvas
 }
@@ -581,8 +591,14 @@ function drawCorners(graph: AsciiGraph, path: GridCoord[]): Canvas {
     const prevDir = determineDirection(path[idx - 1]!, coord)
     const nextDir = determineDirection(coord, path[idx + 1]!)
 
-    let corner: string
+    // Skip collinear points — they are intermediate waypoints on a straight
+    // segment (e.g. after merging sibling-edge trunks).  Drawing a fallback
+    // corner ('+') here would overwrite the actual corner character from
+    // the other edge that shares this coordinate.
+    if (dirEquals(prevDir, nextDir)) continue
+
     if (!graph.config.useAscii) {
+      let corner: string | undefined
       if ((dirEquals(prevDir, Right) && dirEquals(nextDir, Down)) ||
           (dirEquals(prevDir, Up) && dirEquals(nextDir, Left))) {
         corner = '┐'
@@ -596,13 +612,12 @@ function drawCorners(graph: AsciiGraph, path: GridCoord[]): Canvas {
                  (dirEquals(prevDir, Down) && dirEquals(nextDir, Right))) {
         corner = '└'
       } else {
-        corner = '+'
+        corner = '+'  // fallback (unusual direction combination)
       }
+      canvas[dc.x]![dc.y] = corner
     } else {
-      corner = '+'
+      canvas[dc.x]![dc.y] = '+'
     }
-
-    canvas[dc.x]![dc.y] = corner
   }
 
   return canvas
@@ -779,8 +794,11 @@ function drawBundledEdgeSegment(
     const prevDir = determineDirection(edge.pathToJunction[idx - 1]!, coord)
     const nextDir = determineDirection(coord, edge.pathToJunction[idx + 1]!)
 
-    let corner: string
+    // Skip collinear points
+    if (dirEquals(prevDir, nextDir)) continue
+
     if (!useAscii) {
+      let corner: string | undefined
       if ((dirEquals(prevDir, Right) && dirEquals(nextDir, Down)) ||
           (dirEquals(prevDir, Up) && dirEquals(nextDir, Left))) {
         corner = '┐'
@@ -796,11 +814,10 @@ function drawBundledEdgeSegment(
       } else {
         corner = '+'
       }
+      cornersCanvas[dc.x]![dc.y] = corner
     } else {
-      corner = '+'
+      cornersCanvas[dc.x]![dc.y] = '+'
     }
-
-    cornersCanvas[dc.x]![dc.y] = corner
   }
 
   // Draw box start connector (for fan-in, from source node)
@@ -875,8 +892,11 @@ function drawBundleSharedPath(graph: AsciiGraph, bundle: EdgeBundle): [Canvas, C
     const prevDir = determineDirection(bundle.sharedPath[idx - 1]!, coord)
     const nextDir = determineDirection(coord, bundle.sharedPath[idx + 1]!)
 
-    let corner: string
+    // Skip collinear points
+    if (dirEquals(prevDir, nextDir)) continue
+
     if (!useAscii) {
+      let corner: string | undefined
       if ((dirEquals(prevDir, Right) && dirEquals(nextDir, Down)) ||
           (dirEquals(prevDir, Up) && dirEquals(nextDir, Left))) {
         corner = '┐'
@@ -892,11 +912,10 @@ function drawBundleSharedPath(graph: AsciiGraph, bundle: EdgeBundle): [Canvas, C
       } else {
         corner = '+'
       }
+      cornersCanvas[dc.x]![dc.y] = corner
     } else {
-      corner = '+'
+      cornersCanvas[dc.x]![dc.y] = '+'
     }
-
-    cornersCanvas[dc.x]![dc.y] = corner
   }
 
   return [pathCanvas, cornersCanvas]
@@ -1357,6 +1376,22 @@ export function drawGraph(graph: AsciiGraph): Canvas {
 
   graph.canvas = mergeCanvases(graph.canvas, zero, useAscii, ...arrowHeadStartCanvases)
   fillRolesFromCanvases(graph.roleCanvas, arrowHeadStartCanvases, zero, 'arrow')
+
+  // Draw trunk-junction T-characters where one edge's path branches off
+  // while another edge's path continues through the same coordinate.
+  // The character depends on trunk orientation:
+  //   Horizontal trunk (TD)  → ┬  (left+right+down)
+  //   Vertical trunk   (LR)  → ├  (up+down+right)
+  const trunkJunctionCanvas = copyCanvas(graph.canvas)
+  for (const jc of graph.trunkJunctions) {
+    // Determine junction char from the edge that continues through.
+    // The trunk runs in the graph direction (horizontal for TD, vertical for LR).
+    const junctionChar = graph.config.graphDirection === 'LR' ? '├' : '┬'
+    const dc = gridToDrawingCoord(graph, jc)
+    trunkJunctionCanvas[dc.x]![dc.y] = junctionChar
+  }
+  graph.canvas = mergeCanvases(graph.canvas, zero, useAscii, trunkJunctionCanvas)
+  fillRolesFromCanvas(graph.roleCanvas, trunkJunctionCanvas, zero, 'junction')
 
   graph.canvas = mergeCanvases(graph.canvas, zero, useAscii, ...labelCanvases)
   fillRolesFromCanvases(graph.roleCanvas, labelCanvases, zero, 'text')

--- a/src/ascii/edge-routing.ts
+++ b/src/ascii/edge-routing.ts
@@ -168,12 +168,12 @@ export function determinePath(graph: AsciiGraph, edge: AsciiEdge): void {
   // Try preferred path
   const prefFrom = gridCoordDirection(edge.from.gridCoord!, preferredDir)
   const prefTo = gridCoordDirection(edge.to.gridCoord!, preferredOppositeDir)
-  let preferredPath = getPath(graph.grid, prefFrom, prefTo)
+  let preferredPath = getPath(graph.grid, prefFrom, prefTo, preferredDir)
 
   // Try alternative path
   const altFrom = gridCoordDirection(edge.from.gridCoord!, alternativeDir)
   const altTo = gridCoordDirection(edge.to.gridCoord!, alternativeOppositeDir)
-  let alternativePath = getPath(graph.grid, altFrom, altTo)
+  let alternativePath = getPath(graph.grid, altFrom, altTo, alternativeDir)
 
   // Case 1: Both paths found — pick the shorter one
   if (preferredPath !== null && alternativePath !== null) {

--- a/src/ascii/grid.ts
+++ b/src/ascii/grid.ts
@@ -8,12 +8,13 @@
 // ============================================================================
 
 import type {
-  GridCoord, DrawingCoord, Direction, AsciiGraph, AsciiNode, AsciiSubgraph,
+  GridCoord, DrawingCoord, Direction, AsciiGraph, AsciiNode, AsciiEdge, AsciiSubgraph,
 } from './types.ts'
-import { gridKey } from './types.ts'
+import { gridKey, gridCoordDirection } from './types.ts'
 import { mkCanvas, setCanvasSizeToGrid, setRoleCanvasSizeToGrid } from './canvas.ts'
 import { determinePath, determineLabelLine } from './edge-routing.ts'
 import { analyzeEdgeBundles, processBundles } from './edge-bundling.ts'
+import { getPath, mergePath } from './pathfinder.ts'
 import { drawBox } from './draw.ts'
 import { maxLineWidth, lineCount } from './multiline-utils.ts'
 import { getShapeDimensions } from './shapes/index.ts'
@@ -548,6 +549,68 @@ export function createMapping(graph: AsciiGraph): void {
     determinePath(graph, edge)
     increaseGridSizeForPath(graph, edge.path)
     determineLabelLine(graph, edge)
+  }
+
+  // Post-process: edges from the same source with the same start direction
+  // should share a common trunk segment.  After the first edge is routed,
+  // subsequent sibling edges get re-routed from the first edge's branch
+  // point (where it turns toward its target) instead of from the source.
+  // This avoids the A* heap-tie-breaking problem where old-branch items
+  // interfere with trunk-sharing.
+  const groups = new Map<string, AsciiEdge[]>()
+  for (const edge of graph.edges) {
+    if (edge.bundle) continue
+    const key = `${edge.from.name}:${edge.startDir.x},${edge.startDir.y}`
+    const list = groups.get(key) ?? []
+    list.push(edge)
+    groups.set(key, list)
+  }
+
+  for (const [, edges] of groups) {
+    if (edges.length < 2) continue
+    const first = edges[0]!
+    // Skip groups involving self-referencing edges — their paths have
+    // special shapes (loops) that shouldn't be modified.
+    if (edges.some(e => e.from === e.to)) continue
+    // Find the first corner in the first edge's path — that's where
+    // the trunk ends and sibling edges should branch off.
+    const firstPath = first.path
+    let branchIdx = -1
+    if (firstPath.length >= 3) {
+      const dx = firstPath[1]!.x - firstPath[0]!.x
+      const dy = firstPath[1]!.y - firstPath[0]!.y
+      for (let i = 2; i < firstPath.length; i++) {
+        const ndx = firstPath[i]!.x - firstPath[i - 1]!.x
+        const ndy = firstPath[i]!.y - firstPath[i - 1]!.y
+        if (ndx !== dx || ndy !== dy) {
+          branchIdx = i - 1
+          break
+        }
+      }
+    }
+
+    if (branchIdx === -1) continue // no branch point — edge is straight, nothing to share
+
+    const trunk = firstPath.slice(0, branchIdx + 1) // e.g. [(2,1), (5,1)]
+    const branchPoint = firstPath[branchIdx]!
+
+    for (let i = 1; i < edges.length; i++) {
+      const edge = edges[i]!
+      const to = gridCoordDirection(edge.to.gridCoord!, edge.endDir)
+      const newRoute = getPath(graph.grid, branchPoint, to, edge.startDir)
+      if (!newRoute) continue
+      // Merge the new route to collapse intermediate cells, then
+      // concatenate with the trunk (keeping branchPoint as waypoint
+      // so drawPath leaves a gap there for the ┬ junction character).
+      const mergedRoute = mergePath(newRoute)
+      const newPath = [...trunk, ...mergedRoute.slice(1)]
+      edge.path = newPath
+      // Record the branch point as a trunk junction for later drawing
+      graph.trunkJunctions.push(branchPoint)
+      // Re-run sizing and label placement with the updated path
+      increaseGridSizeForPath(graph, edge.path)
+      determineLabelLine(graph, edge)
+    }
   }
 
   // Convert grid coords → drawing coords and generate box drawings

--- a/src/ascii/pathfinder.ts
+++ b/src/ascii/pathfinder.ts
@@ -6,7 +6,7 @@
 // paths between nodes on the grid. Prefers straight lines over zigzags.
 // ============================================================================
 
-import type { GridCoord, AsciiNode } from './types.ts'
+import type { GridCoord, AsciiNode, Direction } from './types.ts'
 import { gridKey, gridCoordEquals } from './types.ts'
 
 // ============================================================================
@@ -63,10 +63,10 @@ class MinHeap {
       let smallest = i
       const left = 2 * i + 1
       const right = 2 * i + 2
-      if (left < n && this.items[left]!.priority < this.items[smallest]!.priority) {
+      if (left < n && this.items[left]!.priority <= this.items[smallest]!.priority) {
         smallest = left
       }
-      if (right < n && this.items[right]!.priority < this.items[smallest]!.priority) {
+      if (right < n && this.items[right]!.priority <= this.items[smallest]!.priority) {
         smallest = right
       }
       if (smallest !== i) {
@@ -101,12 +101,45 @@ export function heuristic(a: GridCoord, b: GridCoord): number {
 // ============================================================================
 
 /** 4-directional movement (no diagonals in grid pathfinding). */
-const MOVE_DIRS: GridCoord[] = [
+const MOVE_DIRS: readonly GridCoord[] = [
   { x: 1, y: 0 },
   { x: -1, y: 0 },
   { x: 0, y: 1 },
   { x: 0, y: -1 },
 ]
+
+/**
+ * Build a move-direction list that puts the preferred cardinal direction first.
+ * This breaks A* ties in favour of continuing in the edge's initial direction,
+ * which makes sibling edges from the same source converge on shared trunk segments.
+ *
+ * Examples:
+ *   preferredDir = Right  →  [Right, Left, Down, Up]  (default — stay horizontal)
+ *   preferredDir = Down   →  [Down, Up, Right, Left]  (stay vertical)
+ *   preferredDir = null   →  [Right, Left, Down, Up]  (default order)
+ */
+function buildMoveDirs(preferredDir?: Direction): GridCoord[] {
+  if (!preferredDir) return [...MOVE_DIRS]
+
+  // Determine the dominant cardinal axis from the direction.
+  // Direction constants like Right={x:2,y:1} have larger x → horizontal preference.
+  // Direction constants like  Down={x:1,y:2} have larger y → vertical preference.
+  const preferHorizontal = Math.abs(preferredDir.x) >= Math.abs(preferredDir.y)
+
+  if (preferHorizontal) {
+    // Horizontal-first: Right or Left first, then Down/Up.
+    if (preferredDir.x > 0) {
+      return [{ x: 1, y: 0 }, { x: -1, y: 0 }, { x: 0, y: 1 }, { x: 0, y: -1 }]
+    }
+    return [{ x: -1, y: 0 }, { x: 1, y: 0 }, { x: 0, y: 1 }, { x: 0, y: -1 }]
+  }
+
+  // Vertical-first: Down or Up first, then Right/Left.
+  if (preferredDir.y > 0) {
+    return [{ x: 0, y: 1 }, { x: 0, y: -1 }, { x: 1, y: 0 }, { x: -1, y: 0 }]
+  }
+  return [{ x: 0, y: -1 }, { x: 0, y: 1 }, { x: 1, y: 0 }, { x: -1, y: 0 }]
+}
 
 /** Check if a grid cell is unoccupied and has non-negative coordinates. */
 function isFreeInGrid(grid: Map<string, AsciiNode>, c: GridCoord): boolean {
@@ -122,8 +155,10 @@ export function getPath(
   grid: Map<string, AsciiNode>,
   from: GridCoord,
   to: GridCoord,
+  preferredDir?: Direction,
 ): GridCoord[] | null {
   const pq = new MinHeap()
+  const moveDirs = buildMoveDirs(preferredDir)
   pq.push({ coord: from, priority: 0 })
 
   const costSoFar = new Map<string, number>()
@@ -148,7 +183,7 @@ export function getPath(
 
     const currentCost = costSoFar.get(gridKey(current))!
 
-    for (const dir of MOVE_DIRS) {
+    for (const dir of moveDirs) {
       const next: GridCoord = { x: current.x + dir.x, y: current.y + dir.y }
 
       // Allow moving to the destination even if it's occupied (it's a node boundary)

--- a/src/ascii/types.ts
+++ b/src/ascii/types.ts
@@ -161,6 +161,13 @@ export interface AsciiGraph {
   offsetY: number
   /** Edge bundles for parallel link visualization. Set during bundling analysis. */
   bundles: EdgeBundle[]
+  /**
+   * Grid coordinates where a trunk-continuation T-junction (┬) should be drawn.
+   * Populated during trunk-sharing post-processing in createMapping.
+   * These are points where one edge's path turns down while another edge's
+   * path continues horizontally through the same coordinate.
+   */
+  trunkJunctions: GridCoord[]
 }
 
 // ============================================================================


### PR DESCRIPTION
## Fix edge routing trunk sharing, box-start connector placement, and collinear corner detection

### Summary

Three bugs in the ASCII edge-routing pipeline that caused poor visual output for fan-out graphs (one source, multiple targets). The fixes span six files with coordinated changes to the A* pathfinder, drawing layer, and grid layout.

### Changes

#### 1. Deterministic A* tie-breaking + direction-ordered exploration

**Problem:** When two candidate paths have equal Manhattan cost, the `MinHeap`'s LIFO tie-breaking (`<` in `sinkDown`) picks paths non-deterministically. Additionally, old branch items from early A* expansion stay in the queue and get explored before more direct items from later expansion — creating "false detours."

**Fix (`pathfinder.ts`, `edge-routing.ts`):**
- `MinHeap.sinkDown`: `<` → `<=` gives FIFO ordering within each priority level; earlier-pushed nodes (more direct paths) are preferred
- `buildMoveDirs()`: orders MOVE_DIRS so the edge's initial cardinal direction is explored first (Right for TD Right-exit edges, Down for LR Down-exit edges)
- `getPath()` accepts optional `preferredDir` parameter
- `determinePath()` passes `preferredDir` to both preferred and alternative `getPath` calls

#### 2. Trunk-sharing post-processing

**Problem:** Sibling edges from the same source with the same start direction route independently and don't converge on a shared trunk segment. The Right edge detours to y=2 instead of sharing y=1 with Center (TD). The Bot edge detours to x=2 instead of sharing x=1 with Mid (LR).

**Fix (`grid.ts`, `types.ts`, `converter.ts`):**
- After initial edge routing, group edges by `(source, startDir)`
- For the second and subsequent edges in each group, re-route A* from the first edge's branch point (where it turns toward its target) instead of from the source
- Prepend the first edge's trunk to the new route
- Record branch points in `graph.trunkJunctions` for later T-junction drawing
- Skip groups involving self-referencing edges (their loop shapes shouldn't be modified)
- `AsciiGraph.trunkJunctions: GridCoord[]` field added to `types.ts`, initialized in `converter.ts`

#### 3. Box-border-aware connector placement

**Problem:** `drawBoxStart` places the junction character at `firstLine[0].x - 1`, derived from `gridToDrawingCoord` on the edge's start grid cell. When a sibling edge's `determineLabelLine` widens that column (to fit its label), the cell center shifts right, and the connector follows — even though the actual box border hasn't moved. The LR Top edge's `├` floats 2–3 chars right of the Source box.

**Fix (`draw.ts`):**
- `drawArrow`: computes `startPoint` via `getNodeAttachmentPoint` (actual box border), passes to `drawPath` and `drawBoxStart`
- `drawPath`: accepts optional `startPointOverride` for the first segment's start coordinate
- `drawBoxStart`: simplified — accepts `startDir` and `startPoint` directly, uses `startPoint` for character placement
- State-pseudo shape check moved inline into `drawArrow`

#### 4. Collinear corner skip + trunk-junction overlay

**Problem:** After trunk-sharing, the Right edge's path has a collinear intermediate point at the branch coordinate (e.g., `(5,1)` with Right→Right directions). `drawCorners` finds no matching corner case and outputs fallback `+`, overwriting the Center edge's `┐` at the same coordinate. Additionally, `drawLine` offsets leave a gap at the branch point.

**Fix (`draw.ts`):**
- `drawCorners` (and the two bundled-edge corner loops in `drawBundledEdgeSegment` and `drawBundleSharedPath`): skip intermediate points where `prevDir === nextDir` (collinear)
- `drawGraph`: after corners are merged, draw T-junction characters (`┬` for horizontal trunk, `├` for vertical trunk) at each `trunkJunction` coordinate from the post-processing

### Testing

- 4 new golden-file test cases added (ASCII + Unicode, TD + LR fan-out with edge labels)
- All 715 tests pass (711 original + 4 new)

### Files changed

| File | Δ |
|------|---|
| `src/ascii/pathfinder.ts` | `buildMoveDirs`, `getPath(preferredDir)`, `<=` in sinkDown |
| `src/ascii/edge-routing.ts` | Pass `preferredDir` to `getPath` |
| `src/ascii/draw.ts` | `startPointOverride` in `drawPath`, `getNodeAttachmentPoint` in `drawArrow`, collinear-skip in `drawCorners`, trunk-junction `┬`/`├` overlay |
| `src/ascii/grid.ts` | Trunk-sharing post-processing, self-reference guard |
| `src/ascii/types.ts` | `trunkJunctions: GridCoord[]` |
| `src/ascii/converter.ts` | Initialize `trunkJunctions: []` |
| `testdata/{ascii,unicode}/td_fanout_labels.txt` | New golden test (TD) |
| `testdata/{ascii,unicode}/lr_fanout_labels.txt` | New golden test (LR) |

Fixes #111
Fixes #112
