### PR TITLE
Add timeline diagram rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The ASCII rendering engine is based on [mermaid-ascii](https://github.com/Alexan
 
 ## Features
 
-- **6 diagram types** — Flowcharts, State, Sequence, Class, ER, and XY Charts (bar, line, combined)
+- **7 diagram types** — Flowcharts, State, Sequence, Class, ER, Timeline, and XY Charts (bar, line, combined)
 - **Dual output** — SVG for rich UIs, ASCII/Unicode for terminals
 - **Synchronous rendering** — No async, no flash. Works with React `useMemo()`
 - **15 built-in themes** — And dead simple to add your own
@@ -364,6 +364,23 @@ Index-specific styles override the default. Supported properties: `stroke`, `str
 
 Works in both flowcharts and state diagrams.
 
+### Timeline Diagrams
+
+Chronological milestones using Mermaid's `timeline` syntax.
+
+```
+timeline
+  title Product roadmap
+  section Foundation
+  2024 : Private alpha
+       : Public beta
+  section Growth
+  2025 : Timeline support
+       : Documentation polish
+```
+
+Timeline diagrams render to both SVG and ASCII/Unicode output, support sections, multiple events per period, continuation lines, multiline labels, and Mermaid accessibility metadata (`accTitle` / `accDescr`).
+
 ### XY Charts
 
 Bar charts, line charts, and combinations — using Mermaid's `xychart-beta` syntax.
@@ -518,6 +535,8 @@ Render a Mermaid diagram to SVG. Synchronous. Auto-detects diagram type.
 | `componentSpacing` | `number` | `24` | Spacing between disconnected components |
 | `thoroughness` | `number` | `3` | Crossing minimization trials (1-7, higher = better but slower) |
 | `interactive` | `boolean` | `false` | Enable hover tooltips on XY chart bars and data points |
+
+**Timeline diagrams:** Diagrams starting with `timeline` are auto-detected and render to SVG or ASCII.
 
 **XY Charts:** Diagrams starting with `xychart-beta` are auto-detected — no separate function needed. The `accent` color option drives the chart series color palette.
 

--- a/src/__tests__/timeline-ascii.test.ts
+++ b/src/__tests__/timeline-ascii.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Tests for timeline ASCII rendering.
+ */
+import { describe, it, expect } from 'bun:test'
+import { renderMermaidASCII } from '../ascii/index.ts'
+
+function render(text: string, options: Parameters<typeof renderMermaidASCII>[1] = {}): string {
+  return renderMermaidASCII(text, { colorMode: 'none', ...options })
+}
+
+describe('timeline ASCII', () => {
+  it('renders a basic timeline with title, period, and event', () => {
+    const result = render(`timeline
+      title Product history
+      2024 : Timeline support`)
+
+    expect(result).toContain('Product history')
+    expect(result).toContain('○ 2024')
+    expect(result).toContain('└─ Timeline support')
+  })
+
+  it('renders section labels and multiple events', () => {
+    const result = render(`timeline
+      section Growth
+      2023 : Public launch
+           : Theme system`)
+
+    expect(result).toContain('[Growth]')
+    expect(result).toContain('○ 2023')
+    expect(result).toContain('├─ Public launch')
+    expect(result).toContain('└─ Theme system')
+  })
+
+  it('uses ASCII-safe glyphs in ASCII mode', () => {
+    const result = render(`timeline
+      2024 : Timeline support`, { useAscii: true })
+
+    expect(result).toContain('o 2024')
+    expect(result).toContain('`- Timeline support')
+    expect(result).not.toContain('○')
+    expect(result).not.toContain('└')
+  })
+
+  it('renders multiline event text on subsequent indented lines', () => {
+    const result = render(`timeline
+      2024 : Soft<br>launch`)
+
+    expect(result).toContain('Soft')
+    expect(result).toContain('launch')
+  })
+
+  it('supports themed HTML output and escapes labels safely', () => {
+    const result = render(`timeline
+      title Roadmap < 2025
+      section Phase <1>
+      2024 : Ship <alpha>`, {
+      colorMode: 'html',
+      theme: {
+        fg: '#101010',
+        border: '#202020',
+        line: '#303030',
+        arrow: '#404040',
+        junction: '#505050',
+        corner: '#606060',
+      },
+    })
+
+    expect(result).toContain('<span style="color:#101010">Roadmap</span>')
+    expect(result).toContain('<span style="color:#101010">&lt;</span>')
+    expect(result).toContain('<span style="color:#202020">[</span>')
+    expect(result).toContain('<span style="color:#101010">Phase</span>')
+    expect(result).toContain('<span style="color:#202020">]</span>')
+    expect(result).toContain('<span style="color:#505050">○</span>')
+    expect(result).toContain('<span style="color:#303030">│</span>')
+    expect(result).toContain('<span style="color:#101010">Ship</span>')
+    expect(result).toContain('<span style="color:#101010">&lt;alpha&gt;</span>')
+    expect(result).not.toContain('Ship <alpha>')
+  })
+
+  it('does not render accessibility metadata as visible timeline content', () => {
+    const result = render(`timeline
+      accTitle: Accessible roadmap
+      accDescr: Product launch plan
+      2024 : Private alpha`)
+
+    expect(result).toContain('○ 2024')
+    expect(result).toContain('Private alpha')
+    expect(result).not.toContain('Accessible roadmap')
+    expect(result).not.toContain('Product launch plan')
+  })
+})

--- a/src/__tests__/timeline-integration.test.ts
+++ b/src/__tests__/timeline-integration.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Integration tests for timeline diagrams — end-to-end parse → layout → render.
+ */
+import { describe, it, expect } from 'bun:test'
+import { renderMermaidSVG } from '../index.ts'
+import type { RenderOptions } from '../types.ts'
+
+function render(text: string, options: RenderOptions = {}): string {
+  return renderMermaidSVG(text, options)
+}
+
+const MERMAID_DOCS_SOCIAL_TIMELINE = `timeline
+  title History of Social Media Platform
+  2002 : LinkedIn
+  2004 : Facebook : Google
+  2005 : YouTube
+  2006 : Twitter`
+
+describe('renderMermaidSVG – timeline diagrams', () => {
+  it('renders a basic timeline to valid SVG', () => {
+    const svg = render(`timeline
+      title Product history
+      2022 : Private alpha
+      2023 : Public launch`)
+
+    expect(svg).toContain('<svg')
+    expect(svg).toContain('</svg>')
+    expect(svg).toContain('Product history')
+    expect(svg).toContain('class="timeline-rail"')
+    expect(svg).toContain('class="timeline-period"')
+    expect(svg).toContain('class="timeline-event"')
+  })
+
+  it('renders section frames and semantic data attributes', () => {
+    const svg = render(`timeline
+      title Beautiful Mermaid
+      section Foundation
+      2020 : Prototype
+      section Growth
+      2021 : Launch`)
+
+    expect(svg).toContain('class="timeline-section"')
+    expect(svg).toContain('data-label="Foundation"')
+    expect(svg).toContain('data-section="Foundation" data-family="0"')
+    expect(svg).toContain('data-section="Growth"')
+    expect(svg).toContain('data-section="Growth" data-family="1"')
+    expect(svg).toContain('Prototype')
+    expect(svg).toContain('Launch')
+  })
+
+  it('renders Mermaid docs social media example with distinct unsectioned color families', () => {
+    const svg = render(MERMAID_DOCS_SOCIAL_TIMELINE)
+    const periodCount = (svg.match(/class="timeline-period"/g) ?? []).length
+    const eventCount = (svg.match(/class="timeline-event"/g) ?? []).length
+    const familyIds = [...svg.matchAll(/class="timeline-period"[\s\S]*?data-family="(\d+)"/g)].map(match => match[1])
+
+    expect(svg).toContain('History of Social Media Platform')
+    expect(svg).toContain('LinkedIn')
+    expect(svg).toContain('Facebook')
+    expect(svg).toContain('Google')
+    expect(svg).toContain('YouTube')
+    expect(svg).toContain('Twitter')
+    expect(periodCount).toBe(4)
+    expect(eventCount).toBe(5)
+    expect(familyIds).toEqual(['0', '1', '2', '3'])
+  })
+
+  it('renders multiple events for a single period', () => {
+    const svg = render(`timeline
+      2024 : Design refresh
+           : Timeline support
+           : Packaging polish`)
+
+    const eventCount = (svg.match(/class="timeline-event"/g) ?? []).length
+    expect(eventCount).toBe(3)
+    expect(svg).toContain('data-period="2024"')
+    expect(svg).toContain('Timeline support')
+  })
+
+  it('renders multiline labels with tspans', () => {
+    const svg = render(`timeline
+      title Product<br>history
+      section Platform<br>work
+      2024<br>Q1 : Soft<br>launch`)
+
+    expect(svg).toContain('<tspan')
+    expect(svg).toContain('Product')
+    expect(svg).toContain('history')
+    expect(svg).toContain('Soft')
+    expect(svg).toContain('launch')
+  })
+
+  it('supports dark themes and CSS variable colors without NaN output', () => {
+    const svg = render(`timeline
+      2024 : Timeline support`, {
+      bg: 'var(--background)',
+      fg: 'var(--foreground)',
+      accent: 'var(--accent)',
+    })
+
+    expect(svg).toContain('--bg:var(--background)')
+    expect(svg).toContain('--fg:var(--foreground)')
+    expect(svg).not.toContain('NaN')
+  })
+
+  it('renders accessibility metadata on the root SVG instead of as timeline content', () => {
+    const svg = render(`timeline
+      accTitle: Accessible roadmap
+      accDescr: Product launch plan
+      2024 : Private alpha`)
+
+    expect(svg).toContain('role="img"')
+    expect(svg).toContain('aria-labelledby="tl-')
+    expect(svg).toContain('aria-describedby="tl-')
+    expect(svg).toContain('Accessible roadmap</title>')
+    expect(svg).toContain('Product launch plan</desc>')
+    expect(svg).not.toContain('data-label="accTitle"')
+  })
+
+  it('wraps long labels automatically without explicit <br> tags', () => {
+    const svg = render(`timeline
+      2024 : This is a deliberately long event label that should wrap across multiple lines to match Mermaid timeline behavior more closely`)
+
+    expect(svg).toContain('<tspan')
+    expect(svg).toContain('This is a deliberately long')
+    expect(svg).toContain('match Mermaid timeline')
+  })
+})

--- a/src/__tests__/timeline-layout.test.ts
+++ b/src/__tests__/timeline-layout.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Layout tests for timeline diagrams — verify spacing, bounds, and section framing.
+ */
+import { describe, it, expect } from 'bun:test'
+import { parseTimelineDiagram } from '../timeline/parser.ts'
+import { layoutTimelineDiagram } from '../timeline/layout.ts'
+
+function layout(source: string) {
+  const lines = source.split('\n').map(line => line.trim()).filter(Boolean)
+  return layoutTimelineDiagram(parseTimelineDiagram(lines))
+}
+
+describe('timeline layout', () => {
+  it('extends the rail beyond a single period marker and keeps the event below it', () => {
+    const diagram = layout(`timeline
+      2024 : Launch`)
+    const section = diagram.sections[0]!
+    const period = section.periods[0]!
+    const event = period.events[0]!
+
+    expect(diagram.rail.x1).toBeLessThan(period.centerX)
+    expect(diagram.rail.x2).toBeGreaterThan(period.centerX)
+    expect(period.pillX + period.pillWidth / 2).toBe(period.centerX)
+    expect(period.stemBottomY).toBeLessThan(event.y)
+    expect(event.y + event.height).toBeLessThanOrEqual(section.y + section.height)
+  })
+
+  it('keeps period columns in order without overlapping event cards', () => {
+    const diagram = layout(`timeline
+      2022 : Alpha
+      2023 : Beta release
+      2024 : General availability`)
+    const periods = diagram.sections[0]!.periods
+
+    expect(periods).toHaveLength(3)
+    expect(periods[0]!.centerX).toBeLessThan(periods[1]!.centerX)
+    expect(periods[1]!.centerX).toBeLessThan(periods[2]!.centerX)
+
+    const firstEvent = periods[0]!.events[0]!
+    const secondEvent = periods[1]!.events[0]!
+    const thirdEvent = periods[2]!.events[0]!
+
+    expect(firstEvent.x + firstEvent.width).toBeLessThan(secondEvent.x)
+    expect(secondEvent.x + secondEvent.width).toBeLessThan(thirdEvent.x)
+  })
+
+  it('adds framed section bounds and header space for named sections', () => {
+    const diagram = layout(`timeline
+      title Delivery plan
+      section Foundation
+      2023 : Prototype
+      section Launch
+      2024 : GA`)
+    const firstSection = diagram.sections[0]!
+    const secondSection = diagram.sections[1]!
+
+    expect(firstSection.framed).toBe(true)
+    expect(firstSection.headerHeight).toBeGreaterThan(0)
+    expect(secondSection.headerHeight).toBeGreaterThan(0)
+    expect(firstSection.x + firstSection.width).toBeLessThan(secondSection.x)
+    expect(firstSection.periods[0]!.centerX).toBeGreaterThan(firstSection.x)
+    expect(firstSection.periods[0]!.centerX).toBeLessThan(firstSection.x + firstSection.width)
+    expect(secondSection.periods[0]!.centerX).toBeGreaterThan(secondSection.x)
+    expect(secondSection.periods[0]!.centerX).toBeLessThan(secondSection.x + secondSection.width)
+    expect(diagram.title!.y).toBeLessThan(firstSection.y + firstSection.headerHeight)
+  })
+
+  it('wraps long labels instead of letting a single event force unbounded width', () => {
+    const diagram = layout(`timeline
+      2024 : This is a deliberately long event label that should wrap onto multiple lines in the positioned timeline output`)
+    const period = diagram.sections[0]!.periods[0]!
+    const event = period.events[0]!
+
+    expect(period.label).toBe('2024')
+    expect(event.text).toContain('\n')
+    expect(event.width).toBeLessThan(220)
+  })
+
+  it('carries accessibility metadata through layout for the renderer', () => {
+    const diagram = layout(`timeline
+      accTitle: Accessible roadmap
+      accDescr: Public milestones
+      2024 : Launch`)
+
+    expect(diagram.accessibilityTitle).toBe('Accessible roadmap')
+    expect(diagram.accessibilityDescription).toBe('Public milestones')
+  })
+})

--- a/src/__tests__/timeline-parser.test.ts
+++ b/src/__tests__/timeline-parser.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Tests for the timeline diagram parser.
+ *
+ * Covers: title, sections, implicit sections, multi-event periods,
+ * continuation lines, and error cases.
+ */
+import { describe, it, expect } from 'bun:test'
+import { parseTimelineDiagram } from '../timeline/parser.ts'
+
+function parse(text: string) {
+  return parseTimelineDiagram(text.split('\n').map(line => line.trim()).filter(Boolean))
+}
+
+describe('parseTimelineDiagram', () => {
+  it('parses a basic timeline with a title', () => {
+    const diagram = parse(`timeline
+      title Product history
+      2022 : Private alpha
+      2023 : Public launch`)
+
+    expect(diagram.title).toBe('Product history')
+    expect(diagram.sections).toHaveLength(1)
+    expect(diagram.sections[0]!.periods).toHaveLength(2)
+    expect(diagram.sections[0]!.periods[0]!.label).toBe('2022')
+    expect(diagram.sections[0]!.periods[0]!.events[0]!.text).toBe('Private alpha')
+  })
+
+  it('parses named sections in order', () => {
+    const diagram = parse(`timeline
+      section Foundation
+      2020 : Prototype
+      2021 : Beta
+      section Growth
+      2022 : Launch`)
+
+    expect(diagram.sections).toHaveLength(2)
+    expect(diagram.sections[0]!.label).toBe('Foundation')
+    expect(diagram.sections[1]!.label).toBe('Growth')
+    expect(diagram.sections[1]!.periods[0]!.label).toBe('2022')
+  })
+
+  it('creates an implicit section for periods before the first section', () => {
+    const diagram = parse(`timeline
+      2021 : Quiet alpha
+      section Public
+      2022 : Launch`)
+
+    expect(diagram.sections).toHaveLength(2)
+    expect(diagram.sections[0]!.label).toBeUndefined()
+    expect(diagram.sections[0]!.periods[0]!.label).toBe('2021')
+    expect(diagram.sections[1]!.label).toBe('Public')
+  })
+
+  it('parses multiple events on a single period line', () => {
+    const diagram = parse(`timeline
+      2024 : Design refresh : Timeline support`)
+
+    expect(diagram.sections[0]!.periods[0]!.events.map(event => event.text)).toEqual([
+      'Design refresh',
+      'Timeline support',
+    ])
+  })
+
+  it('parses continuation lines onto the previous period', () => {
+    const diagram = parse(`timeline
+      2024 : Design refresh
+           : Timeline support
+           : Craft polish`)
+
+    expect(diagram.sections[0]!.periods[0]!.events.map(event => event.text)).toEqual([
+      'Design refresh',
+      'Timeline support',
+      'Craft polish',
+    ])
+  })
+
+  it('normalizes <br> tags in title, section labels, periods, and events', () => {
+    const diagram = parse(`timeline
+      title Platform<br>History
+      section Product<br>Work
+      2024<br>Q1 : Soft<br>launch`)
+
+    expect(diagram.title).toBe('Platform\nHistory')
+    expect(diagram.sections[0]!.label).toBe('Product\nWork')
+    expect(diagram.sections[0]!.periods[0]!.label).toBe('2024\nQ1')
+    expect(diagram.sections[0]!.periods[0]!.events[0]!.text).toBe('Soft\nlaunch')
+  })
+
+
+  it('parses accessibility metadata without turning it into timeline content', () => {
+    const diagram = parse(`timeline
+      accTitle: Accessible roadmap
+      accDescr: Product launch plan
+      2024 : Private alpha`)
+
+    expect(diagram.accessibilityTitle).toBe('Accessible roadmap')
+    expect(diagram.accessibilityDescription).toBe('Product launch plan')
+    expect(diagram.sections[0]!.periods[0]!.label).toBe('2024')
+  })
+
+  it('parses multiline accDescr blocks', () => {
+    const diagram = parse(`timeline
+      accDescr {
+      First line
+      Second line
+      }
+      2024 : Launch`)
+
+    expect(diagram.accessibilityDescription).toBe('First line\nSecond line')
+  })
+
+  it('preserves colons inside event text when they are not event separators', () => {
+    const diagram = parse(`timeline
+      2024 : 10:30 launch : api:v2`)
+
+    expect(diagram.sections[0]!.periods[0]!.events.map(event => event.text)).toEqual([
+      '10:30 launch',
+      'api:v2',
+    ])
+  })
+
+  it('ignores hash-style comment lines supported by Mermaid timeline syntax', () => {
+    const diagram = parse(`timeline
+      # release milestones
+      2024 : Launch`)
+
+    expect(diagram.sections[0]!.periods[0]!.label).toBe('2024')
+  })
+
+  it('throws when a continuation appears before any period', () => {
+    expect(() => parse(`timeline
+      : orphaned event`)).toThrow('Timeline continuation found before any period was declared')
+  })
+
+  it('throws on unsupported timeline syntax instead of silently ignoring it', () => {
+    expect(() => parse(`timeline
+      release now`)).toThrow('Unsupported timeline syntax: "release now"')
+  })
+
+  it('throws when the diagram has no periods', () => {
+    expect(() => parse(`timeline
+      title Empty`)).toThrow('Timeline diagram must include at least one period with events')
+  })
+})

--- a/src/ascii/index.ts
+++ b/src/ascii/index.ts
@@ -10,6 +10,7 @@
 //   - Sequence diagrams (sequenceDiagram) — column-based timeline layout
 //   - Class diagrams (classDiagram) — level-based UML layout
 //   - ER diagrams (erDiagram) — grid layout with crow's foot notation
+//   - Timeline diagrams (timeline) — chronological outline with grouped milestones
 //
 // Usage:
 //   import { renderMermaidASCII } from 'beautiful-mermaid'
@@ -24,6 +25,7 @@ import { canvasToString, flipCanvasVertically, flipRoleCanvasVertically } from '
 import { renderSequenceAscii } from './sequence.ts'
 import { renderClassAscii } from './class-diagram.ts'
 import { renderErAscii } from './er-diagram.ts'
+import { renderTimelineAscii } from './timeline.ts'
 import { renderXYChartAscii } from './xychart.ts'
 import { detectColorMode, DEFAULT_ASCII_THEME, diagramColorsToAsciiTheme } from './ansi.ts'
 import type { AsciiConfig, AsciiTheme, ColorMode } from './types.ts'
@@ -60,10 +62,11 @@ export interface AsciiRenderOptions {
  * Detect the diagram type from the mermaid source text.
  * Mirrors the detection logic in src/index.ts for the SVG renderer.
  */
-function detectDiagramType(text: string): 'flowchart' | 'sequence' | 'class' | 'er' | 'xychart' {
+function detectDiagramType(text: string): 'flowchart' | 'sequence' | 'class' | 'er' | 'timeline' | 'xychart' {
   const firstLine = text.trim().split('\n')[0]?.trim().toLowerCase() ?? ''
 
   if (/^xychart(-beta)?\b/.test(firstLine)) return 'xychart'
+  if (/^timeline\s*$/.test(firstLine)) return 'timeline'
   if (/^sequencediagram\s*$/.test(firstLine)) return 'sequence'
   if (/^classdiagram\s*$/.test(firstLine)) return 'class'
   if (/^erdiagram\s*$/.test(firstLine)) return 'er'
@@ -132,6 +135,11 @@ export function renderMermaidASCII(
 
     case 'er':
       return renderErAscii(text, config, colorMode, theme)
+
+    case 'timeline': {
+      const lines = text.split('\n').map(l => l.trim()).filter(l => l.length > 0 && !l.startsWith('%%'))
+      return renderTimelineAscii(lines, config, colorMode, theme)
+    }
 
     case 'flowchart':
     default: {

--- a/src/ascii/timeline.ts
+++ b/src/ascii/timeline.ts
@@ -1,0 +1,128 @@
+// ============================================================================
+// ASCII renderer — timeline diagrams
+//
+// Renders Mermaid timeline syntax as a chronological outline with per-period
+// markers and indented milestone lists. This keeps the ASCII variant compact
+// and readable in terminals while preserving chronology and section grouping.
+// ============================================================================
+
+import { parseTimelineDiagram } from '../timeline/parser.ts'
+import { colorizeLine, DEFAULT_ASCII_THEME } from './ansi.ts'
+import type { AsciiConfig, AsciiTheme, CharRole, ColorMode } from './types.ts'
+
+interface StyledSegment {
+  text: string
+  role: CharRole | null
+}
+
+function renderStyledLine(
+  segments: StyledSegment[],
+  colorMode: ColorMode,
+  theme: AsciiTheme,
+): string {
+  const chars: string[] = []
+  const roles: (CharRole | null)[] = []
+
+  for (const segment of segments) {
+    for (const char of segment.text) {
+      chars.push(char)
+      roles.push(segment.role)
+    }
+  }
+
+  return colorizeLine(chars, roles, theme, colorMode)
+}
+
+/**
+ * Render a Mermaid timeline diagram to ASCII/Unicode text.
+ */
+export function renderTimelineAscii(
+  lines: string[],
+  config: AsciiConfig,
+  colorMode: ColorMode = 'none',
+  theme: AsciiTheme = DEFAULT_ASCII_THEME,
+): string {
+  const diagram = parseTimelineDiagram(lines)
+  const useAscii = config.useAscii
+
+  const marker = useAscii ? 'o' : '○'
+  const vertical = useAscii ? '|' : '│'
+  const branch = useAscii ? '|' : '├'
+  const lastBranch = useAscii ? '`' : '└'
+  const horizontal = useAscii ? '-' : '─'
+  const periodContinuation = '  '
+
+  const out: string[] = []
+  const pushLine = (segments: StyledSegment[] = []): void => {
+    out.push(segments.length === 0 ? '' : renderStyledLine(segments, colorMode, theme))
+  }
+
+  if (diagram.title) {
+    for (const line of diagram.title.split('\n')) {
+      pushLine([{ text: line, role: 'text' }])
+    }
+    pushLine()
+  }
+
+  for (let sectionIndex = 0; sectionIndex < diagram.sections.length; sectionIndex++) {
+    const section = diagram.sections[sectionIndex]!
+
+    if (section.label) {
+      pushLine([
+        { text: '[', role: 'border' },
+        { text: section.label.replace(/\n/g, ' / '), role: 'text' },
+        { text: ']', role: 'border' },
+      ])
+    }
+
+    for (let periodIndex = 0; periodIndex < section.periods.length; periodIndex++) {
+      const period = section.periods[periodIndex]!
+      const periodLines = period.label.split('\n')
+
+      pushLine([
+        { text: marker, role: 'junction' },
+        { text: ' ', role: null },
+        { text: periodLines[0] ?? '', role: 'text' },
+      ])
+      for (const line of periodLines.slice(1)) {
+        pushLine([
+          { text: `${periodContinuation} `, role: null },
+          { text: line, role: 'text' },
+        ])
+      }
+
+      for (let eventIndex = 0; eventIndex < period.events.length; eventIndex++) {
+        const event = period.events[eventIndex]!
+        const eventLines = event.text.split('\n')
+        const junction = eventIndex === period.events.length - 1 ? lastBranch : branch
+        pushLine([
+          { text: vertical, role: 'line' },
+          { text: '  ', role: null },
+          { text: junction, role: eventIndex === period.events.length - 1 ? 'corner' : 'junction' },
+          { text: horizontal, role: 'line' },
+          { text: ' ', role: null },
+          { text: eventLines[0] ?? '', role: 'text' },
+        ])
+
+        for (const line of eventLines.slice(1)) {
+          pushLine(eventIndex === period.events.length - 1
+            ? [
+                { text: '    ', role: null },
+                { text: line, role: 'text' },
+              ]
+            : [
+                { text: vertical, role: 'line' },
+                { text: '   ', role: null },
+                { text: line, role: 'text' },
+              ])
+        }
+      }
+
+      const morePeriods = periodIndex < section.periods.length - 1
+      const moreSections = sectionIndex < diagram.sections.length - 1
+      if (morePeriods || moreSections) pushLine()
+    }
+  }
+
+  return out.join('\n').trimEnd()
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@
 //   - Sequence diagrams (sequenceDiagram)
 //   - Class diagrams (classDiagram)
 //   - ER diagrams (erDiagram)
+//   - Timeline diagrams (timeline)
 //
 // Theming uses CSS custom properties (--bg, --fg, + optional enrichment).
 // See src/theme.ts for the full variable system.
@@ -43,6 +44,9 @@ import { renderClassSvg } from './class/renderer.ts'
 import { parseErDiagram } from './er/parser.ts'
 import { layoutErDiagramSync } from './er/layout.ts'
 import { renderErSvg } from './er/renderer.ts'
+import { parseTimelineDiagram } from './timeline/parser.ts'
+import { layoutTimelineDiagram } from './timeline/layout.ts'
+import { renderTimelineSvg } from './timeline/renderer.ts'
 import { parseXYChart } from './xychart/parser.ts'
 import { layoutXYChart } from './xychart/layout.ts'
 import { renderXYChartSvg } from './xychart/renderer.ts'
@@ -51,10 +55,11 @@ import { renderXYChartSvg } from './xychart/renderer.ts'
  * Detect the diagram type from the mermaid source text.
  * Returns the type keyword used for routing to the correct pipeline.
  */
-function detectDiagramType(text: string): 'flowchart' | 'sequence' | 'class' | 'er' | 'xychart' {
+function detectDiagramType(text: string): 'flowchart' | 'sequence' | 'class' | 'er' | 'timeline' | 'xychart' {
   const firstLine = text.trim().split(/[\n;]/)[0]?.trim().toLowerCase() ?? ''
 
   if (/^xychart(-beta)?\b/.test(firstLine)) return 'xychart'
+  if (/^timeline\s*$/.test(firstLine)) return 'timeline'
   if (/^sequencediagram\s*$/.test(firstLine)) return 'sequence'
   if (/^classdiagram\s*$/.test(firstLine)) return 'class'
   if (/^erdiagram\s*$/.test(firstLine)) return 'er'
@@ -138,6 +143,11 @@ export function renderMermaidSVG(
       const diagram = parseErDiagram(lines)
       const positioned = layoutErDiagramSync(diagram, options)
       return renderErSvg(positioned, colors, font, transparent)
+    }
+    case 'timeline': {
+      const diagram = parseTimelineDiagram(lines)
+      const positioned = layoutTimelineDiagram(diagram, options)
+      return renderTimelineSvg(positioned, colors, font, transparent)
     }
     case 'xychart': {
       const chart = parseXYChart(lines)

--- a/src/timeline/layout.ts
+++ b/src/timeline/layout.ts
@@ -1,0 +1,358 @@
+import type {
+  TimelineDiagram,
+  PositionedTimelineDiagram,
+  PositionedTimelineSection,
+  PositionedTimelinePeriod,
+  PositionedTimelineEvent,
+} from './types.ts'
+import type { RenderOptions } from '../types.ts'
+import { measureMultilineText, measureTextWidth } from '../text-metrics.ts'
+import { stripFormattingTags } from '../multiline-utils.ts'
+
+// ============================================================================
+// Timeline diagram layout engine
+//
+// Computes direct coordinates for a horizontal timeline with:
+//   - optional section frames
+//   - period pills above the rail
+//   - stacked event cards below the rail
+// ============================================================================
+
+const TL = {
+  paddingX: 32,
+  paddingY: 28,
+  titleFontSize: 18,
+  titleFontWeight: 600,
+  titleGap: 24,
+  titleWrapWidth: 420,
+  sectionHeaderHeight: 24,
+  sectionFontSize: 12,
+  sectionFontWeight: 600,
+  sectionHeaderPadX: 12,
+  sectionHeaderGap: 14,
+  sectionWrapWidth: 168,
+  sectionPadX: 18,
+  sectionPadBottom: 18,
+  sectionGap: 28,
+  columnGap: 24,
+  pillFontSize: 12,
+  pillFontWeight: 600,
+  pillWrapWidth: 116,
+  pillPadX: 12,
+  pillPadY: 8,
+  pillMinWidth: 72,
+  railToPillGap: 22,
+  railToEventsGap: 28,
+  markerRadius: 8,
+  eventFontSize: 12,
+  eventFontWeight: 400,
+  eventWrapWidth: 148,
+  eventPadX: 14,
+  eventPadY: 10,
+  eventMinWidth: 128,
+  eventGap: 10,
+} as const
+
+interface PeriodMetric {
+  label: string
+  pillWidth: number
+  pillHeight: number
+  columnWidth: number
+  stackHeight: number
+  events: Array<{ text: string; width: number; height: number }>
+}
+
+interface SectionMetric {
+  label?: string
+  headerWidth: number
+  innerWidth: number
+  columnAreaWidth: number
+  periods: PeriodMetric[]
+  maxStackHeight: number
+}
+
+/**
+ * Lay out a parsed timeline diagram.
+ */
+export function layoutTimelineDiagram(
+  diagram: TimelineDiagram,
+  _options: RenderOptions = {}
+): PositionedTimelineDiagram {
+  const hasNamedSections = diagram.sections.some(section => !!section.label)
+  const showSectionFrames = diagram.sections.length > 1 || hasNamedSections
+  const sectionHeaderHeight = hasNamedSections ? TL.sectionHeaderHeight : 0
+  const sectionPadX = showSectionFrames ? TL.sectionPadX : 0
+  const titleText = diagram.title
+    ? wrapTimelineText(diagram.title, TL.titleWrapWidth, TL.titleFontSize, TL.titleFontWeight)
+    : undefined
+
+  const titleMetrics = titleText
+    ? measureMultilineText(titleText, TL.titleFontSize, TL.titleFontWeight)
+    : undefined
+
+  const metrics: SectionMetric[] = diagram.sections.map(section => {
+    const wrappedSectionLabel = section.label
+      ? wrapTimelineText(section.label, TL.sectionWrapWidth, TL.sectionFontSize, TL.sectionFontWeight)
+      : undefined
+    const periodMetrics: PeriodMetric[] = section.periods.map(period => {
+      const wrappedPeriodLabel = wrapTimelineText(period.label, TL.pillWrapWidth, TL.pillFontSize, TL.pillFontWeight)
+      const pillText = measureMultilineText(wrappedPeriodLabel, TL.pillFontSize, TL.pillFontWeight)
+      const pillWidth = Math.max(TL.pillMinWidth, pillText.width + TL.pillPadX * 2)
+      const pillHeight = pillText.height + TL.pillPadY * 2
+
+      const eventMetrics = period.events.map(event => {
+        const wrappedEventText = wrapTimelineText(event.text, TL.eventWrapWidth, TL.eventFontSize, TL.eventFontWeight)
+        const text = measureMultilineText(wrappedEventText, TL.eventFontSize, TL.eventFontWeight)
+        return {
+          text: wrappedEventText,
+          width: Math.max(TL.eventMinWidth, text.width + TL.eventPadX * 2),
+          height: text.height + TL.eventPadY * 2,
+        }
+      })
+
+      const columnWidth = Math.max(
+        pillWidth,
+        ...eventMetrics.map(event => event.width),
+      )
+
+      const stackHeight = eventMetrics.reduce((sum, event, index) => {
+        const gap = index === 0 ? 0 : TL.eventGap
+        return sum + gap + event.height
+      }, 0)
+
+      return {
+        label: wrappedPeriodLabel,
+        pillWidth,
+        pillHeight,
+        columnWidth,
+        stackHeight,
+        events: eventMetrics,
+      }
+    })
+
+    const columnAreaWidth = periodMetrics.reduce((sum, period, index) => {
+      const gap = index === 0 ? 0 : TL.columnGap
+      return sum + gap + period.columnWidth
+    }, 0)
+
+    const headerWidth = wrappedSectionLabel
+      ? measureMultilineText(wrappedSectionLabel, TL.sectionFontSize, TL.sectionFontWeight).width + TL.sectionHeaderPadX * 2
+      : 0
+
+    const innerWidth = Math.max(columnAreaWidth, headerWidth)
+    const maxStackHeight = Math.max(0, ...periodMetrics.map(period => period.stackHeight))
+
+    return {
+      label: wrappedSectionLabel,
+      headerWidth,
+      innerWidth,
+      columnAreaWidth,
+      periods: periodMetrics,
+      maxStackHeight,
+    }
+  })
+
+  const maxPillHeight = Math.max(
+    0,
+    ...metrics.flatMap(section => section.periods.map(period => period.pillHeight)),
+  )
+
+  let contentTop = TL.paddingY
+  if (titleMetrics) {
+    contentTop += titleMetrics.height
+    contentTop += TL.titleGap
+  }
+
+  const pillY = contentTop + sectionHeaderHeight + (hasNamedSections ? TL.sectionHeaderGap : 0)
+  const railY = pillY + maxPillHeight + TL.railToPillGap
+  const eventsTop = railY + TL.railToEventsGap
+
+  let cursorX = TL.paddingX
+  const sections: PositionedTimelineSection[] = []
+  let maxBottom = railY + TL.markerRadius
+
+  for (let sectionIndex = 0; sectionIndex < diagram.sections.length; sectionIndex++) {
+    const section = diagram.sections[sectionIndex]!
+    const metric = metrics[sectionIndex]!
+    const sectionWidth = metric.innerWidth + sectionPadX * 2
+    const columnStartX = cursorX + sectionPadX + (metric.innerWidth - metric.columnAreaWidth) / 2
+
+    let periodCursorX = columnStartX
+    const periods: PositionedTimelinePeriod[] = []
+    let sectionBottom = railY + TL.markerRadius
+
+    for (let periodIndex = 0; periodIndex < section.periods.length; periodIndex++) {
+      const period = section.periods[periodIndex]!
+      const periodMetric = metric.periods[periodIndex]!
+      const centerX = periodCursorX + periodMetric.columnWidth / 2
+
+      let eventY = eventsTop
+      const events: PositionedTimelineEvent[] = period.events.map((event, eventIndex) => {
+        const eventMetric = periodMetric.events[eventIndex]!
+        const positioned: PositionedTimelineEvent = {
+          id: event.id,
+          sectionId: section.id,
+          periodId: period.id,
+          periodLabel: periodMetric.label,
+          text: eventMetric.text,
+          x: centerX - eventMetric.width / 2,
+          y: eventY,
+          width: eventMetric.width,
+          height: eventMetric.height,
+        }
+        eventY += eventMetric.height + TL.eventGap
+        return positioned
+      })
+
+      const stemBottomY = events.length > 0 ? events[0]!.y - 10 : railY + 16
+
+      periods.push({
+        id: period.id,
+        sectionId: section.id,
+        label: periodMetric.label,
+        centerX,
+        markerY: railY,
+        pillX: centerX - periodMetric.pillWidth / 2,
+        pillY,
+        pillWidth: periodMetric.pillWidth,
+        pillHeight: periodMetric.pillHeight,
+        stemTopY: railY + TL.markerRadius,
+        stemBottomY,
+        events,
+      })
+
+      if (events.length > 0) {
+        const lastEvent = events[events.length - 1]!
+        sectionBottom = Math.max(sectionBottom, lastEvent.y + lastEvent.height)
+      }
+
+      periodCursorX += periodMetric.columnWidth + TL.columnGap
+    }
+
+    sectionBottom += TL.sectionPadBottom
+    maxBottom = Math.max(maxBottom, sectionBottom)
+
+    sections.push({
+      id: section.id,
+      label: metric.label,
+      x: cursorX,
+      y: contentTop,
+      width: sectionWidth,
+      height: sectionBottom - contentTop,
+      framed: showSectionFrames,
+      headerHeight: sectionHeaderHeight,
+      periods,
+    })
+
+    cursorX += sectionWidth
+    if (sectionIndex < diagram.sections.length - 1) {
+      cursorX += showSectionFrames ? TL.sectionGap : TL.columnGap
+    }
+  }
+
+  const width = cursorX + TL.paddingX
+  const height = maxBottom + TL.paddingY
+  const allPeriods = sections.flatMap(section => section.periods)
+  const firstCenter = allPeriods[0]?.centerX ?? TL.paddingX
+  const lastCenter = allPeriods[allPeriods.length - 1]?.centerX ?? width - TL.paddingX
+
+  return {
+    width,
+    height,
+    title: titleText
+      ? {
+          text: titleText,
+          x: width / 2,
+          y: TL.paddingY + titleMetrics!.height / 2,
+        }
+      : undefined,
+    accessibilityTitle: diagram.accessibilityTitle,
+    accessibilityDescription: diagram.accessibilityDescription,
+    rail: {
+      x1: firstCenter === lastCenter ? firstCenter - 42 : firstCenter,
+      x2: firstCenter === lastCenter ? lastCenter + 42 : lastCenter,
+      y: railY,
+    },
+    sections,
+  }
+}
+
+function wrapTimelineText(
+  text: string,
+  maxWidth: number,
+  fontSize: number,
+  fontWeight: number,
+): string {
+  return text
+    .split('\n')
+    .flatMap(line => wrapTimelineLine(line, maxWidth, fontSize, fontWeight))
+    .join('\n')
+}
+
+function wrapTimelineLine(
+  line: string,
+  maxWidth: number,
+  fontSize: number,
+  fontWeight: number,
+): string[] {
+  const plainLine = stripFormattingTags(line)
+  if (measureTextWidth(plainLine, fontSize, fontWeight) <= maxWidth) {
+    return [line]
+  }
+
+  const words = line.trim().split(/\s+/)
+  if (words.length <= 1) {
+    return breakLongToken(line, maxWidth, fontSize, fontWeight)
+  }
+
+  const wrapped: string[] = []
+  let current = ''
+
+  for (const word of words) {
+    const candidate = current ? `${current} ${word}` : word
+    const candidateWidth = measureTextWidth(stripFormattingTags(candidate), fontSize, fontWeight)
+
+    if (candidateWidth <= maxWidth) {
+      current = candidate
+      continue
+    }
+
+    if (current) {
+      wrapped.push(current)
+      current = ''
+    }
+
+    if (measureTextWidth(stripFormattingTags(word), fontSize, fontWeight) > maxWidth) {
+      wrapped.push(...breakLongToken(word, maxWidth, fontSize, fontWeight))
+    } else {
+      current = word
+    }
+  }
+
+  if (current) wrapped.push(current)
+  return wrapped
+}
+
+function breakLongToken(
+  token: string,
+  maxWidth: number,
+  fontSize: number,
+  fontWeight: number,
+): string[] {
+  const chunks: string[] = []
+  let current = ''
+
+  for (const char of token) {
+    const candidate = current + char
+    if (current && measureTextWidth(stripFormattingTags(candidate), fontSize, fontWeight) > maxWidth) {
+      chunks.push(current)
+      current = char
+      continue
+    }
+
+    current = candidate
+  }
+
+  if (current) chunks.push(current)
+  return chunks
+}

--- a/src/timeline/parser.ts
+++ b/src/timeline/parser.ts
@@ -1,0 +1,185 @@
+import type { TimelineDiagram, TimelineSection, TimelinePeriod, TimelineEvent } from './types.ts'
+import { normalizeBrTags } from '../multiline-utils.ts'
+
+// ============================================================================
+// Timeline diagram parser
+//
+// Parses Mermaid timeline syntax into a TimelineDiagram structure.
+//
+// Supported syntax:
+//   timeline
+//   title Timeline Title
+//   section Section Label
+//   2020 : Event 1
+//   2021 : Event 1 : Event 2
+//        : Continued event for the previous period
+// ============================================================================
+
+/**
+ * Parse a Mermaid timeline diagram.
+ * Expects the first line to be "timeline".
+ */
+export function parseTimelineDiagram(lines: string[]): TimelineDiagram {
+  const diagram: TimelineDiagram = { sections: [] }
+
+  let currentSection: TimelineSection | undefined
+  let currentPeriod: TimelinePeriod | undefined
+  let sectionIndex = 0
+  let periodIndex = 0
+  let eventIndex = 0
+
+  const ensureSection = (): TimelineSection => {
+    if (currentSection) return currentSection
+    currentSection = {
+      id: `section-${sectionIndex++}`,
+      periods: [],
+    }
+    diagram.sections.push(currentSection)
+    return currentSection
+  }
+
+  const pushEvents = (period: TimelinePeriod, rawEvents: string[]): void => {
+    for (const rawEvent of rawEvents) {
+      const normalized = normalizeBrTags(rawEvent.trim())
+      if (!normalized) continue
+
+      const event: TimelineEvent = {
+        id: `event-${eventIndex++}`,
+        text: normalized,
+      }
+      period.events.push(event)
+    }
+  }
+
+  for (let i = 1; i < lines.length; i++) {
+    const line = lines[i]!
+
+    if (/^timeline\b/i.test(line)) continue
+    if (/^#/.test(line)) continue
+
+    const titleMatch = line.match(/^title\s+(.+)$/i)
+    if (titleMatch) {
+      diagram.title = normalizeBrTags(titleMatch[1]!.trim())
+      continue
+    }
+
+    const accTitleMatch = line.match(/^accTitle\s*:\s*(.+)$/i)
+    if (accTitleMatch) {
+      diagram.accessibilityTitle = normalizeBrTags(accTitleMatch[1]!.trim())
+      continue
+    }
+
+    const accDescrMatch = line.match(/^accDescr\s*:\s*(.+)$/i)
+    if (accDescrMatch) {
+      diagram.accessibilityDescription = normalizeBrTags(accDescrMatch[1]!.trim())
+      continue
+    }
+
+    if (/^accDescr\s*\{\s*$/i.test(line)) {
+      const descriptionLines: string[] = []
+      let foundClosingBrace = false
+
+      while (++i < lines.length) {
+        const blockLine = lines[i]!
+        if (blockLine === '}') {
+          foundClosingBrace = true
+          break
+        }
+        descriptionLines.push(blockLine)
+      }
+
+      if (!foundClosingBrace) {
+        throw new Error('Timeline accDescr block was not closed with "}"')
+      }
+
+      diagram.accessibilityDescription = normalizeBrTags(descriptionLines.join('\n').trim())
+      continue
+    }
+
+    const sectionMatch = line.match(/^section\s+([^:]+)$/i)
+    if (sectionMatch) {
+      currentSection = {
+        id: `section-${sectionIndex++}`,
+        label: normalizeBrTags(sectionMatch[1]!.trim()),
+        periods: [],
+      }
+      diagram.sections.push(currentSection)
+      currentPeriod = undefined
+      continue
+    }
+
+    const continuationMatch = line.match(/^:\s+(.+)$/)
+    if (continuationMatch) {
+      if (!currentPeriod) {
+        throw new Error('Timeline continuation found before any period was declared')
+      }
+      pushEvents(currentPeriod, splitTimelineEvents(`: ${continuationMatch[1]!}`))
+      continue
+    }
+
+    const periodMatch = line.match(/^([^:#\n]+?)(\s*:\s+.+)$/)
+    if (periodMatch) {
+      const periodLabel = normalizeBrTags(periodMatch[1]!.trim())
+      const events = splitTimelineEvents(periodMatch[2]!)
+
+      if (!periodLabel) {
+        throw new Error(`Invalid timeline period: "${line}"`)
+      }
+
+      const period: TimelinePeriod = {
+        id: `period-${periodIndex++}`,
+        label: periodLabel,
+        events: [],
+      }
+
+      pushEvents(period, events)
+
+      if (period.events.length === 0) {
+        throw new Error(`Timeline period "${periodLabel}" must include at least one event`)
+      }
+
+      ensureSection().periods.push(period)
+      currentPeriod = period
+      continue
+    }
+
+    throw new Error(`Unsupported timeline syntax: "${line}"`)
+  }
+
+  if (diagram.sections.length === 0 || diagram.sections.every(section => section.periods.length === 0)) {
+    throw new Error('Timeline diagram must include at least one period with events')
+  }
+
+  return diagram
+}
+
+function splitTimelineEvents(raw: string): string[] {
+  const events: string[] = []
+  let index = 0
+
+  while (index < raw.length) {
+    while (index < raw.length && /\s/.test(raw[index]!)) index++
+    if (index >= raw.length) break
+
+    if (raw[index] !== ':') {
+      throw new Error(`Invalid timeline event list: "${raw}"`)
+    }
+
+    index++
+    if (index >= raw.length || !/\s/.test(raw[index]!)) {
+      throw new Error(`Timeline events must use ": " separators: "${raw}"`)
+    }
+
+    while (index < raw.length && /\s/.test(raw[index]!)) index++
+    const start = index
+
+    while (index < raw.length) {
+      if (raw[index] === ':' && /\s/.test(raw[index + 1] ?? '')) break
+      index++
+    }
+
+    events.push(raw.slice(start, index).trim())
+  }
+
+  return events
+}

--- a/src/timeline/renderer.ts
+++ b/src/timeline/renderer.ts
@@ -1,0 +1,320 @@
+import type { PositionedTimelineDiagram, PositionedTimelineSection, PositionedTimelinePeriod, PositionedTimelineEvent } from './types.ts'
+import type { DiagramColors } from '../theme.ts'
+import { svgOpenTag, buildStyleBlock } from '../theme.ts'
+import { renderMultilineText, escapeXml } from '../multiline-utils.ts'
+
+// ============================================================================
+// Timeline diagram SVG renderer
+//
+// Visual language:
+//   - crisp section frames aligned with the rest of beautiful-mermaid
+//   - a single horizontal rail
+//   - period pills above the rail
+//   - stacked event cards below with a subtle accent strip
+//   - color families grouped by section (or by period when unsectioned)
+// ============================================================================
+
+const TL = {
+  titleFontSize: 18,
+  titleFontWeight: 600,
+  sectionFontSize: 12,
+  sectionFontWeight: 600,
+  pillFontSize: 12,
+  pillFontWeight: 600,
+  eventFontSize: 12,
+  eventFontWeight: 400,
+  markerOuterRadius: 8,
+  markerInnerRadius: 4.5,
+  eventAccentWidth: 4,
+} as const
+
+interface TimelineFamilyPalette {
+  accent: string
+  fill: string
+  label: string
+  line: string
+}
+
+const TL_THEME_FAMILY_ACCENTS = [
+  'var(--_arrow)',
+  mix('var(--_arrow)', 'var(--_line)', 72),
+  mix('var(--_arrow)', 'var(--_text-sec)', 60),
+  mix('var(--_line)', 'var(--_text)', 56),
+  mix('var(--_arrow)', 'var(--_node-stroke)', 46),
+] as const
+
+const TL_DEFAULT_FAMILY_ACCENTS = [
+  '#5B7FFF',
+  '#159A72',
+  '#D18A24',
+  '#CC5A5A',
+  '#6B7280',
+] as const
+
+/**
+ * Render a positioned timeline diagram as an SVG string.
+ */
+export function renderTimelineSvg(
+  diagram: PositionedTimelineDiagram,
+  colors: DiagramColors,
+  font: string = 'Inter',
+  transparent: boolean = false,
+): string {
+  const parts: string[] = []
+  const useSectionFamilies = diagram.sections.some(section => Boolean(section.label))
+  const accessibleTitle = diagram.accessibilityTitle ?? diagram.title?.text.replace(/\n+/g, ' ')
+  const accessibleDescription = diagram.accessibilityDescription
+  const familyPalettes = getTimelineFamilyPalettes(colors)
+  const uid = `tl-${hashTimeline(diagram)}`
+  const titleId = `${uid}-title`
+  const descId = `${uid}-desc`
+  const rootAttrs = buildAccessibilityAttrs(accessibleTitle, accessibleDescription, titleId, descId)
+
+  parts.push(withRootAttrs(svgOpenTag(diagram.width, diagram.height, colors, transparent), rootAttrs))
+  parts.push(buildStyleBlock(font, false))
+  parts.push(timelineStyles())
+
+  if (accessibleTitle) {
+    parts.push(`<title id="${titleId}">${escapeXml(accessibleTitle)}</title>`)
+  }
+  if (accessibleDescription) {
+    parts.push(`<desc id="${descId}">${escapeXml(accessibleDescription)}</desc>`)
+  }
+
+  for (let sectionIndex = 0; sectionIndex < diagram.sections.length; sectionIndex++) {
+    const section = diagram.sections[sectionIndex]!
+    const familyIndex = useSectionFamilies ? sectionIndex : 0
+    if (section.framed) {
+      parts.push(renderSectionFrame(section, familyIndex, familyPalettes))
+    }
+  }
+
+  parts.push(
+    `<line class="timeline-rail" x1="${diagram.rail.x1}" y1="${diagram.rail.y}" x2="${diagram.rail.x2}" y2="${diagram.rail.y}" />`
+  )
+
+  let periodFamilyIndex = 0
+  for (let sectionIndex = 0; sectionIndex < diagram.sections.length; sectionIndex++) {
+    const section = diagram.sections[sectionIndex]!
+    const sectionFamilyIndex = useSectionFamilies ? sectionIndex : undefined
+    for (const period of section.periods) {
+      const familyIndex = sectionFamilyIndex ?? periodFamilyIndex++
+      parts.push(renderPeriod(period, section.label, familyIndex, familyPalettes))
+    }
+  }
+
+  if (diagram.title) {
+    parts.push(
+      renderMultilineText(
+        diagram.title.text,
+        diagram.title.x,
+        diagram.title.y,
+        TL.titleFontSize,
+        `class="timeline-title" text-anchor="middle" font-size="${TL.titleFontSize}" font-weight="${TL.titleFontWeight}"`,
+      )
+    )
+  }
+
+  parts.push('</svg>')
+  return parts.join('\n')
+}
+
+function timelineStyles(): string {
+  return `<style>
+  .timeline-title { fill: var(--_text); }
+  .timeline-rail { stroke: var(--_line); stroke-width: 1.5; stroke-linecap: round; }
+  .timeline-section-bg { fill: var(--tl-section-bg, color-mix(in srgb, var(--_node-fill) 88%, var(--bg))); stroke: var(--tl-line, var(--_node-stroke)); stroke-width: 1; }
+  .timeline-section-band { fill: var(--tl-section-band, color-mix(in srgb, var(--_arrow) 8%, var(--bg))); stroke: var(--tl-line, var(--_node-stroke)); stroke-width: 1; }
+  .timeline-section-label { fill: var(--tl-label, var(--_text-sec)); }
+  .timeline-stem { stroke: var(--tl-line, color-mix(in srgb, var(--_arrow) 32%, var(--_line))); stroke-width: 1; stroke-dasharray: 3 4; }
+  .timeline-marker-ring { fill: var(--bg); stroke: var(--tl-line, var(--_arrow)); stroke-width: 1.5; }
+  .timeline-marker-core { fill: var(--tl-accent, var(--_arrow)); }
+  .timeline-period-pill { fill: var(--tl-pill-fill, color-mix(in srgb, var(--_arrow) 7%, var(--bg))); stroke: var(--tl-pill-stroke, color-mix(in srgb, var(--_arrow) 20%, var(--bg))); stroke-width: 1; }
+  .timeline-period-text { fill: var(--tl-label, var(--_text)); }
+  .timeline-event-card { fill: var(--tl-event-fill, var(--_node-fill)); stroke: var(--tl-line, var(--_node-stroke)); stroke-width: 1; }
+  .timeline-event-accent { fill: var(--tl-event-accent, color-mix(in srgb, var(--_arrow) 18%, var(--bg))); }
+  .timeline-event-text { fill: var(--tl-label, var(--_text-muted)); }
+</style>`
+}
+
+function renderSectionFrame(
+  section: PositionedTimelineSection,
+  familyIndex: number,
+  familyPalettes: readonly TimelineFamilyPalette[],
+): string {
+  const parts: string[] = []
+  const labelAttr = section.label ? ` data-label="${escapeAttr(section.label)}"` : ''
+  const familyAttr = renderFamilyAttr(familyIndex, familyPalettes)
+  parts.push(`<g class="timeline-section" data-id="${escapeAttr(section.id)}"${labelAttr}${familyAttr}>`)
+  parts.push(
+    `  <rect class="timeline-section-bg" x="${section.x}" y="${section.y}" width="${section.width}" height="${section.height}" rx="0" ry="0" />`
+  )
+
+  if (section.headerHeight > 0) {
+    parts.push(
+      `  <rect class="timeline-section-band" x="${section.x}" y="${section.y}" width="${section.width}" height="${section.headerHeight}" rx="0" ry="0" />`
+    )
+    if (section.label) {
+      parts.push(
+        '  ' + renderMultilineText(
+          section.label,
+          section.x + 12,
+          section.y + section.headerHeight / 2,
+          TL.sectionFontSize,
+          `class="timeline-section-label" text-anchor="start" font-size="${TL.sectionFontSize}" font-weight="${TL.sectionFontWeight}"`,
+        )
+      )
+    }
+  }
+
+  parts.push('</g>')
+  return parts.join('\n')
+}
+
+function renderPeriod(
+  period: PositionedTimelinePeriod,
+  sectionLabel: string | undefined,
+  familyIndex: number,
+  familyPalettes: readonly TimelineFamilyPalette[],
+): string {
+  const parts: string[] = []
+  const sectionAttr = sectionLabel ? ` data-section="${escapeAttr(sectionLabel)}"` : ''
+  const familyAttr = renderFamilyAttr(familyIndex, familyPalettes)
+
+  parts.push(
+    `<g class="timeline-period" data-id="${escapeAttr(period.id)}" data-label="${escapeAttr(period.label)}"${sectionAttr}${familyAttr}>`
+  )
+  parts.push(
+    `  <line class="timeline-stem" x1="${period.centerX}" y1="${period.stemTopY}" x2="${period.centerX}" y2="${period.stemBottomY}" />`
+  )
+  parts.push(
+    `  <rect class="timeline-period-pill" x="${period.pillX}" y="${period.pillY}" width="${period.pillWidth}" height="${period.pillHeight}" rx="0" ry="0" />`
+  )
+  parts.push(
+    '  ' + renderMultilineText(
+      period.label,
+      period.centerX,
+      period.pillY + period.pillHeight / 2,
+      TL.pillFontSize,
+      `class="timeline-period-text" text-anchor="middle" font-size="${TL.pillFontSize}" font-weight="${TL.pillFontWeight}"`,
+    )
+  )
+  parts.push(
+    `  <circle class="timeline-marker-ring" cx="${period.centerX}" cy="${period.markerY}" r="${TL.markerOuterRadius}" />`
+  )
+  parts.push(
+    `  <circle class="timeline-marker-core" cx="${period.centerX}" cy="${period.markerY}" r="${TL.markerInnerRadius}" />`
+  )
+
+  for (const event of period.events) {
+    parts.push(renderEvent(event, sectionLabel, familyIndex, familyPalettes))
+  }
+
+  parts.push('</g>')
+  return parts.join('\n')
+}
+
+function renderEvent(
+  event: PositionedTimelineEvent,
+  sectionLabel: string | undefined,
+  familyIndex: number,
+  familyPalettes: readonly TimelineFamilyPalette[],
+): string {
+  const sectionAttr = sectionLabel ? ` data-section="${escapeAttr(sectionLabel)}"` : ''
+  const familyAttr = ` data-family="${familyIndex % familyPalettes.length}"`
+
+  return [
+    `<g class="timeline-event" data-id="${escapeAttr(event.id)}" data-period="${escapeAttr(event.periodLabel)}"${sectionAttr}${familyAttr}>`,
+    `  <rect class="timeline-event-card" x="${event.x}" y="${event.y}" width="${event.width}" height="${event.height}" rx="0" ry="0" />`,
+    `  <rect class="timeline-event-accent" x="${event.x}" y="${event.y}" width="${TL.eventAccentWidth}" height="${event.height}" rx="0" ry="0" />`,
+    '  ' + renderMultilineText(
+      event.text,
+      event.x + TL.eventAccentWidth + 12,
+      event.y + event.height / 2,
+      TL.eventFontSize,
+      `class="timeline-event-text" text-anchor="start" font-size="${TL.eventFontSize}" font-weight="${TL.eventFontWeight}"`,
+    ),
+    '</g>',
+].join('\n')
+}
+
+function renderFamilyAttr(familyIndex: number, familyPalettes: readonly TimelineFamilyPalette[]): string {
+  const family = familyIndex % familyPalettes.length
+  const palette = familyPalettes[family]!
+  const style = [
+    `--tl-accent:${palette.accent}`,
+    `--tl-fill:${palette.fill}`,
+    `--tl-label:${palette.label}`,
+    `--tl-line:${palette.line}`,
+    `--tl-section-bg:${mix(palette.fill, 'var(--bg)', 6)}`,
+    `--tl-section-band:${mix(palette.fill, 'var(--bg)', 12)}`,
+    `--tl-pill-fill:${mix(palette.fill, 'var(--bg)', 11)}`,
+    `--tl-pill-stroke:${mix(palette.fill, palette.line, 36)}`,
+    `--tl-event-fill:${mix(palette.fill, 'var(--_node-fill)', 16)}`,
+    `--tl-event-accent:${mix(palette.fill, 'var(--bg)', 26)}`,
+  ].join(';')
+
+  return ` data-family="${family}" style="${escapeAttr(style)}"`
+}
+
+function getTimelineFamilyPalettes(
+  colors: DiagramColors,
+): readonly TimelineFamilyPalette[] {
+  const hasThemeEnrichment = Boolean(
+    colors.accent ||
+    colors.line ||
+    colors.muted ||
+    colors.surface ||
+    colors.border
+  )
+
+  return Array.from({ length: 12 }, (_, index) => {
+    const defaultFill = hasThemeEnrichment
+      ? TL_THEME_FAMILY_ACCENTS[index % TL_THEME_FAMILY_ACCENTS.length]!
+      : TL_DEFAULT_FAMILY_ACCENTS[index % TL_DEFAULT_FAMILY_ACCENTS.length]!
+    const fill = defaultFill
+    const label = 'var(--_text)'
+    const line = mix(fill, 'var(--_line)', 48)
+
+    return { accent: fill, fill, label, line }
+  })
+}
+
+function mix(primary: string, secondary: string, amount: number): string {
+  return `color-mix(in srgb, ${primary} ${amount}%, ${secondary})`
+}
+
+function withRootAttrs(svgTag: string, attrs: Record<string, string>): string {
+  const attrText = Object.entries(attrs)
+    .map(([key, value]) => ` ${key}="${escapeAttr(value)}"`)
+    .join('')
+  return svgTag.replace(/>$/, `${attrText}>`)
+}
+
+function buildAccessibilityAttrs(
+  title: string | undefined,
+  description: string | undefined,
+  titleId: string,
+  descId: string,
+): Record<string, string> {
+  if (!title && !description) return {}
+
+  const attrs: Record<string, string> = { role: 'img' }
+  if (title) attrs['aria-labelledby'] = titleId
+  if (description) attrs['aria-describedby'] = descId
+  return attrs
+}
+
+function hashTimeline(diagram: { width: number; height: number; sections: Array<{ periods: unknown[] }> }): string {
+  let h = 0x811c9dc5
+  const s = `${diagram.width}|${diagram.height}|${diagram.sections.map(s => s.periods.length).join(',')}`
+  for (let i = 0; i < s.length; i++) {
+    h ^= s.charCodeAt(i)
+    h = Math.imul(h, 0x01000193)
+  }
+  return (h >>> 0).toString(36)
+}
+
+function escapeAttr(text: string): string {
+  return escapeXml(text)
+}

--- a/src/timeline/types.ts
+++ b/src/timeline/types.ts
@@ -1,0 +1,103 @@
+// ============================================================================
+// Timeline diagram types
+//
+// Models Mermaid timeline diagrams in parsed and positioned form.
+// Timeline diagrams show chronological milestones grouped into optional sections.
+// ============================================================================
+
+/** Parsed timeline diagram — logical structure from Mermaid text */
+export interface TimelineDiagram {
+  /** Optional timeline title */
+  title?: string
+  /** Optional accessibility title (Mermaid accTitle) */
+  accessibilityTitle?: string
+  /** Optional accessibility description (Mermaid accDescr) */
+  accessibilityDescription?: string
+  /** Ordered sections in input order */
+  sections: TimelineSection[]
+}
+
+export interface TimelineSection {
+  id: string
+  /** Optional section label. Undefined means "ungrouped" / implicit section. */
+  label?: string
+  periods: TimelinePeriod[]
+}
+
+export interface TimelinePeriod {
+  id: string
+  label: string
+  events: TimelineEvent[]
+}
+
+export interface TimelineEvent {
+  id: string
+  text: string
+}
+
+// ============================================================================
+// Positioned timeline diagram — ready for SVG rendering
+// ============================================================================
+
+export interface PositionedTimelineDiagram {
+  width: number
+  height: number
+  title?: PositionedTimelineTitle
+  accessibilityTitle?: string
+  accessibilityDescription?: string
+  rail: TimelineRail
+  sections: PositionedTimelineSection[]
+}
+
+export interface PositionedTimelineTitle {
+  text: string
+  x: number
+  y: number
+}
+
+export interface TimelineRail {
+  x1: number
+  x2: number
+  y: number
+}
+
+export interface PositionedTimelineSection {
+  id: string
+  label?: string
+  x: number
+  y: number
+  width: number
+  height: number
+  /** Whether to render a framed background for this section. */
+  framed: boolean
+  /** Height of the section header band. 0 when there is no visible header row. */
+  headerHeight: number
+  periods: PositionedTimelinePeriod[]
+}
+
+export interface PositionedTimelinePeriod {
+  id: string
+  sectionId: string
+  label: string
+  centerX: number
+  markerY: number
+  pillX: number
+  pillY: number
+  pillWidth: number
+  pillHeight: number
+  stemTopY: number
+  stemBottomY: number
+  events: PositionedTimelineEvent[]
+}
+
+export interface PositionedTimelineEvent {
+  id: string
+  sectionId: string
+  periodId: string
+  periodLabel: string
+  text: string
+  x: number
+  y: number
+  width: number
+  height: number
+}


### PR DESCRIPTION
## What

Adds support for Mermaid `timeline` diagrams.

Closes #86.

## Why

`timeline` is a Mermaid diagram family used for chronological/education content, but this package currently routes unknown headers to the flowchart parser and cannot render timeline syntax.

## How

- Added a dedicated timeline parser for:
  - `title`
  - named `section`s
  - implicit sections
  - period rows with one or more events
  - continuation event lines
  - multiline labels via `<br>`
  - `accTitle` / `accDescr` accessibility metadata
- Added a timeline layout pass that positions:
  - section frames
  - a horizontal rail
  - period pills and markers
  - wrapped event cards
- Added SVG rendering with semantic classes/data attributes and accessible `<title>/<desc>` metadata.
- Added ASCII/Unicode timeline rendering and routed `timeline` through both public render APIs.
- Documented the supported syntax in the README.

This PR intentionally does not include Mermaid frontmatter/config handling; that is isolated in #117 / issue #79.

## Testing

- Added focused tests:
  - `src/__tests__/timeline-parser.test.ts`
  - `src/__tests__/timeline-layout.test.ts`
  - `src/__tests__/timeline-integration.test.ts`
  - `src/__tests__/timeline-ascii.test.ts`
- The integration tests fail on upstream `main` because `timeline` is not a recognized diagram type and falls through to the flowchart parser.
- Ran:
  - `bun test src/__tests__/timeline-parser.test.ts src/__tests__/timeline-layout.test.ts src/__tests__/timeline-integration.test.ts src/__tests__/timeline-ascii.test.ts --timeout 120000`
  - `bun test src/__tests__/ --timeout 120000`
  - `bun run build`

## Risk

Moderate-low. The new code is isolated under `src/timeline/*` plus small routing additions in the SVG and ASCII entry points. Existing diagram families keep their current parsing/rendering paths. The full existing test suite passes with the new route present.