### PR TITLE
Support Mermaid frontmatter and init config

### DIFF
--- a/README.md
+++ b/README.md
@@ -518,6 +518,20 @@ Render a Mermaid diagram to SVG. Synchronous. Auto-detects diagram type.
 | `componentSpacing` | `number` | `24` | Spacing between disconnected components |
 | `thoroughness` | `number` | `3` | Crossing minimization trials (1-7, higher = better but slower) |
 | `interactive` | `boolean` | `false` | Enable hover tooltips on XY chart bars and data points |
+| `mermaidConfig` | `MermaidRuntimeConfig` | `{}` | Base Mermaid-style config merged before frontmatter and `%%{init}%%` directives |
+
+**Mermaid config:** Leading YAML frontmatter and `%%{init: ...}%%` / `%%{initialize: ...}%%` directives are stripped before parsing and merged into runtime config. Explicit render options still win over config-derived theme values.
+
+```mermaid
+---
+theme: dark
+themeVariables:
+  primaryTextColor: "#f8fafc"
+  primaryColor: "#38bdf8"
+---
+graph TD
+  A[Configured] --> B[Diagram]
+```
 
 **XY Charts:** Diagrams starting with `xychart-beta` are auto-detected — no separate function needed. The `accent` color option drives the chart series color palette.
 
@@ -539,6 +553,7 @@ Render a Mermaid diagram to ASCII/Unicode text. Synchronous.
 | `boxBorderPadding` | `number` | `1` | Inner box padding |
 | `colorMode` | `string` | `'auto'` | `'none'`, `'auto'`, `'ansi16'`, `'ansi256'`, `'truecolor'`, or `'html'` |
 | `theme` | `Partial<AsciiTheme>` | — | Override default colors for ASCII output |
+| `mermaidConfig` | `MermaidRuntimeConfig` | `{}` | Base Mermaid-style config merged before frontmatter and `%%{init}%%` directives |
 
 ### `parseMermaid(text): MermaidGraph`
 

--- a/bun.lock
+++ b/bun.lock
@@ -7,6 +7,7 @@
       "dependencies": {
         "elkjs": "^0.11.0",
         "entities": "^7.0.1",
+        "yaml": "^2.8.2",
       },
       "devDependencies": {
         "@types/bun": "^1.3.9",
@@ -310,6 +311,8 @@
     "vfile": ["vfile@6.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "vfile-message": "^4.0.0" } }, "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q=="],
 
     "vfile-message": ["vfile-message@4.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw=="],
+
+    "yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
 
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
   }

--- a/package.json
+++ b/package.json
@@ -51,7 +51,8 @@
   },
   "dependencies": {
     "elkjs": "^0.11.0",
-    "entities": "^7.0.1"
+    "entities": "^7.0.1",
+    "yaml": "^2.8.2"
   },
   "devDependencies": {
     "@types/bun": "^1.3.9",

--- a/src/__tests__/mermaid-source.test.ts
+++ b/src/__tests__/mermaid-source.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from 'bun:test'
+
+import { renderMermaidASCII } from '../ascii/index.ts'
+import { renderMermaidSVG } from '../index.ts'
+import {
+  getFrontmatterMap,
+  getFrontmatterScalar,
+  normalizeMermaidSource,
+  preprocessMermaidSource,
+} from '../mermaid-source.ts'
+
+describe('preprocessMermaidSource', () => {
+  it('parses real YAML frontmatter, including anchors, lists, and block scalars', () => {
+    const processed = preprocessMermaidSource(`---
+theme: base
+themeCSS: |
+  .foo { fill: red; }
+secure:
+  - theme
+palette: &palette
+  plotColorPalette: "#ff6b6b, #0ea5e9"
+themeVariables:
+  xyChart: *palette
+config:
+  xyChart:
+    width: 640
+---
+xychart
+x-axis [A]
+bar [1]`)
+
+    expect(processed.body).toBe(`xychart
+x-axis [A]
+bar [1]`)
+    expect(getFrontmatterScalar<string>(processed.frontmatter, ['theme'])).toBe('base')
+    expect(getFrontmatterScalar<string>(processed.frontmatter, ['themeCSS'])).toContain('.foo { fill: red; }')
+    expect(processed.frontmatter.secure).toEqual(['theme'])
+    expect(getFrontmatterScalar<string>(processed.frontmatter, ['themeVariables', 'xyChart', 'plotColorPalette']))
+      .toBe('#ff6b6b, #0ea5e9')
+    expect(getFrontmatterScalar<number>(processed.frontmatter, ['xyChart', 'width'])).toBe(640)
+  })
+
+  it('merges init directives before and after the header and strips them from the body', () => {
+    const processed = preprocessMermaidSource(`%%{init: { theme: base, config: { xyChart: { width: 640 } } }}%%
+xychart
+%% regular comment
+x-axis [A]
+%%{initialize: { fontFamily: 'Fira Code', themeVariables: { primaryTextColor: '#111111' } }}%%
+bar [1]`)
+
+    expect(processed.lines).toEqual([
+      'xychart',
+      'x-axis [A]',
+      'bar [1]',
+    ])
+    expect(processed.body).not.toContain('%%{')
+    expect(processed.lines).not.toContain('%% regular comment')
+    expect(getFrontmatterScalar<string>(processed.frontmatter, ['theme'])).toBe('base')
+    expect(getFrontmatterScalar<number>(processed.frontmatter, ['xyChart', 'width'])).toBe(640)
+    expect(getFrontmatterScalar<string>(processed.frontmatter, ['fontFamily'])).toBe('Fira Code')
+    expect(getFrontmatterScalar<string>(processed.frontmatter, ['themeVariables', 'primaryTextColor'])).toBe('#111111')
+  })
+})
+
+describe('normalizeMermaidSource', () => {
+  it('merges base config with parsed frontmatter and directive overrides', () => {
+    const normalized = normalizeMermaidSource(`---
+theme: neutral
+xyChart:
+  width: 480
+---
+%%{init: { xyChart: { width: 640 }, themeVariables: { primaryTextColor: '#111111' } }}%%
+xychart
+  x-axis [A]
+  bar [1]`, {
+      fontFamily: 'IBM Plex Sans',
+      xyChart: { width: 320, height: 240 },
+    })
+
+    expect(normalized.text).toBe(`xychart
+x-axis [A]
+bar [1]`)
+    expect(normalized.config.theme).toBe('neutral')
+    expect(normalized.config.fontFamily).toBe('IBM Plex Sans')
+    expect(normalized.config.xyChart).toEqual(expect.objectContaining({
+      width: 640,
+      height: 240,
+    }))
+    expect(normalized.config.themeVariables?.primaryTextColor).toBe('#111111')
+    expect(getFrontmatterMap(normalized.frontmatter, ['xyChart'])).toEqual(expect.objectContaining({
+      width: 640,
+      height: 240,
+    }))
+  })
+})
+
+describe('rendering with Mermaid config source metadata', () => {
+  it('strips frontmatter/init directives before SVG parsing and applies theme config', () => {
+    const svg = renderMermaidSVG(`---
+theme: forest
+---
+%%{init: { fontFamily: 'Fira Code', themeVariables: { primaryTextColor: '#123456' } }}%%
+graph TD
+  A --> B`)
+
+    expect(svg).toContain('<svg')
+    expect(svg).toContain('--bg:#f0fdf4')
+    expect(svg).toContain('--fg:#123456')
+    expect(svg).toContain('Fira%20Code')
+    expect(svg).not.toContain('%%{init')
+  })
+
+  it('strips frontmatter/init directives before ASCII parsing', () => {
+    const ascii = renderMermaidASCII(`---
+theme: dark
+---
+%%{init: { themeVariables: { primaryTextColor: '#ffffff' } }}%%
+graph LR
+  A --> B`)
+
+    expect(ascii).toContain('A')
+    expect(ascii).toContain('B')
+    expect(ascii).toContain('►')
+  })
+})

--- a/src/ascii/index.ts
+++ b/src/ascii/index.ts
@@ -27,6 +27,8 @@ import { renderErAscii } from './er-diagram.ts'
 import { renderXYChartAscii } from './xychart.ts'
 import { detectColorMode, DEFAULT_ASCII_THEME, diagramColorsToAsciiTheme } from './ansi.ts'
 import type { AsciiConfig, AsciiTheme, ColorMode } from './types.ts'
+import { normalizeMermaidSource } from '../mermaid-source.ts'
+import type { MermaidRuntimeConfig } from '../mermaid-source.ts'
 
 // Re-export types for external use
 export type { AsciiTheme, ColorMode }
@@ -54,15 +56,15 @@ export interface AsciiRenderOptions {
   colorMode?: ColorMode | 'auto'
   /** Theme colors for ASCII output. Uses default theme if not provided. */
   theme?: Partial<AsciiTheme>
+  /** Optional Mermaid-style runtime config, merged before frontmatter and init directives. */
+  mermaidConfig?: MermaidRuntimeConfig
 }
 
 /**
  * Detect the diagram type from the mermaid source text.
  * Mirrors the detection logic in src/index.ts for the SVG renderer.
  */
-function detectDiagramType(text: string): 'flowchart' | 'sequence' | 'class' | 'er' | 'xychart' {
-  const firstLine = text.trim().split('\n')[0]?.trim().toLowerCase() ?? ''
-
+function detectDiagramType(firstLine: string): 'flowchart' | 'sequence' | 'class' | 'er' | 'xychart' {
   if (/^xychart(-beta)?\b/.test(firstLine)) return 'xychart'
   if (/^sequencediagram\s*$/.test(firstLine)) return 'sequence'
   if (/^classdiagram\s*$/.test(firstLine)) return 'class'
@@ -117,26 +119,27 @@ export function renderMermaidASCII(
 
   // Merge user theme with defaults
   const theme: AsciiTheme = { ...DEFAULT_ASCII_THEME, ...options.theme }
+  const normalizedSource = normalizeMermaidSource(text, options.mermaidConfig ?? {})
 
-  const diagramType = detectDiagramType(text)
+  const diagramType = detectDiagramType(normalizedSource.firstLine)
 
   switch (diagramType) {
     case 'xychart':
-      return renderXYChartAscii(text, config, colorMode, theme)
+      return renderXYChartAscii(normalizedSource.text, config, colorMode, theme)
 
     case 'sequence':
-      return renderSequenceAscii(text, config, colorMode, theme)
+      return renderSequenceAscii(normalizedSource.text, config, colorMode, theme)
 
     case 'class':
-      return renderClassAscii(text, config, colorMode, theme)
+      return renderClassAscii(normalizedSource.text, config, colorMode, theme)
 
     case 'er':
-      return renderErAscii(text, config, colorMode, theme)
+      return renderErAscii(normalizedSource.text, config, colorMode, theme)
 
     case 'flowchart':
     default: {
       // Flowchart + state diagram pipeline (original)
-      const parsed = parseMermaid(text)
+      const parsed = parseMermaid(normalizedSource.text)
 
       // Normalize direction for grid layout.
       // BT is laid out as TD then flipped vertically after drawing.

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@
 
 export type { RenderOptions, MermaidGraph, PositionedGraph } from './types.ts'
 export type { DiagramColors, ThemeName } from './theme.ts'
+export type { MermaidRuntimeConfig, MermaidThemeVariables } from './mermaid-source.ts'
 export { fromShikiTheme, THEMES, DEFAULTS } from './theme.ts'
 export { parseMermaid } from './parser.ts'
 export { renderMermaidASCII, renderMermaidAscii } from './ascii/index.ts'
@@ -32,7 +33,9 @@ import { layoutGraphSync } from './layout.ts'
 import { renderSvg } from './renderer.ts'
 import type { RenderOptions } from './types.ts'
 import type { DiagramColors } from './theme.ts'
-import { DEFAULTS } from './theme.ts'
+import { DEFAULTS, THEMES } from './theme.ts'
+import { normalizeMermaidSource } from './mermaid-source.ts'
+import type { MermaidRuntimeConfig, MermaidThemeVariables } from './mermaid-source.ts'
 
 import { parseSequenceDiagram } from './sequence/parser.ts'
 import { layoutSequenceDiagram } from './sequence/layout.ts'
@@ -68,16 +71,54 @@ function detectDiagramType(text: string): 'flowchart' | 'sequence' | 'class' | '
  * Uses DEFAULTS for bg/fg when not provided, and passes through
  * optional enrichment colors (line, accent, muted, surface, border).
  */
-function buildColors(options: RenderOptions): DiagramColors {
+const ZINC_DARK = THEMES['zinc-dark'] ?? { bg: '#18181B', fg: '#FAFAFA' }
+
+const MERMAID_THEME_COLORS: Record<string, DiagramColors> = {
+  default: { bg: DEFAULTS.bg, fg: DEFAULTS.fg },
+  base: { bg: DEFAULTS.bg, fg: DEFAULTS.fg },
+  neutral: { bg: '#ffffff', fg: '#1f2937', line: '#9ca3af', accent: '#6b7280', muted: '#6b7280' },
+  dark: {
+    bg: ZINC_DARK.bg,
+    fg: ZINC_DARK.fg,
+    line: ZINC_DARK.line,
+    accent: ZINC_DARK.accent,
+    muted: ZINC_DARK.muted,
+    surface: ZINC_DARK.surface,
+    border: ZINC_DARK.border,
+  },
+  forest: { bg: '#f0fdf4', fg: '#14532d', line: '#4d7c0f', accent: '#15803d', muted: '#65a30d', border: '#86efac' },
+}
+
+function buildColors(options: RenderOptions, config: MermaidRuntimeConfig): DiagramColors {
+  const theme = resolveThemeColors(config.theme)
+  const vars = config.themeVariables
+
   return {
-    bg: options.bg ?? DEFAULTS.bg,
-    fg: options.fg ?? DEFAULTS.fg,
-    line: options.line,
-    accent: options.accent,
-    muted: options.muted,
-    surface: options.surface,
-    border: options.border,
+    bg: options.bg ?? readThemeValue(vars, 'background', 'mainBkg') ?? theme?.bg ?? DEFAULTS.bg,
+    fg: options.fg ?? readThemeValue(vars, 'primaryTextColor', 'textColor', 'nodeTextColor') ?? theme?.fg ?? DEFAULTS.fg,
+    line: options.line ?? readThemeValue(vars, 'lineColor', 'defaultLinkColor') ?? theme?.line,
+    accent: options.accent ?? readThemeValue(vars, 'arrowheadColor', 'primaryColor') ?? theme?.accent,
+    muted: options.muted ?? readThemeValue(vars, 'secondaryTextColor', 'tertiaryTextColor') ?? theme?.muted,
+    surface: options.surface ?? readThemeValue(vars, 'primaryColor', 'nodeBkg', 'mainBkg') ?? theme?.surface,
+    border: options.border ?? readThemeValue(vars, 'primaryBorderColor', 'secondaryBorderColor') ?? theme?.border,
   }
+}
+
+function resolveThemeColors(themeName: string | undefined): DiagramColors | undefined {
+  if (!themeName) return undefined
+  if (themeName in THEMES) return THEMES[themeName as keyof typeof THEMES]
+  return MERMAID_THEME_COLORS[themeName.toLowerCase()]
+}
+
+function readThemeValue(vars: MermaidThemeVariables | undefined, ...keys: string[]): string | undefined {
+  if (!vars) return undefined
+
+  for (const key of keys) {
+    const value = vars[key]
+    if (typeof value === 'string' && value.length > 0) return value
+  }
+
+  return undefined
 }
 
 /**
@@ -115,13 +156,16 @@ export function renderMermaidSVG(
   // Decode XML entities that may leak from markdown parsers (e.g. rehype-raw).
   // Without this, escapeXml() double-encodes them: &lt; → &amp;lt; → literal "&lt;" in SVG.
   text = decodeXML(text)
+  const normalizedSource = normalizeMermaidSource(text, options.mermaidConfig ?? {})
 
-  const colors = buildColors(options)
-  const font = options.font ?? 'Inter'
+  const colors = buildColors(options, normalizedSource.config)
+  const font = options.font
+    ?? normalizedSource.config.fontFamily
+    ?? readThemeValue(normalizedSource.config.themeVariables, 'fontFamily')
+    ?? 'Inter'
   const transparent = options.transparent ?? false
-  const diagramType = detectDiagramType(text)
-
-  const lines = text.split('\n').map(l => l.trim()).filter(l => l.length > 0 && !l.startsWith('%%'))
+  const diagramType = detectDiagramType(normalizedSource.text)
+  const lines = normalizedSource.lines
 
   switch (diagramType) {
     case 'sequence': {
@@ -146,7 +190,7 @@ export function renderMermaidSVG(
     }
     case 'flowchart':
     default: {
-      const graph = parseMermaid(text)
+      const graph = parseMermaid(normalizedSource.text)
       const positioned = layoutGraphSync(graph, options)
       return renderSvg(positioned, colors, font, transparent)
     }

--- a/src/mermaid-source.ts
+++ b/src/mermaid-source.ts
@@ -1,0 +1,489 @@
+// ============================================================================
+// Mermaid source normalization + config extraction
+//
+// Handles:
+//   - UTF-8 BOM stripping
+//   - leading YAML frontmatter
+//   - Mermaid directives / init blocks (%%{init: ...}%%)
+//   - Mermaid comment stripping for downstream line-based parsers
+//   - normalized, trimmed diagram lines for downstream parsers
+// ============================================================================
+
+import YAML from 'yaml'
+
+export type MermaidConfigScalar = string | number | boolean | null
+export type MermaidConfigValue = MermaidConfigScalar | MermaidConfigValue[] | MermaidConfigMap
+
+export interface MermaidConfigMap {
+  [key: string]: MermaidConfigValue | undefined
+}
+
+export type MermaidFrontmatterScalar = MermaidConfigScalar
+export type MermaidFrontmatterValue = MermaidConfigValue
+export type MermaidFrontmatterList = MermaidFrontmatterValue[]
+
+export interface MermaidFrontmatterMap extends MermaidConfigMap {}
+
+export interface MermaidThemeVariables extends MermaidConfigMap {
+  fontFamily?: string
+}
+
+export interface MermaidRuntimeConfig extends MermaidConfigMap {
+  theme?: string
+  fontFamily?: string
+  themeVariables?: MermaidThemeVariables
+  xyChart?: MermaidConfigMap
+  useMaxWidth?: boolean
+  useWidth?: number
+  themeCSS?: string
+}
+
+export interface ProcessedMermaidSource {
+  body: string
+  lines: string[]
+  frontmatter: MermaidFrontmatterMap
+}
+
+export interface NormalizedMermaidSource {
+  text: string
+  lines: string[]
+  firstLine: string
+  config: MermaidRuntimeConfig
+  frontmatter: MermaidFrontmatterMap
+}
+
+const FRONTMATTER_REGEX = /^\uFEFF?\s*---\s*\r?\n([\s\S]*?)\r?\n\s*---\s*(?:\r?\n|$)/
+const INIT_DIRECTIVE_REGEX = /^\s*%%\{\s*(?:init|initialize)\s*:\s*([\s\S]*?)\}\s*%%\s*(?:\r?\n|$)?/gm
+
+export function normalizeMermaidSource(
+  text: string,
+  baseConfig: MermaidRuntimeConfig = {},
+): NormalizedMermaidSource {
+  const processed = preprocessMermaidSource(text, runtimeConfigToFrontmatterMap(baseConfig))
+
+  return {
+    text: processed.lines.join('\n'),
+    lines: processed.lines,
+    firstLine: processed.lines[0]?.toLowerCase() ?? '',
+    config: normalizeMermaidRuntimeConfig(processed.frontmatter),
+    frontmatter: processed.frontmatter,
+  }
+}
+
+export function preprocessMermaidSource(
+  text: string,
+  baseFrontmatter: MermaidFrontmatterMap = {},
+): ProcessedMermaidSource {
+  const frontmatterMatch = text.match(FRONTMATTER_REGEX)
+  const yamlFrontmatter = frontmatterMatch ? canonicalizeFrontmatterMap(parseYamlDocument(frontmatterMatch[1]!)) : {}
+  const rawBody = frontmatterMatch ? text.slice(frontmatterMatch[0].length) : text
+  const { body, frontmatter: directiveFrontmatter } = extractInitDirectives(rawBody)
+  const frontmatter = mergeFrontmatterMaps(
+    mergeFrontmatterMaps(canonicalizeFrontmatterMap(baseFrontmatter), yamlFrontmatter),
+    canonicalizeFrontmatterMap(directiveFrontmatter),
+  )
+
+  return {
+    body,
+    lines: toMermaidLines(body),
+    frontmatter,
+  }
+}
+
+export function toMermaidLines(text: string): string[] {
+  return text
+    .replace(/^\uFEFF/, '')
+    .split(/\r?\n/)
+    .map(line => line.trim())
+    .filter(line => line.length > 0 && !line.startsWith('%%'))
+}
+
+export function mergeMermaidConfigs(...configs: MermaidRuntimeConfig[]): MermaidRuntimeConfig {
+  const merged: MermaidFrontmatterMap = {}
+
+  for (const config of configs) {
+    mergeInto(merged, runtimeConfigToFrontmatterMap(config))
+  }
+
+  return normalizeMermaidRuntimeConfig(merged)
+}
+
+export function mergeFrontmatterMaps(
+  base: MermaidFrontmatterMap,
+  override: MermaidFrontmatterMap,
+): MermaidFrontmatterMap {
+  const merged = cloneFrontmatterMap(base)
+
+  for (const [key, value] of Object.entries(override)) {
+    if (value === undefined) continue
+
+    const existing = merged[key]
+    if (isFrontmatterMap(existing) && isFrontmatterMap(value)) {
+      merged[key] = mergeFrontmatterMaps(existing, value)
+      continue
+    }
+
+    merged[key] = cloneFrontmatterValue(value)
+  }
+
+  return merged
+}
+
+export function getFrontmatterMap(
+  root: MermaidFrontmatterMap,
+  path: readonly string[],
+): MermaidFrontmatterMap | undefined {
+  let current: MermaidFrontmatterValue | undefined = root
+  for (const segment of path) {
+    if (!isFrontmatterMap(current)) return undefined
+    current = current[segment]
+  }
+  return isFrontmatterMap(current) ? current : undefined
+}
+
+export function getFrontmatterScalar<T extends MermaidFrontmatterScalar>(
+  root: MermaidFrontmatterMap,
+  path: readonly string[],
+): T | undefined {
+  let current: MermaidFrontmatterValue | undefined = root
+  for (const segment of path) {
+    if (!isFrontmatterMap(current)) return undefined
+    current = current[segment]
+  }
+  return current !== undefined && !Array.isArray(current) && (typeof current !== 'object' || current === null)
+    ? current as T
+    : undefined
+}
+
+export function getFrontmatterList<T extends MermaidFrontmatterValue = MermaidFrontmatterValue>(
+  root: MermaidFrontmatterMap,
+  path: readonly string[],
+): T[] | undefined {
+  let current: MermaidFrontmatterValue | undefined = root
+  for (const segment of path) {
+    if (!isFrontmatterMap(current)) return undefined
+    current = current[segment]
+  }
+  return Array.isArray(current) ? current as T[] : undefined
+}
+
+function runtimeConfigToFrontmatterMap(config: MermaidRuntimeConfig): MermaidFrontmatterMap {
+  return canonicalizeFrontmatterMap(toFrontmatterMap(config) ?? {})
+}
+
+function normalizeMermaidRuntimeConfig(raw: MermaidFrontmatterMap): MermaidRuntimeConfig {
+  const config = cloneFrontmatterMap(raw) as MermaidRuntimeConfig
+
+  if (isFrontmatterMap(config.themeVariables)) {
+    config.themeVariables = cloneFrontmatterMap(config.themeVariables) as MermaidThemeVariables
+  }
+
+  return config
+}
+
+function mergeInto(target: MermaidFrontmatterMap, source: MermaidFrontmatterMap | undefined): void {
+  if (!source) return
+
+  for (const [key, value] of Object.entries(source)) {
+    if (value === undefined) continue
+
+    if (Array.isArray(value)) {
+      target[key] = value.map(entry => cloneFrontmatterValue(entry)!)
+      continue
+    }
+
+    if (isFrontmatterMap(value)) {
+      const existing = isFrontmatterMap(target[key]) ? target[key] as MermaidFrontmatterMap : {}
+      target[key] = existing
+      mergeInto(existing, value)
+      continue
+    }
+
+    target[key] = value
+  }
+}
+
+function canonicalizeFrontmatterMap(raw: MermaidFrontmatterMap): MermaidFrontmatterMap {
+  const topLevel = cloneFrontmatterMap(raw)
+  const configRoot = isFrontmatterMap(topLevel.config) ? topLevel.config : undefined
+  delete topLevel.config
+
+  return configRoot ? mergeFrontmatterMaps(configRoot, topLevel) : topLevel
+}
+
+function parseYamlDocument(text: string): MermaidFrontmatterMap {
+  try {
+    return toFrontmatterMap(YAML.parse(text)) ?? {}
+  } catch {
+    return {}
+  }
+}
+
+function extractInitDirectives(text: string): { body: string; frontmatter: MermaidFrontmatterMap } {
+  let merged: MermaidFrontmatterMap = {}
+
+  const body = text.replace(INIT_DIRECTIVE_REGEX, (_match, payload: string) => {
+    const parsed = parseDirectiveMap(payload)
+    if (parsed) merged = mergeFrontmatterMaps(merged, canonicalizeFrontmatterMap(parsed))
+    return ''
+  })
+
+  return { body, frontmatter: merged }
+}
+
+function parseDirectiveMap(text: string): MermaidFrontmatterMap | undefined {
+  try {
+    return toFrontmatterMap(YAML.parse(text))
+  } catch {
+    return parseLooseObjectLiteral(text)
+  }
+}
+
+function toFrontmatterMap(value: unknown): MermaidFrontmatterMap | undefined {
+  if (!isPlainObject(value)) return undefined
+
+  const map: MermaidFrontmatterMap = {}
+  for (const [key, entry] of Object.entries(value)) {
+    const parsed = toFrontmatterValue(entry)
+    if (parsed !== undefined) map[key] = parsed
+  }
+  return map
+}
+
+function toFrontmatterValue(value: unknown): MermaidFrontmatterValue | undefined {
+  if (value === null) return null
+  if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') return value
+
+  if (Array.isArray(value)) {
+    const items: MermaidFrontmatterList = []
+    for (const entry of value) {
+      const parsed = toFrontmatterValue(entry)
+      if (parsed === undefined) return undefined
+      items.push(parsed)
+    }
+    return items
+  }
+
+  return toFrontmatterMap(value)
+}
+
+function cloneFrontmatterMap(value: MermaidFrontmatterMap): MermaidFrontmatterMap {
+  const clone: MermaidFrontmatterMap = {}
+  for (const [key, entry] of Object.entries(value)) {
+    clone[key] = cloneFrontmatterValue(entry)
+  }
+  return clone
+}
+
+function cloneFrontmatterValue(value: MermaidFrontmatterValue | undefined): MermaidFrontmatterValue | undefined {
+  if (value === undefined || value === null) return value
+  if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') return value
+  if (Array.isArray(value)) return value.map(entry => cloneFrontmatterValue(entry)!)
+  return cloneFrontmatterMap(value)
+}
+
+function isFrontmatterMap(value: MermaidFrontmatterValue | undefined): value is MermaidFrontmatterMap {
+  return !!value && typeof value === 'object' && !Array.isArray(value)
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value)
+}
+
+function parseScalar(valueText: string): MermaidFrontmatterScalar {
+  if ((valueText.startsWith('"') && valueText.endsWith('"')) || (valueText.startsWith("'") && valueText.endsWith("'"))) {
+    return unescapeQuotedString(valueText)
+  }
+  if (valueText === 'true') return true
+  if (valueText === 'false') return false
+  if (valueText === 'null') return null
+  if (/^[+-]?(?:\d+(?:\.\d+)?|\.\d+)$/.test(valueText)) return Number(valueText)
+  return valueText
+}
+
+function parseLooseObjectLiteral(text: string): MermaidFrontmatterMap | undefined {
+  const parsed = parseFlowValue(text.trim())
+  return isFrontmatterMap(parsed) ? parsed : undefined
+}
+
+function parseFlowValue(text: string): MermaidFrontmatterValue | undefined {
+  const trimmed = text.trim()
+  if (trimmed.length === 0) return undefined
+
+  if (trimmed.startsWith('{') && trimmed.endsWith('}')) {
+    return parseFlowMap(trimmed.slice(1, -1))
+  }
+  if (trimmed.startsWith('[') && trimmed.endsWith(']')) {
+    return parseFlowList(trimmed.slice(1, -1))
+  }
+
+  return parseScalar(trimmed)
+}
+
+function parseFlowMap(text: string): MermaidFrontmatterMap | undefined {
+  const map: MermaidFrontmatterMap = {}
+  for (const entry of splitFlowEntries(text)) {
+    const colonIdx = findSeparatorIndex(entry, ':')
+    if (colonIdx === -1) return undefined
+
+    const rawKey = entry.slice(0, colonIdx).trim()
+    const rawValue = entry.slice(colonIdx + 1).trim()
+    const key = parseFlowKey(rawKey)
+    if (!key) return undefined
+
+    const value = parseFlowValue(rawValue)
+    if (value === undefined) return undefined
+    map[key] = value
+  }
+  return map
+}
+
+function parseFlowList(text: string): MermaidFrontmatterList | undefined {
+  const values: MermaidFrontmatterList = []
+  for (const entry of splitFlowEntries(text)) {
+    const value = parseFlowValue(entry)
+    if (value === undefined) return undefined
+    values.push(value)
+  }
+  return values
+}
+
+function parseFlowKey(text: string): string | undefined {
+  const trimmed = text.trim()
+  if (!trimmed) return undefined
+  if ((trimmed.startsWith('"') && trimmed.endsWith('"')) || (trimmed.startsWith("'") && trimmed.endsWith("'"))) {
+    return unescapeQuotedString(trimmed)
+  }
+  return trimmed
+}
+
+function splitFlowEntries(text: string): string[] {
+  const entries: string[] = []
+  let current = ''
+  let quote: '"' | "'" | null = null
+  let braceDepth = 0
+  let bracketDepth = 0
+
+  for (let i = 0; i < text.length; i++) {
+    const char = text[i]!
+    if (quote) {
+      current += char
+      if (char === quote && text[i - 1] !== '\\') quote = null
+      continue
+    }
+
+    if (char === '"' || char === "'") {
+      quote = char
+      current += char
+      continue
+    }
+    if (char === '{') {
+      braceDepth++
+      current += char
+      continue
+    }
+    if (char === '}') {
+      braceDepth--
+      current += char
+      continue
+    }
+    if (char === '[') {
+      bracketDepth++
+      current += char
+      continue
+    }
+    if (char === ']') {
+      bracketDepth--
+      current += char
+      continue
+    }
+    if (char === ',' && braceDepth === 0 && bracketDepth === 0) {
+      const value = current.trim()
+      if (value) entries.push(value)
+      current = ''
+      continue
+    }
+
+    current += char
+  }
+
+  const trailing = current.trim()
+  if (trailing) entries.push(trailing)
+  return entries
+}
+
+function findSeparatorIndex(text: string, separator: ':' | ','): number {
+  let quote: '"' | "'" | null = null
+  let braceDepth = 0
+  let bracketDepth = 0
+
+  for (let i = 0; i < text.length; i++) {
+    const char = text[i]!
+    if (quote) {
+      if (char === quote && text[i - 1] !== '\\') quote = null
+      continue
+    }
+    if (char === '"' || char === "'") {
+      quote = char
+      continue
+    }
+    if (char === '{') {
+      braceDepth++
+      continue
+    }
+    if (char === '}') {
+      braceDepth--
+      continue
+    }
+    if (char === '[') {
+      bracketDepth++
+      continue
+    }
+    if (char === ']') {
+      bracketDepth--
+      continue
+    }
+    if (char === separator && braceDepth === 0 && bracketDepth === 0) return i
+  }
+
+  return -1
+}
+
+function unescapeQuotedString(valueText: string): string {
+  try {
+    if (valueText.startsWith("'")) {
+      return valueText
+        .slice(1, -1)
+        .replace(/\\\\/g, '\\')
+        .replace(/\\'/g, "'")
+    }
+    return JSON.parse(valueText)
+  } catch {
+    return valueText.slice(1, -1)
+  }
+}
+
+export type RoutedDiagramType = 'flowchart' | 'sequence' | 'class' | 'er' | 'xychart'
+
+/**
+ * Return the logical Mermaid lines after frontmatter/init/comment normalization.
+ * This is a thin wrapper around the richer source preprocessing used by the
+ * public SVG and ASCII entry points.
+ */
+export function preprocessMermaidLines(text: string): string[] {
+  return preprocessMermaidSource(text).lines
+}
+
+/**
+ * Detect the routed Mermaid diagram family from the first logical line.
+ */
+export function detectDiagramType(text: string): RoutedDiagramType {
+  const firstLine = preprocessMermaidLines(text)[0]?.split(';')[0]?.trim().toLowerCase() ?? ''
+
+  if (/^xychart(-beta)?\b/.test(firstLine)) return 'xychart'
+  if (/^sequencediagram\s*$/.test(firstLine)) return 'sequence'
+  if (/^classdiagram\s*$/.test(firstLine)) return 'class'
+  if (/^erdiagram\s*$/.test(firstLine)) return 'er'
+
+  return 'flowchart'
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+import type { MermaidRuntimeConfig } from './mermaid-source.ts'
+
 // ============================================================================
 // Parsed graph — logical structure extracted from Mermaid text
 // ============================================================================
@@ -161,4 +163,6 @@ export interface RenderOptions {
   transparent?: boolean
   /** Enable hover tooltips on chart data points (xychart only). Default: false */
   interactive?: boolean
+  /** Optional Mermaid-style runtime config, merged before frontmatter and init directives. */
+  mermaidConfig?: MermaidRuntimeConfig
 }


### PR DESCRIPTION
## What

Adds Mermaid-style source config support for existing render entry points:

- YAML frontmatter at the top of a diagram
- `%%{init: ...}%%` and `%%{initialize: ...}%%` directives
- optional `mermaidConfig` render option as a base config

Closes #79.

## Why

Mermaid diagrams can include config metadata before the diagram header. Today that metadata is passed to diagram parsers as if it were diagram syntax, so configured diagrams either fail parsing or ignore theme/font config.

## How

- Added a small source-normalization module that:
  - strips UTF-8 BOMs, frontmatter, init directives, and Mermaid comments
  - parses YAML frontmatter with `yaml`
  - parses Mermaid init payloads, including loose object-literal style payloads
  - merges config in precedence order: render option `mermaidConfig` → YAML frontmatter → init directives
- Routed SVG and ASCII rendering through normalized source before diagram dispatch.
- Applied supported Mermaid theme/font config to SVG color/font selection while preserving explicit render options.
- Documented the behavior and public option.

## Testing

- Added `src/__tests__/mermaid-source.test.ts` covering YAML parsing, init directive parsing, merge precedence, SVG routing, ASCII routing, and config-derived theme/font output.
- These rendering tests fail on upstream `main` because frontmatter/init directives reach the parser instead of being stripped.
- Ran:
  - `bun test src/__tests__/mermaid-source.test.ts --timeout 120000`
  - `bun test src/__tests__/ --timeout 120000`
  - `bun run build`

## Risk

Low. Existing diagrams without frontmatter normalize to the same logical source. Explicit render options still override config-derived colors/fonts, so existing callers keep control.