### PR TITLE
fix: auto-contrast text color for nodes with custom fills

### DIFF
--- a/src/__tests__/renderer.test.ts
+++ b/src/__tests__/renderer.test.ts
@@ -433,6 +433,81 @@ describe('renderSvg – inline styles', () => {
 })
 
 // ============================================================================
+// Auto-contrast text color for custom fills
+// ============================================================================
+
+describe('renderSvg – auto-contrast text color', () => {
+  it('uses black text on light fill in dark mode', () => {
+    // Light pastel fill + dark-mode fg (#FAFAFA) would produce invisible white-on-pastel
+    const node = makeNode({ inlineStyle: { fill: '#FFFACD' } }) // lemon chiffon
+    const graph = makeGraph({ nodes: [node] })
+    const svg = renderSvg(graph, darkColors)
+    // Text should be black, not the dark-mode fg
+    expect(svg).toContain('fill="#000000"')
+  })
+
+  it('uses white text on dark fill in light mode', () => {
+    const node = makeNode({ inlineStyle: { fill: '#1a1a1a' } })
+    const graph = makeGraph({ nodes: [node] })
+    const svg = renderSvg(graph, lightColors)
+    expect(svg).toContain('fill="#FFFFFF"')
+  })
+
+  it('uses white text on dark fill in dark mode', () => {
+    const node = makeNode({ inlineStyle: { fill: '#000080' } }) // navy
+    const graph = makeGraph({ nodes: [node] })
+    const svg = renderSvg(graph, darkColors)
+    expect(svg).toContain('fill="#FFFFFF"')
+  })
+
+  it('uses black text on bright red fill', () => {
+    const node = makeNode({ inlineStyle: { fill: '#FF6B6B' } })
+    const graph = makeGraph({ nodes: [node] })
+    const svg = renderSvg(graph, darkColors)
+    // #FF6B6B luminance ≈ 0.56 → should pick black
+    expect(svg).toContain('fill="#000000"')
+  })
+
+  it('uses black text on light green fill', () => {
+    const node = makeNode({ inlineStyle: { fill: '#90EE90' } })
+    const graph = makeGraph({ nodes: [node] })
+    const svg = renderSvg(graph, darkColors)
+    expect(svg).toContain('fill="#000000"')
+  })
+
+  it('handles short hex (#RGB) fills', () => {
+    const node = makeNode({ inlineStyle: { fill: '#f00' } }) // red
+    const graph = makeGraph({ nodes: [node] })
+    const svg = renderSvg(graph, darkColors)
+    // #ff0000 luminance ≈ 0.30 → white text
+    expect(svg).toContain('fill="#FFFFFF"')
+  })
+
+  it('respects explicit color even with custom fill', () => {
+    // User set both fill and color — color takes precedence
+    const node = makeNode({ inlineStyle: { fill: '#FFFACD', color: '#0000FF' } })
+    const graph = makeGraph({ nodes: [node] })
+    const svg = renderSvg(graph, darkColors)
+    expect(svg).toContain('fill="#0000FF"')
+  })
+
+  it('uses var(--_text) when fill is a CSS variable', () => {
+    // CSS variable fills can\'t be parsed at render time — fall back to theme
+    const node = makeNode({ inlineStyle: { fill: 'var(--_node-fill)' } })
+    const graph = makeGraph({ nodes: [node] })
+    const svg = renderSvg(graph, darkColors)
+    expect(svg).toContain('fill="var(--_text)"')
+  })
+
+  it('uses var(--_text) when no inline style at all', () => {
+    const node = makeNode()
+    const graph = makeGraph({ nodes: [node] })
+    const svg = renderSvg(graph, darkColors)
+    expect(svg).toContain('fill="var(--_text)"')
+  })
+})
+
+// ============================================================================
 // XML escaping
 // ============================================================================
 

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -565,6 +565,73 @@ function renderStateEnd(x: number, y: number, w: number, h: number): string {
 // Node label rendering
 // ============================================================================
 
+/**
+ * Parse a hex color string (#RGB, #RRGGBB, or #RRGGBBAA) into RGB components.
+ * Returns null if the string is not a valid hex color.
+ */
+function parseHexToRgb(hex: string): { r: number; g: number; b: number } | null {
+  const m = hex.match(/^#([0-9a-fA-F]{3,8})$/)
+  if (!m) return null
+  const h = m[1]!
+  if (h.length === 3) {
+    return {
+      r: parseInt(h[0]! + h[0]!, 16),
+      g: parseInt(h[1]! + h[1]!, 16),
+      b: parseInt(h[2]! + h[2]!, 16),
+    }
+  }
+  if (h.length >= 6) {
+    return {
+      r: parseInt(h.slice(0, 2), 16),
+      g: parseInt(h.slice(2, 4), 16),
+      b: parseInt(h.slice(4, 6), 16),
+    }
+  }
+  return null
+}
+
+/**
+ * Parse an rgb()/rgba() CSS function into RGB components.
+ * Handles both comma and space syntax: rgb(255, 0, 0) and rgb(255 0 0).
+ */
+function parseRgbFunc(color: string): { r: number; g: number; b: number } | null {
+  const m = color.match(/^rgba?\(\s*(\d{1,3})[\s,]+(\d{1,3})[\s,]+(\d{1,3})/)
+  if (!m) return null
+  return { r: parseInt(m[1]!, 10), g: parseInt(m[2]!, 10), b: parseInt(m[3]!, 10) }
+}
+
+/**
+ * Determine whether a color string is a concrete (resolvable) color value
+ * rather than a CSS variable reference like var(--_node-fill).
+ */
+function isConcreteColor(color: string): boolean {
+  return color.startsWith('#') || color.startsWith('rgb')
+}
+
+/**
+ * Choose a high-contrast text color (black or white) for the given background.
+ *
+ * Uses the BT.601 perceived brightness formula to determine whether the
+ * background is light or dark, then returns the opposite for maximum readability.
+ * Returns null if the background color cannot be parsed.
+ */
+function contrastTextColor(bgColor: string): string | null {
+  const rgb = parseHexToRgb(bgColor) ?? parseRgbFunc(bgColor)
+  if (!rgb) return null
+  // BT.601 perceived brightness — good enough for black-vs-white decisions
+  const luminance = (0.299 * rgb.r + 0.587 * rgb.g + 0.114 * rgb.b) / 255
+  return luminance > 0.55 ? '#000000' : '#FFFFFF'
+}
+
+/**
+ * Render the text label for a node.
+ *
+ * Text color resolution order:
+ * 1. Explicit `color` from classDef / style → use as-is.
+ * 2. Concrete `fill` (e.g. #FF6B6B) without explicit `color` → auto-pick
+ *    black or white based on fill luminance for guaranteed readability.
+ * 3. No inline style → fall back to theme variable var(--_text).
+ */
 function renderNodeLabel(node: PositionedNode, font: string): string {
   // State pseudostates have no label
   if (node.shape === 'state-start' || node.shape === 'state-end') {
@@ -574,8 +641,19 @@ function renderNodeLabel(node: PositionedNode, font: string): string {
   const cx = node.x + node.width / 2
   const cy = node.y + node.height / 2
 
-  // Resolve text color — inline styles can override the CSS variable default
-  const textColor = escapeAttr(node.inlineStyle?.color ?? 'var(--_text)')
+  // Resolve text color with auto-contrast for custom fills
+  let textColor: string
+  if (node.inlineStyle?.color) {
+    // User explicitly set text color — respect it
+    textColor = escapeAttr(node.inlineStyle.color)
+  } else if (node.inlineStyle?.fill && isConcreteColor(node.inlineStyle.fill)) {
+    // Custom fill without explicit text color — auto-pick for contrast.
+    // This prevents white-on-pastel in dark mode and black-on-dark in light mode.
+    textColor = contrastTextColor(node.inlineStyle.fill) ?? 'var(--_text)'
+  } else {
+    // No custom fill — follow the theme
+    textColor = 'var(--_text)'
+  }
 
   return renderMultilineText(
     node.label,


### PR DESCRIPTION
## Summary

Fixes #115 — node label text is unreadable on custom fills in dark mode.

When a node has a custom `fill` via `classDef` or `style` but no explicit `color`, the text falls back to `var(--_text)` (= theme foreground). In dark mode this produces **white text on light fills** — invisible.

## Changes

**`src/renderer.ts`** — `renderNodeLabel()` now resolves text color in 3 tiers:

1. **Explicit `color`** from classDef/style → use as-is (no change)
2. **Concrete `fill`** (hex/rgb) without `color` → auto-pick `#000000` or `#FFFFFF` based on perceived brightness (BT.601 luma)
3. **No inline style** → `var(--_text)` theme default (no change)

Helper functions added (all internal, not exported):
- `parseHexToRgb()` — handles `#RGB`, `#RRGGBB`, `#RRGGBBAA`
- `parseRgbFunc()` — handles `rgb()` / `rgba()` with comma or space syntax
- `isConcreteColor()` — distinguishes `#hex`/`rgb()` from CSS variable references
- `contrastTextColor()` — BT.601 perceived brightness → black or white

**`src/__tests__/renderer.test.ts`** — 9 new tests covering:
- Light fill in dark mode → black text
- Dark fill in light/dark mode → white text
- Specific colors (#FF6B6B, #90EE90, #f00)
- Short hex (#RGB) support
- Explicit color override takes precedence
- CSS variable fills fall back to `var(--_text)`
- No inline style → unchanged behavior

## Test results

```
56 pass, 0 fail — all existing tests unaffected
```

## Before / After

| Mode | Before | After |
|------|--------|-------|
| Dark, `fill:#FF6B6B` | ❌ White text on red | ✅ Black text on red |
| Dark, `fill:#FFFACD` | ❌ White text on yellow | ✅ Black text on yellow |
| Dark, `fill:#000080` | ✅ White text on navy | ✅ White text on navy |
| Light, `fill:#333` | ❌ Dark text on dark | ✅ White text on dark |
| Any, `color:#0000FF` | ✅ Blue text (user set) | ✅ Blue text (unchanged) |
| Any, no inline style | ✅ `var(--_text)` | ✅ `var(--_text)` (unchanged) |