### PR TITLE
feat: add MCP server with SVG/ASCII rendering tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -489,6 +489,51 @@ XY charts render to ASCII with dedicated chart-drawing characters:
 
 ---
 
+## MCP Server
+
+`beautiful-mermaid` ships with a built-in [MCP (Model Context Protocol)](https://modelcontextprotocol.io) server, letting AI coding assistants render diagrams natively through the tool-calling protocol.
+
+### Configure
+
+Add to your MCP client (Cursor, Claude Desktop, etc.):
+
+```json
+{
+  "mcpServers": {
+    "beautiful-mermaid": {
+      "command": "npx",
+      "args": ["beautiful-mermaid"]
+    }
+  }
+}
+```
+
+Or use Bun for faster startup:
+
+```json
+{
+  "mcpServers": {
+    "beautiful-mermaid": {
+      "command": "bun",
+      "args": ["run", "beautiful-mermaid"]
+    }
+  }
+}
+```
+
+### Available Tools
+
+| Tool | Description |
+|------|-------------|
+| `render_mermaid_svg` | Render diagrams to SVG with theme support |
+| `render_mermaid_ascii` | Render diagrams to ASCII/Unicode art |
+| `parse_mermaid` | Parse Mermaid source into a JSON graph |
+| `list_diagram_types` | List all 6 supported diagram types |
+
+The SVG tool supports theme selection via `theme_name` (all 15 built-in themes), custom `bg`/`fg` overrides, and transparent background. The ASCII tool detects CJK characters and can emit warnings for terminal alignment.
+
+---
+
 ## API Reference
 
 ### `renderMermaidSVG(text, options?): string`

--- a/bun.lock
+++ b/bun.lock
@@ -5,8 +5,11 @@
     "": {
       "name": "beautiful-mermaid",
       "dependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "@modelcontextprotocol/server": "^2.0.0-alpha.2",
         "elkjs": "^0.11.0",
         "entities": "^7.0.1",
+        "zod": "^4.4.3",
       },
       "devDependencies": {
         "@types/bun": "^1.3.9",
@@ -17,300 +20,306 @@
     },
   },
   "packages": {
-    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.3", "", { "os": "aix", "cpu": "ppc64" }, "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg=="],
+    "@cfworker/json-schema": ["@cfworker/json-schema@4.1.1", "https://mirrors.huaweicloud.com/repository/npm/@cfworker/json-schema/-/json-schema-4.1.1.tgz", {}, "sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og=="],
 
-    "@esbuild/android-arm": ["@esbuild/android-arm@0.27.3", "", { "os": "android", "cpu": "arm" }, "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA=="],
+    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.3", "https://mirrors.huaweicloud.com/repository/npm/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz", { "os": "aix", "cpu": "ppc64" }, "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg=="],
 
-    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.27.3", "", { "os": "android", "cpu": "arm64" }, "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg=="],
+    "@esbuild/android-arm": ["@esbuild/android-arm@0.27.3", "https://mirrors.huaweicloud.com/repository/npm/@esbuild/android-arm/-/android-arm-0.27.3.tgz", { "os": "android", "cpu": "arm" }, "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA=="],
 
-    "@esbuild/android-x64": ["@esbuild/android-x64@0.27.3", "", { "os": "android", "cpu": "x64" }, "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ=="],
+    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.27.3", "https://mirrors.huaweicloud.com/repository/npm/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz", { "os": "android", "cpu": "arm64" }, "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg=="],
 
-    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.27.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg=="],
+    "@esbuild/android-x64": ["@esbuild/android-x64@0.27.3", "https://mirrors.huaweicloud.com/repository/npm/@esbuild/android-x64/-/android-x64-0.27.3.tgz", { "os": "android", "cpu": "x64" }, "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ=="],
 
-    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.27.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg=="],
+    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.27.3", "https://mirrors.huaweicloud.com/repository/npm/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz", { "os": "darwin", "cpu": "arm64" }, "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg=="],
 
-    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.27.3", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w=="],
+    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.27.3", "https://mirrors.huaweicloud.com/repository/npm/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz", { "os": "darwin", "cpu": "x64" }, "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg=="],
 
-    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.27.3", "", { "os": "freebsd", "cpu": "x64" }, "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA=="],
+    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.27.3", "https://mirrors.huaweicloud.com/repository/npm/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz", { "os": "freebsd", "cpu": "arm64" }, "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w=="],
 
-    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.27.3", "", { "os": "linux", "cpu": "arm" }, "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw=="],
+    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.27.3", "https://mirrors.huaweicloud.com/repository/npm/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz", { "os": "freebsd", "cpu": "x64" }, "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA=="],
 
-    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.27.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg=="],
+    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.27.3", "https://mirrors.huaweicloud.com/repository/npm/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz", { "os": "linux", "cpu": "arm" }, "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw=="],
 
-    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.27.3", "", { "os": "linux", "cpu": "ia32" }, "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg=="],
+    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.27.3", "https://mirrors.huaweicloud.com/repository/npm/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz", { "os": "linux", "cpu": "arm64" }, "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg=="],
 
-    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.27.3", "", { "os": "linux", "cpu": "none" }, "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA=="],
+    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.27.3", "https://mirrors.huaweicloud.com/repository/npm/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz", { "os": "linux", "cpu": "ia32" }, "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg=="],
 
-    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.27.3", "", { "os": "linux", "cpu": "none" }, "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw=="],
+    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.27.3", "https://mirrors.huaweicloud.com/repository/npm/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz", { "os": "linux", "cpu": "none" }, "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA=="],
 
-    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.27.3", "", { "os": "linux", "cpu": "ppc64" }, "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA=="],
+    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.27.3", "https://mirrors.huaweicloud.com/repository/npm/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz", { "os": "linux", "cpu": "none" }, "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw=="],
 
-    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.27.3", "", { "os": "linux", "cpu": "none" }, "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ=="],
+    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.27.3", "https://mirrors.huaweicloud.com/repository/npm/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz", { "os": "linux", "cpu": "ppc64" }, "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA=="],
 
-    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.27.3", "", { "os": "linux", "cpu": "s390x" }, "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw=="],
+    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.27.3", "https://mirrors.huaweicloud.com/repository/npm/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz", { "os": "linux", "cpu": "none" }, "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ=="],
 
-    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.27.3", "", { "os": "linux", "cpu": "x64" }, "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA=="],
+    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.27.3", "https://mirrors.huaweicloud.com/repository/npm/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz", { "os": "linux", "cpu": "s390x" }, "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw=="],
 
-    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.27.3", "", { "os": "none", "cpu": "arm64" }, "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA=="],
+    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.27.3", "https://mirrors.huaweicloud.com/repository/npm/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz", { "os": "linux", "cpu": "x64" }, "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA=="],
 
-    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.27.3", "", { "os": "none", "cpu": "x64" }, "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA=="],
+    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.27.3", "https://mirrors.huaweicloud.com/repository/npm/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz", { "os": "none", "cpu": "arm64" }, "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA=="],
 
-    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.27.3", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw=="],
+    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.27.3", "https://mirrors.huaweicloud.com/repository/npm/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz", { "os": "none", "cpu": "x64" }, "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA=="],
 
-    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.27.3", "", { "os": "openbsd", "cpu": "x64" }, "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ=="],
+    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.27.3", "https://mirrors.huaweicloud.com/repository/npm/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz", { "os": "openbsd", "cpu": "arm64" }, "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw=="],
 
-    "@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.27.3", "", { "os": "none", "cpu": "arm64" }, "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g=="],
+    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.27.3", "https://mirrors.huaweicloud.com/repository/npm/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz", { "os": "openbsd", "cpu": "x64" }, "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ=="],
 
-    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.27.3", "", { "os": "sunos", "cpu": "x64" }, "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA=="],
+    "@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.27.3", "https://mirrors.huaweicloud.com/repository/npm/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz", { "os": "none", "cpu": "arm64" }, "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g=="],
 
-    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.27.3", "", { "os": "win32", "cpu": "arm64" }, "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA=="],
+    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.27.3", "https://mirrors.huaweicloud.com/repository/npm/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz", { "os": "sunos", "cpu": "x64" }, "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA=="],
 
-    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.27.3", "", { "os": "win32", "cpu": "ia32" }, "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q=="],
+    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.27.3", "https://mirrors.huaweicloud.com/repository/npm/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz", { "os": "win32", "cpu": "arm64" }, "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA=="],
 
-    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.3", "", { "os": "win32", "cpu": "x64" }, "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA=="],
+    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.27.3", "https://mirrors.huaweicloud.com/repository/npm/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz", { "os": "win32", "cpu": "ia32" }, "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q=="],
 
-    "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
+    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.3", "https://mirrors.huaweicloud.com/repository/npm/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz", { "os": "win32", "cpu": "x64" }, "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA=="],
 
-    "@jridgewell/resolve-uri": ["@jridgewell/resolve-uri@3.1.2", "", {}, "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw=="],
+    "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "https://mirrors.huaweicloud.com/repository/npm/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
 
-    "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
+    "@jridgewell/resolve-uri": ["@jridgewell/resolve-uri@3.1.2", "https://mirrors.huaweicloud.com/repository/npm/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz", {}, "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw=="],
 
-    "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+    "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "https://mirrors.huaweicloud.com/repository/npm/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
 
-    "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.59.0", "", { "os": "android", "cpu": "arm" }, "sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg=="],
+    "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "https://mirrors.huaweicloud.com/repository/npm/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
-    "@rollup/rollup-android-arm64": ["@rollup/rollup-android-arm64@4.59.0", "", { "os": "android", "cpu": "arm64" }, "sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q=="],
+    "@modelcontextprotocol/server": ["@modelcontextprotocol/server@2.0.0-alpha.2", "https://mirrors.huaweicloud.com/repository/npm/@modelcontextprotocol/server/-/server-2.0.0-alpha.2.tgz", { "dependencies": { "zod": "^4.0" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-gmLgdHzlYM8L7Aw/+VE0kxjT25WKamtUSLNhdOgrJq5CrESvqVSoAfWSJJeNPUXNTluQ+dYDGFbKVitdsJtbPA=="],
 
-    "@rollup/rollup-darwin-arm64": ["@rollup/rollup-darwin-arm64@4.59.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-W2Psnbh1J8ZJw0xKAd8zdNgF9HRLkdWwwdWqubSVk0pUuQkoHnv7rx4GiF9rT4t5DIZGAsConRE3AxCdJ4m8rg=="],
+    "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.59.0", "https://mirrors.huaweicloud.com/repository/npm/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.59.0.tgz", { "os": "android", "cpu": "arm" }, "sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg=="],
 
-    "@rollup/rollup-darwin-x64": ["@rollup/rollup-darwin-x64@4.59.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w=="],
+    "@rollup/rollup-android-arm64": ["@rollup/rollup-android-arm64@4.59.0", "https://mirrors.huaweicloud.com/repository/npm/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.59.0.tgz", { "os": "android", "cpu": "arm64" }, "sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q=="],
 
-    "@rollup/rollup-freebsd-arm64": ["@rollup/rollup-freebsd-arm64@4.59.0", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-EsKaJ5ytAu9jI3lonzn3BgG8iRBjV4LxZexygcQbpiU0wU0ATxhNVEpXKfUa0pS05gTcSDMKpn3Sx+QB9RlTTA=="],
+    "@rollup/rollup-darwin-arm64": ["@rollup/rollup-darwin-arm64@4.59.0", "https://mirrors.huaweicloud.com/repository/npm/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.59.0.tgz", { "os": "darwin", "cpu": "arm64" }, "sha512-W2Psnbh1J8ZJw0xKAd8zdNgF9HRLkdWwwdWqubSVk0pUuQkoHnv7rx4GiF9rT4t5DIZGAsConRE3AxCdJ4m8rg=="],
 
-    "@rollup/rollup-freebsd-x64": ["@rollup/rollup-freebsd-x64@4.59.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-d3DuZi2KzTMjImrxoHIAODUZYoUUMsuUiY4SRRcJy6NJoZ6iIqWnJu9IScV9jXysyGMVuW+KNzZvBLOcpdl3Vg=="],
+    "@rollup/rollup-darwin-x64": ["@rollup/rollup-darwin-x64@4.59.0", "https://mirrors.huaweicloud.com/repository/npm/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.59.0.tgz", { "os": "darwin", "cpu": "x64" }, "sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w=="],
 
-    "@rollup/rollup-linux-arm-gnueabihf": ["@rollup/rollup-linux-arm-gnueabihf@4.59.0", "", { "os": "linux", "cpu": "arm" }, "sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw=="],
+    "@rollup/rollup-freebsd-arm64": ["@rollup/rollup-freebsd-arm64@4.59.0", "https://mirrors.huaweicloud.com/repository/npm/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.59.0.tgz", { "os": "freebsd", "cpu": "arm64" }, "sha512-EsKaJ5ytAu9jI3lonzn3BgG8iRBjV4LxZexygcQbpiU0wU0ATxhNVEpXKfUa0pS05gTcSDMKpn3Sx+QB9RlTTA=="],
 
-    "@rollup/rollup-linux-arm-musleabihf": ["@rollup/rollup-linux-arm-musleabihf@4.59.0", "", { "os": "linux", "cpu": "arm" }, "sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA=="],
+    "@rollup/rollup-freebsd-x64": ["@rollup/rollup-freebsd-x64@4.59.0", "https://mirrors.huaweicloud.com/repository/npm/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.59.0.tgz", { "os": "freebsd", "cpu": "x64" }, "sha512-d3DuZi2KzTMjImrxoHIAODUZYoUUMsuUiY4SRRcJy6NJoZ6iIqWnJu9IScV9jXysyGMVuW+KNzZvBLOcpdl3Vg=="],
 
-    "@rollup/rollup-linux-arm64-gnu": ["@rollup/rollup-linux-arm64-gnu@4.59.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA=="],
+    "@rollup/rollup-linux-arm-gnueabihf": ["@rollup/rollup-linux-arm-gnueabihf@4.59.0", "https://mirrors.huaweicloud.com/repository/npm/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.59.0.tgz", { "os": "linux", "cpu": "arm" }, "sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw=="],
 
-    "@rollup/rollup-linux-arm64-musl": ["@rollup/rollup-linux-arm64-musl@4.59.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA=="],
+    "@rollup/rollup-linux-arm-musleabihf": ["@rollup/rollup-linux-arm-musleabihf@4.59.0", "https://mirrors.huaweicloud.com/repository/npm/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.59.0.tgz", { "os": "linux", "cpu": "arm" }, "sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA=="],
 
-    "@rollup/rollup-linux-loong64-gnu": ["@rollup/rollup-linux-loong64-gnu@4.59.0", "", { "os": "linux", "cpu": "none" }, "sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg=="],
+    "@rollup/rollup-linux-arm64-gnu": ["@rollup/rollup-linux-arm64-gnu@4.59.0", "https://mirrors.huaweicloud.com/repository/npm/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.59.0.tgz", { "os": "linux", "cpu": "arm64" }, "sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA=="],
 
-    "@rollup/rollup-linux-loong64-musl": ["@rollup/rollup-linux-loong64-musl@4.59.0", "", { "os": "linux", "cpu": "none" }, "sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q=="],
+    "@rollup/rollup-linux-arm64-musl": ["@rollup/rollup-linux-arm64-musl@4.59.0", "https://mirrors.huaweicloud.com/repository/npm/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.59.0.tgz", { "os": "linux", "cpu": "arm64" }, "sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA=="],
 
-    "@rollup/rollup-linux-ppc64-gnu": ["@rollup/rollup-linux-ppc64-gnu@4.59.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA=="],
+    "@rollup/rollup-linux-loong64-gnu": ["@rollup/rollup-linux-loong64-gnu@4.59.0", "https://mirrors.huaweicloud.com/repository/npm/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.59.0.tgz", { "os": "linux", "cpu": "none" }, "sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg=="],
 
-    "@rollup/rollup-linux-ppc64-musl": ["@rollup/rollup-linux-ppc64-musl@4.59.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA=="],
+    "@rollup/rollup-linux-loong64-musl": ["@rollup/rollup-linux-loong64-musl@4.59.0", "https://mirrors.huaweicloud.com/repository/npm/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.59.0.tgz", { "os": "linux", "cpu": "none" }, "sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q=="],
 
-    "@rollup/rollup-linux-riscv64-gnu": ["@rollup/rollup-linux-riscv64-gnu@4.59.0", "", { "os": "linux", "cpu": "none" }, "sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg=="],
+    "@rollup/rollup-linux-ppc64-gnu": ["@rollup/rollup-linux-ppc64-gnu@4.59.0", "https://mirrors.huaweicloud.com/repository/npm/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.59.0.tgz", { "os": "linux", "cpu": "ppc64" }, "sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA=="],
 
-    "@rollup/rollup-linux-riscv64-musl": ["@rollup/rollup-linux-riscv64-musl@4.59.0", "", { "os": "linux", "cpu": "none" }, "sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg=="],
+    "@rollup/rollup-linux-ppc64-musl": ["@rollup/rollup-linux-ppc64-musl@4.59.0", "https://mirrors.huaweicloud.com/repository/npm/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.59.0.tgz", { "os": "linux", "cpu": "ppc64" }, "sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA=="],
 
-    "@rollup/rollup-linux-s390x-gnu": ["@rollup/rollup-linux-s390x-gnu@4.59.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w=="],
+    "@rollup/rollup-linux-riscv64-gnu": ["@rollup/rollup-linux-riscv64-gnu@4.59.0", "https://mirrors.huaweicloud.com/repository/npm/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.59.0.tgz", { "os": "linux", "cpu": "none" }, "sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg=="],
 
-    "@rollup/rollup-linux-x64-gnu": ["@rollup/rollup-linux-x64-gnu@4.59.0", "", { "os": "linux", "cpu": "x64" }, "sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg=="],
+    "@rollup/rollup-linux-riscv64-musl": ["@rollup/rollup-linux-riscv64-musl@4.59.0", "https://mirrors.huaweicloud.com/repository/npm/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.59.0.tgz", { "os": "linux", "cpu": "none" }, "sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg=="],
 
-    "@rollup/rollup-linux-x64-musl": ["@rollup/rollup-linux-x64-musl@4.59.0", "", { "os": "linux", "cpu": "x64" }, "sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg=="],
+    "@rollup/rollup-linux-s390x-gnu": ["@rollup/rollup-linux-s390x-gnu@4.59.0", "https://mirrors.huaweicloud.com/repository/npm/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.59.0.tgz", { "os": "linux", "cpu": "s390x" }, "sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w=="],
 
-    "@rollup/rollup-openbsd-x64": ["@rollup/rollup-openbsd-x64@4.59.0", "", { "os": "openbsd", "cpu": "x64" }, "sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ=="],
+    "@rollup/rollup-linux-x64-gnu": ["@rollup/rollup-linux-x64-gnu@4.59.0", "https://mirrors.huaweicloud.com/repository/npm/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.59.0.tgz", { "os": "linux", "cpu": "x64" }, "sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg=="],
 
-    "@rollup/rollup-openharmony-arm64": ["@rollup/rollup-openharmony-arm64@4.59.0", "", { "os": "none", "cpu": "arm64" }, "sha512-tt9KBJqaqp5i5HUZzoafHZX8b5Q2Fe7UjYERADll83O4fGqJ49O1FsL6LpdzVFQcpwvnyd0i+K/VSwu/o/nWlA=="],
+    "@rollup/rollup-linux-x64-musl": ["@rollup/rollup-linux-x64-musl@4.59.0", "https://mirrors.huaweicloud.com/repository/npm/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.59.0.tgz", { "os": "linux", "cpu": "x64" }, "sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg=="],
 
-    "@rollup/rollup-win32-arm64-msvc": ["@rollup/rollup-win32-arm64-msvc@4.59.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-V5B6mG7OrGTwnxaNUzZTDTjDS7F75PO1ae6MJYdiMu60sq0CqN5CVeVsbhPxalupvTX8gXVSU9gq+Rx1/hvu6A=="],
+    "@rollup/rollup-openbsd-x64": ["@rollup/rollup-openbsd-x64@4.59.0", "https://mirrors.huaweicloud.com/repository/npm/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.59.0.tgz", { "os": "openbsd", "cpu": "x64" }, "sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ=="],
 
-    "@rollup/rollup-win32-ia32-msvc": ["@rollup/rollup-win32-ia32-msvc@4.59.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-UKFMHPuM9R0iBegwzKF4y0C4J9u8C6MEJgFuXTBerMk7EJ92GFVFYBfOZaSGLu6COf7FxpQNqhNS4c4icUPqxA=="],
+    "@rollup/rollup-openharmony-arm64": ["@rollup/rollup-openharmony-arm64@4.59.0", "https://mirrors.huaweicloud.com/repository/npm/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.59.0.tgz", { "os": "none", "cpu": "arm64" }, "sha512-tt9KBJqaqp5i5HUZzoafHZX8b5Q2Fe7UjYERADll83O4fGqJ49O1FsL6LpdzVFQcpwvnyd0i+K/VSwu/o/nWlA=="],
 
-    "@rollup/rollup-win32-x64-gnu": ["@rollup/rollup-win32-x64-gnu@4.59.0", "", { "os": "win32", "cpu": "x64" }, "sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA=="],
+    "@rollup/rollup-win32-arm64-msvc": ["@rollup/rollup-win32-arm64-msvc@4.59.0", "https://mirrors.huaweicloud.com/repository/npm/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.59.0.tgz", { "os": "win32", "cpu": "arm64" }, "sha512-V5B6mG7OrGTwnxaNUzZTDTjDS7F75PO1ae6MJYdiMu60sq0CqN5CVeVsbhPxalupvTX8gXVSU9gq+Rx1/hvu6A=="],
 
-    "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.59.0", "", { "os": "win32", "cpu": "x64" }, "sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA=="],
+    "@rollup/rollup-win32-ia32-msvc": ["@rollup/rollup-win32-ia32-msvc@4.59.0", "https://mirrors.huaweicloud.com/repository/npm/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.59.0.tgz", { "os": "win32", "cpu": "ia32" }, "sha512-UKFMHPuM9R0iBegwzKF4y0C4J9u8C6MEJgFuXTBerMk7EJ92GFVFYBfOZaSGLu6COf7FxpQNqhNS4c4icUPqxA=="],
 
-    "@shikijs/core": ["@shikijs/core@3.21.0", "", { "dependencies": { "@shikijs/types": "3.21.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4", "hast-util-to-html": "^9.0.5" } }, "sha512-AXSQu/2n1UIQekY8euBJlvFYZIw0PHY63jUzGbrOma4wPxzznJXTXkri+QcHeBNaFxiiOljKxxJkVSoB3PjbyA=="],
+    "@rollup/rollup-win32-x64-gnu": ["@rollup/rollup-win32-x64-gnu@4.59.0", "https://mirrors.huaweicloud.com/repository/npm/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.59.0.tgz", { "os": "win32", "cpu": "x64" }, "sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA=="],
 
-    "@shikijs/engine-javascript": ["@shikijs/engine-javascript@3.21.0", "", { "dependencies": { "@shikijs/types": "3.21.0", "@shikijs/vscode-textmate": "^10.0.2", "oniguruma-to-es": "^4.3.4" } }, "sha512-ATwv86xlbmfD9n9gKRiwuPpWgPENAWCLwYCGz9ugTJlsO2kOzhOkvoyV/UD+tJ0uT7YRyD530x6ugNSffmvIiQ=="],
+    "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.59.0", "https://mirrors.huaweicloud.com/repository/npm/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.59.0.tgz", { "os": "win32", "cpu": "x64" }, "sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA=="],
 
-    "@shikijs/engine-oniguruma": ["@shikijs/engine-oniguruma@3.21.0", "", { "dependencies": { "@shikijs/types": "3.21.0", "@shikijs/vscode-textmate": "^10.0.2" } }, "sha512-OYknTCct6qiwpQDqDdf3iedRdzj6hFlOPv5hMvI+hkWfCKs5mlJ4TXziBG9nyabLwGulrUjHiCq3xCspSzErYQ=="],
+    "@shikijs/core": ["@shikijs/core@3.21.0", "https://mirrors.huaweicloud.com/repository/npm/@shikijs/core/-/core-3.21.0.tgz", { "dependencies": { "@shikijs/types": "3.21.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4", "hast-util-to-html": "^9.0.5" } }, "sha512-AXSQu/2n1UIQekY8euBJlvFYZIw0PHY63jUzGbrOma4wPxzznJXTXkri+QcHeBNaFxiiOljKxxJkVSoB3PjbyA=="],
 
-    "@shikijs/langs": ["@shikijs/langs@3.21.0", "", { "dependencies": { "@shikijs/types": "3.21.0" } }, "sha512-g6mn5m+Y6GBJ4wxmBYqalK9Sp0CFkUqfNzUy2pJglUginz6ZpWbaWjDB4fbQ/8SHzFjYbtU6Ddlp1pc+PPNDVA=="],
+    "@shikijs/engine-javascript": ["@shikijs/engine-javascript@3.21.0", "https://mirrors.huaweicloud.com/repository/npm/@shikijs/engine-javascript/-/engine-javascript-3.21.0.tgz", { "dependencies": { "@shikijs/types": "3.21.0", "@shikijs/vscode-textmate": "^10.0.2", "oniguruma-to-es": "^4.3.4" } }, "sha512-ATwv86xlbmfD9n9gKRiwuPpWgPENAWCLwYCGz9ugTJlsO2kOzhOkvoyV/UD+tJ0uT7YRyD530x6ugNSffmvIiQ=="],
 
-    "@shikijs/themes": ["@shikijs/themes@3.21.0", "", { "dependencies": { "@shikijs/types": "3.21.0" } }, "sha512-BAE4cr9EDiZyYzwIHEk7JTBJ9CzlPuM4PchfcA5ao1dWXb25nv6hYsoDiBq2aZK9E3dlt3WB78uI96UESD+8Mw=="],
+    "@shikijs/engine-oniguruma": ["@shikijs/engine-oniguruma@3.21.0", "https://mirrors.huaweicloud.com/repository/npm/@shikijs/engine-oniguruma/-/engine-oniguruma-3.21.0.tgz", { "dependencies": { "@shikijs/types": "3.21.0", "@shikijs/vscode-textmate": "^10.0.2" } }, "sha512-OYknTCct6qiwpQDqDdf3iedRdzj6hFlOPv5hMvI+hkWfCKs5mlJ4TXziBG9nyabLwGulrUjHiCq3xCspSzErYQ=="],
 
-    "@shikijs/types": ["@shikijs/types@3.21.0", "", { "dependencies": { "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-zGrWOxZ0/+0ovPY7PvBU2gIS9tmhSUUt30jAcNV0Bq0gb2S98gwfjIs1vxlmH5zM7/4YxLamT6ChlqqAJmPPjA=="],
+    "@shikijs/langs": ["@shikijs/langs@3.21.0", "https://mirrors.huaweicloud.com/repository/npm/@shikijs/langs/-/langs-3.21.0.tgz", { "dependencies": { "@shikijs/types": "3.21.0" } }, "sha512-g6mn5m+Y6GBJ4wxmBYqalK9Sp0CFkUqfNzUy2pJglUginz6ZpWbaWjDB4fbQ/8SHzFjYbtU6Ddlp1pc+PPNDVA=="],
 
-    "@shikijs/vscode-textmate": ["@shikijs/vscode-textmate@10.0.2", "", {}, "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg=="],
+    "@shikijs/themes": ["@shikijs/themes@3.21.0", "https://mirrors.huaweicloud.com/repository/npm/@shikijs/themes/-/themes-3.21.0.tgz", { "dependencies": { "@shikijs/types": "3.21.0" } }, "sha512-BAE4cr9EDiZyYzwIHEk7JTBJ9CzlPuM4PchfcA5ao1dWXb25nv6hYsoDiBq2aZK9E3dlt3WB78uI96UESD+8Mw=="],
 
-    "@types/bun": ["@types/bun@1.3.9", "", { "dependencies": { "bun-types": "1.3.9" } }, "sha512-KQ571yULOdWJiMH+RIWIOZ7B2RXQGpL1YQrBtLIV3FqDcCu6FsbFUBwhdKUlCKUpS3PJDsHlJ1QKlpxoVR+xtw=="],
+    "@shikijs/types": ["@shikijs/types@3.21.0", "https://mirrors.huaweicloud.com/repository/npm/@shikijs/types/-/types-3.21.0.tgz", { "dependencies": { "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-zGrWOxZ0/+0ovPY7PvBU2gIS9tmhSUUt30jAcNV0Bq0gb2S98gwfjIs1vxlmH5zM7/4YxLamT6ChlqqAJmPPjA=="],
 
-    "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
+    "@shikijs/vscode-textmate": ["@shikijs/vscode-textmate@10.0.2", "https://mirrors.huaweicloud.com/repository/npm/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz", {}, "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg=="],
 
-    "@types/hast": ["@types/hast@3.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ=="],
+    "@types/bun": ["@types/bun@1.3.9", "https://mirrors.huaweicloud.com/repository/npm/@types/bun/-/bun-1.3.9.tgz", { "dependencies": { "bun-types": "1.3.9" } }, "sha512-KQ571yULOdWJiMH+RIWIOZ7B2RXQGpL1YQrBtLIV3FqDcCu6FsbFUBwhdKUlCKUpS3PJDsHlJ1QKlpxoVR+xtw=="],
 
-    "@types/mdast": ["@types/mdast@4.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA=="],
+    "@types/estree": ["@types/estree@1.0.8", "https://mirrors.huaweicloud.com/repository/npm/@types/estree/-/estree-1.0.8.tgz", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
-    "@types/node": ["@types/node@25.3.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-4K3bqJpXpqfg2XKGK9bpDTc6xO/xoUP/RBWS7AtRMug6zZFaRekiLzjVtAoZMquxoAbzBvy5nxQ7veS5eYzf8A=="],
+    "@types/hast": ["@types/hast@3.0.4", "https://mirrors.huaweicloud.com/repository/npm/@types/hast/-/hast-3.0.4.tgz", { "dependencies": { "@types/unist": "*" } }, "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ=="],
 
-    "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
+    "@types/mdast": ["@types/mdast@4.0.4", "https://mirrors.huaweicloud.com/repository/npm/@types/mdast/-/mdast-4.0.4.tgz", { "dependencies": { "@types/unist": "*" } }, "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA=="],
 
-    "@ungap/structured-clone": ["@ungap/structured-clone@1.3.0", "", {}, "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g=="],
+    "@types/node": ["@types/node@25.3.0", "https://mirrors.huaweicloud.com/repository/npm/@types/node/-/node-25.3.0.tgz", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-4K3bqJpXpqfg2XKGK9bpDTc6xO/xoUP/RBWS7AtRMug6zZFaRekiLzjVtAoZMquxoAbzBvy5nxQ7veS5eYzf8A=="],
 
-    "acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
+    "@types/unist": ["@types/unist@3.0.3", "https://mirrors.huaweicloud.com/repository/npm/@types/unist/-/unist-3.0.3.tgz", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 
-    "any-promise": ["any-promise@1.3.0", "", {}, "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A=="],
+    "@ungap/structured-clone": ["@ungap/structured-clone@1.3.0", "https://mirrors.huaweicloud.com/repository/npm/@ungap/structured-clone/-/structured-clone-1.3.0.tgz", {}, "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g=="],
 
-    "bun-types": ["bun-types@1.3.9", "", { "dependencies": { "@types/node": "*" } }, "sha512-+UBWWOakIP4Tswh0Bt0QD0alpTY8cb5hvgiYeWCMet9YukHbzuruIEeXC2D7nMJPB12kbh8C7XJykSexEqGKJg=="],
+    "acorn": ["acorn@8.16.0", "https://mirrors.huaweicloud.com/repository/npm/acorn/-/acorn-8.16.0.tgz", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
 
-    "bundle-require": ["bundle-require@5.1.0", "", { "dependencies": { "load-tsconfig": "^0.2.3" }, "peerDependencies": { "esbuild": ">=0.18" } }, "sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA=="],
+    "any-promise": ["any-promise@1.3.0", "https://mirrors.huaweicloud.com/repository/npm/any-promise/-/any-promise-1.3.0.tgz", {}, "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A=="],
 
-    "cac": ["cac@6.7.14", "", {}, "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ=="],
+    "bun-types": ["bun-types@1.3.9", "https://mirrors.huaweicloud.com/repository/npm/bun-types/-/bun-types-1.3.9.tgz", { "dependencies": { "@types/node": "*" } }, "sha512-+UBWWOakIP4Tswh0Bt0QD0alpTY8cb5hvgiYeWCMet9YukHbzuruIEeXC2D7nMJPB12kbh8C7XJykSexEqGKJg=="],
 
-    "ccount": ["ccount@2.0.1", "", {}, "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg=="],
+    "bundle-require": ["bundle-require@5.1.0", "https://mirrors.huaweicloud.com/repository/npm/bundle-require/-/bundle-require-5.1.0.tgz", { "dependencies": { "load-tsconfig": "^0.2.3" }, "peerDependencies": { "esbuild": ">=0.18" } }, "sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA=="],
 
-    "character-entities-html4": ["character-entities-html4@2.1.0", "", {}, "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA=="],
+    "cac": ["cac@6.7.14", "https://mirrors.huaweicloud.com/repository/npm/cac/-/cac-6.7.14.tgz", {}, "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ=="],
 
-    "character-entities-legacy": ["character-entities-legacy@3.0.0", "", {}, "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ=="],
+    "ccount": ["ccount@2.0.1", "https://mirrors.huaweicloud.com/repository/npm/ccount/-/ccount-2.0.1.tgz", {}, "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg=="],
 
-    "chokidar": ["chokidar@4.0.3", "", { "dependencies": { "readdirp": "^4.0.1" } }, "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA=="],
+    "character-entities-html4": ["character-entities-html4@2.1.0", "https://mirrors.huaweicloud.com/repository/npm/character-entities-html4/-/character-entities-html4-2.1.0.tgz", {}, "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA=="],
 
-    "comma-separated-tokens": ["comma-separated-tokens@2.0.3", "", {}, "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg=="],
+    "character-entities-legacy": ["character-entities-legacy@3.0.0", "https://mirrors.huaweicloud.com/repository/npm/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz", {}, "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ=="],
 
-    "commander": ["commander@4.1.1", "", {}, "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA=="],
+    "chokidar": ["chokidar@4.0.3", "https://mirrors.huaweicloud.com/repository/npm/chokidar/-/chokidar-4.0.3.tgz", { "dependencies": { "readdirp": "^4.0.1" } }, "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA=="],
 
-    "confbox": ["confbox@0.1.8", "", {}, "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w=="],
+    "comma-separated-tokens": ["comma-separated-tokens@2.0.3", "https://mirrors.huaweicloud.com/repository/npm/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz", {}, "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg=="],
 
-    "consola": ["consola@3.4.2", "", {}, "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA=="],
+    "commander": ["commander@4.1.1", "https://mirrors.huaweicloud.com/repository/npm/commander/-/commander-4.1.1.tgz", {}, "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA=="],
 
-    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+    "confbox": ["confbox@0.1.8", "https://mirrors.huaweicloud.com/repository/npm/confbox/-/confbox-0.1.8.tgz", {}, "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w=="],
 
-    "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
+    "consola": ["consola@3.4.2", "https://mirrors.huaweicloud.com/repository/npm/consola/-/consola-3.4.2.tgz", {}, "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA=="],
 
-    "devlop": ["devlop@1.1.0", "", { "dependencies": { "dequal": "^2.0.0" } }, "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA=="],
+    "debug": ["debug@4.4.3", "https://mirrors.huaweicloud.com/repository/npm/debug/-/debug-4.4.3.tgz", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
-    "elkjs": ["elkjs@0.11.0", "", {}, "sha512-u4J8h9mwEDaYMqo0RYJpqNMFDoMK7f+pu4GjcV+N8jIC7TRdORgzkfSjTJemhqONFfH6fBI3wpysgWbhgVWIXw=="],
+    "dequal": ["dequal@2.0.3", "https://mirrors.huaweicloud.com/repository/npm/dequal/-/dequal-2.0.3.tgz", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
 
-    "entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
+    "devlop": ["devlop@1.1.0", "https://mirrors.huaweicloud.com/repository/npm/devlop/-/devlop-1.1.0.tgz", { "dependencies": { "dequal": "^2.0.0" } }, "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA=="],
 
-    "esbuild": ["esbuild@0.27.3", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.3", "@esbuild/android-arm": "0.27.3", "@esbuild/android-arm64": "0.27.3", "@esbuild/android-x64": "0.27.3", "@esbuild/darwin-arm64": "0.27.3", "@esbuild/darwin-x64": "0.27.3", "@esbuild/freebsd-arm64": "0.27.3", "@esbuild/freebsd-x64": "0.27.3", "@esbuild/linux-arm": "0.27.3", "@esbuild/linux-arm64": "0.27.3", "@esbuild/linux-ia32": "0.27.3", "@esbuild/linux-loong64": "0.27.3", "@esbuild/linux-mips64el": "0.27.3", "@esbuild/linux-ppc64": "0.27.3", "@esbuild/linux-riscv64": "0.27.3", "@esbuild/linux-s390x": "0.27.3", "@esbuild/linux-x64": "0.27.3", "@esbuild/netbsd-arm64": "0.27.3", "@esbuild/netbsd-x64": "0.27.3", "@esbuild/openbsd-arm64": "0.27.3", "@esbuild/openbsd-x64": "0.27.3", "@esbuild/openharmony-arm64": "0.27.3", "@esbuild/sunos-x64": "0.27.3", "@esbuild/win32-arm64": "0.27.3", "@esbuild/win32-ia32": "0.27.3", "@esbuild/win32-x64": "0.27.3" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg=="],
+    "elkjs": ["elkjs@0.11.0", "https://mirrors.huaweicloud.com/repository/npm/elkjs/-/elkjs-0.11.0.tgz", {}, "sha512-u4J8h9mwEDaYMqo0RYJpqNMFDoMK7f+pu4GjcV+N8jIC7TRdORgzkfSjTJemhqONFfH6fBI3wpysgWbhgVWIXw=="],
 
-    "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
+    "entities": ["entities@7.0.1", "https://mirrors.huaweicloud.com/repository/npm/entities/-/entities-7.0.1.tgz", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
 
-    "fix-dts-default-cjs-exports": ["fix-dts-default-cjs-exports@1.0.1", "", { "dependencies": { "magic-string": "^0.30.17", "mlly": "^1.7.4", "rollup": "^4.34.8" } }, "sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg=="],
+    "esbuild": ["esbuild@0.27.3", "https://mirrors.huaweicloud.com/repository/npm/esbuild/-/esbuild-0.27.3.tgz", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.3", "@esbuild/android-arm": "0.27.3", "@esbuild/android-arm64": "0.27.3", "@esbuild/android-x64": "0.27.3", "@esbuild/darwin-arm64": "0.27.3", "@esbuild/darwin-x64": "0.27.3", "@esbuild/freebsd-arm64": "0.27.3", "@esbuild/freebsd-x64": "0.27.3", "@esbuild/linux-arm": "0.27.3", "@esbuild/linux-arm64": "0.27.3", "@esbuild/linux-ia32": "0.27.3", "@esbuild/linux-loong64": "0.27.3", "@esbuild/linux-mips64el": "0.27.3", "@esbuild/linux-ppc64": "0.27.3", "@esbuild/linux-riscv64": "0.27.3", "@esbuild/linux-s390x": "0.27.3", "@esbuild/linux-x64": "0.27.3", "@esbuild/netbsd-arm64": "0.27.3", "@esbuild/netbsd-x64": "0.27.3", "@esbuild/openbsd-arm64": "0.27.3", "@esbuild/openbsd-x64": "0.27.3", "@esbuild/openharmony-arm64": "0.27.3", "@esbuild/sunos-x64": "0.27.3", "@esbuild/win32-arm64": "0.27.3", "@esbuild/win32-ia32": "0.27.3", "@esbuild/win32-x64": "0.27.3" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg=="],
 
-    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+    "fdir": ["fdir@6.5.0", "https://mirrors.huaweicloud.com/repository/npm/fdir/-/fdir-6.5.0.tgz", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
-    "hast-util-to-html": ["hast-util-to-html@9.0.5", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "ccount": "^2.0.0", "comma-separated-tokens": "^2.0.0", "hast-util-whitespace": "^3.0.0", "html-void-elements": "^3.0.0", "mdast-util-to-hast": "^13.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0", "stringify-entities": "^4.0.0", "zwitch": "^2.0.4" } }, "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw=="],
+    "fix-dts-default-cjs-exports": ["fix-dts-default-cjs-exports@1.0.1", "https://mirrors.huaweicloud.com/repository/npm/fix-dts-default-cjs-exports/-/fix-dts-default-cjs-exports-1.0.1.tgz", { "dependencies": { "magic-string": "^0.30.17", "mlly": "^1.7.4", "rollup": "^4.34.8" } }, "sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg=="],
 
-    "hast-util-whitespace": ["hast-util-whitespace@3.0.0", "", { "dependencies": { "@types/hast": "^3.0.0" } }, "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw=="],
+    "fsevents": ["fsevents@2.3.3", "https://mirrors.huaweicloud.com/repository/npm/fsevents/-/fsevents-2.3.3.tgz", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
-    "html-void-elements": ["html-void-elements@3.0.0", "", {}, "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg=="],
+    "hast-util-to-html": ["hast-util-to-html@9.0.5", "https://mirrors.huaweicloud.com/repository/npm/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz", { "dependencies": { "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "ccount": "^2.0.0", "comma-separated-tokens": "^2.0.0", "hast-util-whitespace": "^3.0.0", "html-void-elements": "^3.0.0", "mdast-util-to-hast": "^13.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0", "stringify-entities": "^4.0.0", "zwitch": "^2.0.4" } }, "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw=="],
 
-    "joycon": ["joycon@3.1.1", "", {}, "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw=="],
+    "hast-util-whitespace": ["hast-util-whitespace@3.0.0", "https://mirrors.huaweicloud.com/repository/npm/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz", { "dependencies": { "@types/hast": "^3.0.0" } }, "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw=="],
 
-    "lilconfig": ["lilconfig@3.1.3", "", {}, "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw=="],
+    "html-void-elements": ["html-void-elements@3.0.0", "https://mirrors.huaweicloud.com/repository/npm/html-void-elements/-/html-void-elements-3.0.0.tgz", {}, "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg=="],
 
-    "lines-and-columns": ["lines-and-columns@1.2.4", "", {}, "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="],
+    "joycon": ["joycon@3.1.1", "https://mirrors.huaweicloud.com/repository/npm/joycon/-/joycon-3.1.1.tgz", {}, "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw=="],
 
-    "load-tsconfig": ["load-tsconfig@0.2.5", "", {}, "sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg=="],
+    "lilconfig": ["lilconfig@3.1.3", "https://mirrors.huaweicloud.com/repository/npm/lilconfig/-/lilconfig-3.1.3.tgz", {}, "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw=="],
 
-    "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
+    "lines-and-columns": ["lines-and-columns@1.2.4", "https://mirrors.huaweicloud.com/repository/npm/lines-and-columns/-/lines-and-columns-1.2.4.tgz", {}, "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="],
 
-    "mdast-util-to-hast": ["mdast-util-to-hast@13.2.1", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "@ungap/structured-clone": "^1.0.0", "devlop": "^1.0.0", "micromark-util-sanitize-uri": "^2.0.0", "trim-lines": "^3.0.0", "unist-util-position": "^5.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" } }, "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA=="],
+    "load-tsconfig": ["load-tsconfig@0.2.5", "https://mirrors.huaweicloud.com/repository/npm/load-tsconfig/-/load-tsconfig-0.2.5.tgz", {}, "sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg=="],
 
-    "micromark-util-character": ["micromark-util-character@2.1.1", "", { "dependencies": { "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q=="],
+    "magic-string": ["magic-string@0.30.21", "https://mirrors.huaweicloud.com/repository/npm/magic-string/-/magic-string-0.30.21.tgz", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
-    "micromark-util-encode": ["micromark-util-encode@2.0.1", "", {}, "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw=="],
+    "mdast-util-to-hast": ["mdast-util-to-hast@13.2.1", "https://mirrors.huaweicloud.com/repository/npm/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz", { "dependencies": { "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "@ungap/structured-clone": "^1.0.0", "devlop": "^1.0.0", "micromark-util-sanitize-uri": "^2.0.0", "trim-lines": "^3.0.0", "unist-util-position": "^5.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" } }, "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA=="],
 
-    "micromark-util-sanitize-uri": ["micromark-util-sanitize-uri@2.0.1", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-encode": "^2.0.0", "micromark-util-symbol": "^2.0.0" } }, "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ=="],
+    "micromark-util-character": ["micromark-util-character@2.1.1", "https://mirrors.huaweicloud.com/repository/npm/micromark-util-character/-/micromark-util-character-2.1.1.tgz", { "dependencies": { "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q=="],
 
-    "micromark-util-symbol": ["micromark-util-symbol@2.0.1", "", {}, "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q=="],
+    "micromark-util-encode": ["micromark-util-encode@2.0.1", "https://mirrors.huaweicloud.com/repository/npm/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz", {}, "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw=="],
 
-    "micromark-util-types": ["micromark-util-types@2.0.2", "", {}, "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA=="],
+    "micromark-util-sanitize-uri": ["micromark-util-sanitize-uri@2.0.1", "https://mirrors.huaweicloud.com/repository/npm/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-encode": "^2.0.0", "micromark-util-symbol": "^2.0.0" } }, "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ=="],
 
-    "mlly": ["mlly@1.8.0", "", { "dependencies": { "acorn": "^8.15.0", "pathe": "^2.0.3", "pkg-types": "^1.3.1", "ufo": "^1.6.1" } }, "sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g=="],
+    "micromark-util-symbol": ["micromark-util-symbol@2.0.1", "https://mirrors.huaweicloud.com/repository/npm/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz", {}, "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q=="],
 
-    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+    "micromark-util-types": ["micromark-util-types@2.0.2", "https://mirrors.huaweicloud.com/repository/npm/micromark-util-types/-/micromark-util-types-2.0.2.tgz", {}, "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA=="],
 
-    "mz": ["mz@2.7.0", "", { "dependencies": { "any-promise": "^1.0.0", "object-assign": "^4.0.1", "thenify-all": "^1.0.0" } }, "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q=="],
+    "mlly": ["mlly@1.8.0", "https://mirrors.huaweicloud.com/repository/npm/mlly/-/mlly-1.8.0.tgz", { "dependencies": { "acorn": "^8.15.0", "pathe": "^2.0.3", "pkg-types": "^1.3.1", "ufo": "^1.6.1" } }, "sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g=="],
 
-    "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
+    "ms": ["ms@2.1.3", "https://mirrors.huaweicloud.com/repository/npm/ms/-/ms-2.1.3.tgz", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
-    "oniguruma-parser": ["oniguruma-parser@0.12.1", "", {}, "sha512-8Unqkvk1RYc6yq2WBYRj4hdnsAxVze8i7iPfQr8e4uSP3tRv0rpZcbGUDvxfQQcdwHt/e9PrMvGCsa8OqG9X3w=="],
+    "mz": ["mz@2.7.0", "https://mirrors.huaweicloud.com/repository/npm/mz/-/mz-2.7.0.tgz", { "dependencies": { "any-promise": "^1.0.0", "object-assign": "^4.0.1", "thenify-all": "^1.0.0" } }, "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q=="],
 
-    "oniguruma-to-es": ["oniguruma-to-es@4.3.4", "", { "dependencies": { "oniguruma-parser": "^0.12.1", "regex": "^6.0.1", "regex-recursion": "^6.0.2" } }, "sha512-3VhUGN3w2eYxnTzHn+ikMI+fp/96KoRSVK9/kMTcFqj1NRDh2IhQCKvYxDnWePKRXY/AqH+Fuiyb7VHSzBjHfA=="],
+    "object-assign": ["object-assign@4.1.1", "https://mirrors.huaweicloud.com/repository/npm/object-assign/-/object-assign-4.1.1.tgz", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
 
-    "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
+    "oniguruma-parser": ["oniguruma-parser@0.12.1", "https://mirrors.huaweicloud.com/repository/npm/oniguruma-parser/-/oniguruma-parser-0.12.1.tgz", {}, "sha512-8Unqkvk1RYc6yq2WBYRj4hdnsAxVze8i7iPfQr8e4uSP3tRv0rpZcbGUDvxfQQcdwHt/e9PrMvGCsa8OqG9X3w=="],
 
-    "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
+    "oniguruma-to-es": ["oniguruma-to-es@4.3.4", "https://mirrors.huaweicloud.com/repository/npm/oniguruma-to-es/-/oniguruma-to-es-4.3.4.tgz", { "dependencies": { "oniguruma-parser": "^0.12.1", "regex": "^6.0.1", "regex-recursion": "^6.0.2" } }, "sha512-3VhUGN3w2eYxnTzHn+ikMI+fp/96KoRSVK9/kMTcFqj1NRDh2IhQCKvYxDnWePKRXY/AqH+Fuiyb7VHSzBjHfA=="],
 
-    "picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
+    "pathe": ["pathe@2.0.3", "https://mirrors.huaweicloud.com/repository/npm/pathe/-/pathe-2.0.3.tgz", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
 
-    "pirates": ["pirates@4.0.7", "", {}, "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA=="],
+    "picocolors": ["picocolors@1.1.1", "https://mirrors.huaweicloud.com/repository/npm/picocolors/-/picocolors-1.1.1.tgz", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
-    "pkg-types": ["pkg-types@1.3.1", "", { "dependencies": { "confbox": "^0.1.8", "mlly": "^1.7.4", "pathe": "^2.0.1" } }, "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ=="],
+    "picomatch": ["picomatch@4.0.3", "https://mirrors.huaweicloud.com/repository/npm/picomatch/-/picomatch-4.0.3.tgz", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
 
-    "postcss-load-config": ["postcss-load-config@6.0.1", "", { "dependencies": { "lilconfig": "^3.1.1" }, "peerDependencies": { "jiti": ">=1.21.0", "postcss": ">=8.0.9", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["jiti", "postcss", "tsx", "yaml"] }, "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g=="],
+    "pirates": ["pirates@4.0.7", "https://mirrors.huaweicloud.com/repository/npm/pirates/-/pirates-4.0.7.tgz", {}, "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA=="],
 
-    "property-information": ["property-information@7.1.0", "", {}, "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ=="],
+    "pkg-types": ["pkg-types@1.3.1", "https://mirrors.huaweicloud.com/repository/npm/pkg-types/-/pkg-types-1.3.1.tgz", { "dependencies": { "confbox": "^0.1.8", "mlly": "^1.7.4", "pathe": "^2.0.1" } }, "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ=="],
 
-    "readdirp": ["readdirp@4.1.2", "", {}, "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="],
+    "postcss-load-config": ["postcss-load-config@6.0.1", "https://mirrors.huaweicloud.com/repository/npm/postcss-load-config/-/postcss-load-config-6.0.1.tgz", { "dependencies": { "lilconfig": "^3.1.1" }, "peerDependencies": { "jiti": ">=1.21.0", "postcss": ">=8.0.9", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["jiti", "postcss", "tsx", "yaml"] }, "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g=="],
 
-    "regex": ["regex@6.1.0", "", { "dependencies": { "regex-utilities": "^2.3.0" } }, "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg=="],
+    "property-information": ["property-information@7.1.0", "https://mirrors.huaweicloud.com/repository/npm/property-information/-/property-information-7.1.0.tgz", {}, "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ=="],
 
-    "regex-recursion": ["regex-recursion@6.0.2", "", { "dependencies": { "regex-utilities": "^2.3.0" } }, "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg=="],
+    "readdirp": ["readdirp@4.1.2", "https://mirrors.huaweicloud.com/repository/npm/readdirp/-/readdirp-4.1.2.tgz", {}, "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="],
 
-    "regex-utilities": ["regex-utilities@2.3.0", "", {}, "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng=="],
+    "regex": ["regex@6.1.0", "https://mirrors.huaweicloud.com/repository/npm/regex/-/regex-6.1.0.tgz", { "dependencies": { "regex-utilities": "^2.3.0" } }, "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg=="],
 
-    "resolve-from": ["resolve-from@5.0.0", "", {}, "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw=="],
+    "regex-recursion": ["regex-recursion@6.0.2", "https://mirrors.huaweicloud.com/repository/npm/regex-recursion/-/regex-recursion-6.0.2.tgz", { "dependencies": { "regex-utilities": "^2.3.0" } }, "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg=="],
 
-    "rollup": ["rollup@4.59.0", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.59.0", "@rollup/rollup-android-arm64": "4.59.0", "@rollup/rollup-darwin-arm64": "4.59.0", "@rollup/rollup-darwin-x64": "4.59.0", "@rollup/rollup-freebsd-arm64": "4.59.0", "@rollup/rollup-freebsd-x64": "4.59.0", "@rollup/rollup-linux-arm-gnueabihf": "4.59.0", "@rollup/rollup-linux-arm-musleabihf": "4.59.0", "@rollup/rollup-linux-arm64-gnu": "4.59.0", "@rollup/rollup-linux-arm64-musl": "4.59.0", "@rollup/rollup-linux-loong64-gnu": "4.59.0", "@rollup/rollup-linux-loong64-musl": "4.59.0", "@rollup/rollup-linux-ppc64-gnu": "4.59.0", "@rollup/rollup-linux-ppc64-musl": "4.59.0", "@rollup/rollup-linux-riscv64-gnu": "4.59.0", "@rollup/rollup-linux-riscv64-musl": "4.59.0", "@rollup/rollup-linux-s390x-gnu": "4.59.0", "@rollup/rollup-linux-x64-gnu": "4.59.0", "@rollup/rollup-linux-x64-musl": "4.59.0", "@rollup/rollup-openbsd-x64": "4.59.0", "@rollup/rollup-openharmony-arm64": "4.59.0", "@rollup/rollup-win32-arm64-msvc": "4.59.0", "@rollup/rollup-win32-ia32-msvc": "4.59.0", "@rollup/rollup-win32-x64-gnu": "4.59.0", "@rollup/rollup-win32-x64-msvc": "4.59.0", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg=="],
+    "regex-utilities": ["regex-utilities@2.3.0", "https://mirrors.huaweicloud.com/repository/npm/regex-utilities/-/regex-utilities-2.3.0.tgz", {}, "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng=="],
 
-    "shiki": ["shiki@3.21.0", "", { "dependencies": { "@shikijs/core": "3.21.0", "@shikijs/engine-javascript": "3.21.0", "@shikijs/engine-oniguruma": "3.21.0", "@shikijs/langs": "3.21.0", "@shikijs/themes": "3.21.0", "@shikijs/types": "3.21.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-N65B/3bqL/TI2crrXr+4UivctrAGEjmsib5rPMMPpFp1xAx/w03v8WZ9RDDFYteXoEgY7qZ4HGgl5KBIu1153w=="],
+    "resolve-from": ["resolve-from@5.0.0", "https://mirrors.huaweicloud.com/repository/npm/resolve-from/-/resolve-from-5.0.0.tgz", {}, "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw=="],
 
-    "source-map": ["source-map@0.7.6", "", {}, "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ=="],
+    "rollup": ["rollup@4.59.0", "https://mirrors.huaweicloud.com/repository/npm/rollup/-/rollup-4.59.0.tgz", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.59.0", "@rollup/rollup-android-arm64": "4.59.0", "@rollup/rollup-darwin-arm64": "4.59.0", "@rollup/rollup-darwin-x64": "4.59.0", "@rollup/rollup-freebsd-arm64": "4.59.0", "@rollup/rollup-freebsd-x64": "4.59.0", "@rollup/rollup-linux-arm-gnueabihf": "4.59.0", "@rollup/rollup-linux-arm-musleabihf": "4.59.0", "@rollup/rollup-linux-arm64-gnu": "4.59.0", "@rollup/rollup-linux-arm64-musl": "4.59.0", "@rollup/rollup-linux-loong64-gnu": "4.59.0", "@rollup/rollup-linux-loong64-musl": "4.59.0", "@rollup/rollup-linux-ppc64-gnu": "4.59.0", "@rollup/rollup-linux-ppc64-musl": "4.59.0", "@rollup/rollup-linux-riscv64-gnu": "4.59.0", "@rollup/rollup-linux-riscv64-musl": "4.59.0", "@rollup/rollup-linux-s390x-gnu": "4.59.0", "@rollup/rollup-linux-x64-gnu": "4.59.0", "@rollup/rollup-linux-x64-musl": "4.59.0", "@rollup/rollup-openbsd-x64": "4.59.0", "@rollup/rollup-openharmony-arm64": "4.59.0", "@rollup/rollup-win32-arm64-msvc": "4.59.0", "@rollup/rollup-win32-ia32-msvc": "4.59.0", "@rollup/rollup-win32-x64-gnu": "4.59.0", "@rollup/rollup-win32-x64-msvc": "4.59.0", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg=="],
 
-    "space-separated-tokens": ["space-separated-tokens@2.0.2", "", {}, "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q=="],
+    "shiki": ["shiki@3.21.0", "https://mirrors.huaweicloud.com/repository/npm/shiki/-/shiki-3.21.0.tgz", { "dependencies": { "@shikijs/core": "3.21.0", "@shikijs/engine-javascript": "3.21.0", "@shikijs/engine-oniguruma": "3.21.0", "@shikijs/langs": "3.21.0", "@shikijs/themes": "3.21.0", "@shikijs/types": "3.21.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-N65B/3bqL/TI2crrXr+4UivctrAGEjmsib5rPMMPpFp1xAx/w03v8WZ9RDDFYteXoEgY7qZ4HGgl5KBIu1153w=="],
 
-    "stringify-entities": ["stringify-entities@4.0.4", "", { "dependencies": { "character-entities-html4": "^2.0.0", "character-entities-legacy": "^3.0.0" } }, "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg=="],
+    "source-map": ["source-map@0.7.6", "https://mirrors.huaweicloud.com/repository/npm/source-map/-/source-map-0.7.6.tgz", {}, "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ=="],
 
-    "sucrase": ["sucrase@3.35.1", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.2", "commander": "^4.0.0", "lines-and-columns": "^1.1.6", "mz": "^2.7.0", "pirates": "^4.0.1", "tinyglobby": "^0.2.11", "ts-interface-checker": "^0.1.9" }, "bin": { "sucrase": "bin/sucrase", "sucrase-node": "bin/sucrase-node" } }, "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw=="],
+    "space-separated-tokens": ["space-separated-tokens@2.0.2", "https://mirrors.huaweicloud.com/repository/npm/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz", {}, "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q=="],
 
-    "thenify": ["thenify@3.3.1", "", { "dependencies": { "any-promise": "^1.0.0" } }, "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw=="],
+    "stringify-entities": ["stringify-entities@4.0.4", "https://mirrors.huaweicloud.com/repository/npm/stringify-entities/-/stringify-entities-4.0.4.tgz", { "dependencies": { "character-entities-html4": "^2.0.0", "character-entities-legacy": "^3.0.0" } }, "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg=="],
 
-    "thenify-all": ["thenify-all@1.6.0", "", { "dependencies": { "thenify": ">= 3.1.0 < 4" } }, "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA=="],
+    "sucrase": ["sucrase@3.35.1", "https://mirrors.huaweicloud.com/repository/npm/sucrase/-/sucrase-3.35.1.tgz", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.2", "commander": "^4.0.0", "lines-and-columns": "^1.1.6", "mz": "^2.7.0", "pirates": "^4.0.1", "tinyglobby": "^0.2.11", "ts-interface-checker": "^0.1.9" }, "bin": { "sucrase": "bin/sucrase", "sucrase-node": "bin/sucrase-node" } }, "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw=="],
 
-    "tinyexec": ["tinyexec@0.3.2", "", {}, "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA=="],
+    "thenify": ["thenify@3.3.1", "https://mirrors.huaweicloud.com/repository/npm/thenify/-/thenify-3.3.1.tgz", { "dependencies": { "any-promise": "^1.0.0" } }, "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw=="],
 
-    "tinyglobby": ["tinyglobby@0.2.15", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.3" } }, "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ=="],
+    "thenify-all": ["thenify-all@1.6.0", "https://mirrors.huaweicloud.com/repository/npm/thenify-all/-/thenify-all-1.6.0.tgz", { "dependencies": { "thenify": ">= 3.1.0 < 4" } }, "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA=="],
 
-    "tree-kill": ["tree-kill@1.2.2", "", { "bin": { "tree-kill": "cli.js" } }, "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A=="],
+    "tinyexec": ["tinyexec@0.3.2", "https://mirrors.huaweicloud.com/repository/npm/tinyexec/-/tinyexec-0.3.2.tgz", {}, "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA=="],
 
-    "trim-lines": ["trim-lines@3.0.1", "", {}, "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg=="],
+    "tinyglobby": ["tinyglobby@0.2.15", "https://mirrors.huaweicloud.com/repository/npm/tinyglobby/-/tinyglobby-0.2.15.tgz", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.3" } }, "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ=="],
 
-    "ts-interface-checker": ["ts-interface-checker@0.1.13", "", {}, "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA=="],
+    "tree-kill": ["tree-kill@1.2.2", "https://mirrors.huaweicloud.com/repository/npm/tree-kill/-/tree-kill-1.2.2.tgz", { "bin": { "tree-kill": "cli.js" } }, "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A=="],
 
-    "tsup": ["tsup@8.5.1", "", { "dependencies": { "bundle-require": "^5.1.0", "cac": "^6.7.14", "chokidar": "^4.0.3", "consola": "^3.4.0", "debug": "^4.4.0", "esbuild": "^0.27.0", "fix-dts-default-cjs-exports": "^1.0.0", "joycon": "^3.1.1", "picocolors": "^1.1.1", "postcss-load-config": "^6.0.1", "resolve-from": "^5.0.0", "rollup": "^4.34.8", "source-map": "^0.7.6", "sucrase": "^3.35.0", "tinyexec": "^0.3.2", "tinyglobby": "^0.2.11", "tree-kill": "^1.2.2" }, "peerDependencies": { "@microsoft/api-extractor": "^7.36.0", "@swc/core": "^1", "postcss": "^8.4.12", "typescript": ">=4.5.0" }, "optionalPeers": ["@microsoft/api-extractor", "@swc/core", "postcss", "typescript"], "bin": { "tsup": "dist/cli-default.js", "tsup-node": "dist/cli-node.js" } }, "sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing=="],
+    "trim-lines": ["trim-lines@3.0.1", "https://mirrors.huaweicloud.com/repository/npm/trim-lines/-/trim-lines-3.0.1.tgz", {}, "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg=="],
 
-    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+    "ts-interface-checker": ["ts-interface-checker@0.1.13", "https://mirrors.huaweicloud.com/repository/npm/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz", {}, "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA=="],
 
-    "ufo": ["ufo@1.6.3", "", {}, "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q=="],
+    "tsup": ["tsup@8.5.1", "https://mirrors.huaweicloud.com/repository/npm/tsup/-/tsup-8.5.1.tgz", { "dependencies": { "bundle-require": "^5.1.0", "cac": "^6.7.14", "chokidar": "^4.0.3", "consola": "^3.4.0", "debug": "^4.4.0", "esbuild": "^0.27.0", "fix-dts-default-cjs-exports": "^1.0.0", "joycon": "^3.1.1", "picocolors": "^1.1.1", "postcss-load-config": "^6.0.1", "resolve-from": "^5.0.0", "rollup": "^4.34.8", "source-map": "^0.7.6", "sucrase": "^3.35.0", "tinyexec": "^0.3.2", "tinyglobby": "^0.2.11", "tree-kill": "^1.2.2" }, "peerDependencies": { "@microsoft/api-extractor": "^7.36.0", "@swc/core": "^1", "postcss": "^8.4.12", "typescript": ">=4.5.0" }, "optionalPeers": ["@microsoft/api-extractor", "@swc/core", "postcss", "typescript"], "bin": { "tsup": "dist/cli-default.js", "tsup-node": "dist/cli-node.js" } }, "sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing=="],
 
-    "undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
+    "typescript": ["typescript@5.9.3", "https://mirrors.huaweicloud.com/repository/npm/typescript/-/typescript-5.9.3.tgz", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
-    "unist-util-is": ["unist-util-is@6.0.1", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g=="],
+    "ufo": ["ufo@1.6.3", "https://mirrors.huaweicloud.com/repository/npm/ufo/-/ufo-1.6.3.tgz", {}, "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q=="],
 
-    "unist-util-position": ["unist-util-position@5.0.0", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA=="],
+    "undici-types": ["undici-types@7.18.2", "https://mirrors.huaweicloud.com/repository/npm/undici-types/-/undici-types-7.18.2.tgz", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 
-    "unist-util-stringify-position": ["unist-util-stringify-position@4.0.0", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ=="],
+    "unist-util-is": ["unist-util-is@6.0.1", "https://mirrors.huaweicloud.com/repository/npm/unist-util-is/-/unist-util-is-6.0.1.tgz", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g=="],
 
-    "unist-util-visit": ["unist-util-visit@5.1.0", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0", "unist-util-visit-parents": "^6.0.0" } }, "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg=="],
+    "unist-util-position": ["unist-util-position@5.0.0", "https://mirrors.huaweicloud.com/repository/npm/unist-util-position/-/unist-util-position-5.0.0.tgz", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA=="],
 
-    "unist-util-visit-parents": ["unist-util-visit-parents@6.0.2", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0" } }, "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ=="],
+    "unist-util-stringify-position": ["unist-util-stringify-position@4.0.0", "https://mirrors.huaweicloud.com/repository/npm/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ=="],
 
-    "vfile": ["vfile@6.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "vfile-message": "^4.0.0" } }, "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q=="],
+    "unist-util-visit": ["unist-util-visit@5.1.0", "https://mirrors.huaweicloud.com/repository/npm/unist-util-visit/-/unist-util-visit-5.1.0.tgz", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0", "unist-util-visit-parents": "^6.0.0" } }, "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg=="],
 
-    "vfile-message": ["vfile-message@4.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw=="],
+    "unist-util-visit-parents": ["unist-util-visit-parents@6.0.2", "https://mirrors.huaweicloud.com/repository/npm/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0" } }, "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ=="],
 
-    "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
+    "vfile": ["vfile@6.0.3", "https://mirrors.huaweicloud.com/repository/npm/vfile/-/vfile-6.0.3.tgz", { "dependencies": { "@types/unist": "^3.0.0", "vfile-message": "^4.0.0" } }, "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q=="],
+
+    "vfile-message": ["vfile-message@4.0.3", "https://mirrors.huaweicloud.com/repository/npm/vfile-message/-/vfile-message-4.0.3.tgz", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw=="],
+
+    "zod": ["zod@4.4.3", "https://mirrors.huaweicloud.com/repository/npm/zod/-/zod-4.4.3.tgz", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
+
+    "zwitch": ["zwitch@2.0.4", "https://mirrors.huaweicloud.com/repository/npm/zwitch/-/zwitch-2.0.4.tgz", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,11 +6,19 @@
   "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "bin": {
+    "beautiful-mermaid": "./dist/mcp/cli.js"
+  },
   "exports": {
     ".": {
       "bun": "./src/index.ts",
       "import": "./dist/index.js",
       "types": "./dist/index.d.ts"
+    },
+    "./mcp": {
+      "bun": "./src/mcp/server.ts",
+      "import": "./dist/mcp/cli.js",
+      "types": "./dist/mcp/cli.d.ts"
     }
   },
   "repository": {
@@ -50,8 +58,11 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
+    "@cfworker/json-schema": "^4.1.1",
+    "@modelcontextprotocol/server": "^2.0.0-alpha.2",
     "elkjs": "^0.11.0",
-    "entities": "^7.0.1"
+    "entities": "^7.0.1",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@types/bun": "^1.3.9",

--- a/src/__tests__/mcp-e2e.test.ts
+++ b/src/__tests__/mcp-e2e.test.ts
@@ -1,0 +1,468 @@
+// ============================================================================
+// End-to-end MCP server test — launches actual server process over stdio
+// and exercises the full JSON-RPC 2.0 protocol lifecycle.
+//
+// Tests real MCP protocol messages: initialize, tools/list, tools/call for
+// all 4 tools, with both success and error cases.
+// ============================================================================
+
+import { describe, it, expect, beforeAll, afterAll } from 'bun:test'
+import { spawn } from 'node:child_process'
+import type { ChildProcess } from 'node:child_process'
+import { join } from 'node:path'
+
+// ============================================================================
+// MCP JSON-RPC client helper
+// ============================================================================
+
+interface JsonRpcRequest {
+  jsonrpc: '2.0'
+  method: string
+  params?: Record<string, unknown>
+  id?: number
+}
+
+interface JsonRpcResponse {
+  jsonrpc: '2.0'
+  id?: number
+  result?: unknown
+  error?: { code: number; message: string }
+}
+
+class McpClient {
+  private proc: ChildProcess
+  private nextId = 1
+  private pending: Map<number, {
+    resolve: (r: JsonRpcResponse) => void
+    reject: (e: Error) => void
+  }> = new Map()
+  private buffer = ''
+  private ready = false
+
+  constructor(command: string, args: string[], cwd: string) {
+    this.proc = spawn(command, args, {
+      stdio: ['pipe', 'pipe', 'pipe'],
+      cwd,
+      env: { ...process.env, FORCE_COLOR: '0' },
+    })
+  }
+
+  async start(): Promise<McpClient> {
+    // Wait for server to be ready by sending initialize
+    const resp = await this.request('initialize', {
+      protocolVersion: '2024-11-05',
+      capabilities: {},
+      clientInfo: { name: 'e2e-test', version: '1.0.0' },
+    })
+    if ('error' in resp && resp.error) {
+      throw new Error(`Initialize failed: ${resp.error.message}`)
+    }
+    // Send initialized notification
+    this.notify('notifications/initialized')
+    this.ready = true
+    return this
+  }
+
+  private handleData(data: string): void {
+    this.buffer += data
+    const lines = this.buffer.split('\n')
+    this.buffer = lines.pop() ?? ''
+
+    for (const line of lines) {
+      if (!line.trim()) continue
+      try {
+        const msg = JSON.parse(line) as JsonRpcResponse
+        if (msg.id !== undefined && this.pending.has(msg.id)) {
+          this.pending.get(msg.id)!.resolve(msg)
+          this.pending.delete(msg.id)
+        }
+      } catch {
+        // Skip non-JSON lines (stderr output, etc.)
+      }
+    }
+  }
+
+  async request(method: string, params?: Record<string, unknown>): Promise<JsonRpcResponse> {
+    const id = this.nextId++
+    const request: JsonRpcRequest = { jsonrpc: '2.0', method, id }
+    if (params) request.params = params
+
+    return new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        this.pending.delete(id)
+        reject(new Error(`Request ${method} (id=${id}) timed out after 15s`))
+      }, 15000)
+
+      this.pending.set(id, {
+        resolve: (r) => { clearTimeout(timeout); resolve(r) },
+        reject: (e) => { clearTimeout(timeout); reject(e) },
+      })
+
+      // Set up data handler on first request
+      if (!this.hasHandler) {
+        this.proc.stdout!.on('data', (d: Buffer) => this.handleData(d.toString()))
+        this.hasHandler = true
+      }
+
+      this.proc.stdin!.write(JSON.stringify(request) + '\n')
+    })
+  }
+
+  notify(method: string, params?: Record<string, unknown>): void {
+    const msg: JsonRpcRequest = { jsonrpc: '2.0', method }
+    if (params) msg.params = params
+    this.proc.stdin!.write(JSON.stringify(msg) + '\n')
+  }
+
+  async close(): Promise<void> {
+    this.proc.kill()
+    // Wait up to 3s for graceful shutdown
+    await new Promise<void>((resolve) => {
+      this.proc.on('close', () => resolve())
+      setTimeout(() => resolve(), 3000)
+    })
+  }
+
+  private hasHandler = false
+}
+
+// ============================================================================
+// Helper: call a tool and extract content text
+// ============================================================================
+
+async function callTool(
+  client: McpClient,
+  name: string,
+  args: Record<string, unknown>,
+): Promise<{ text: string; isError?: boolean }> {
+  const resp = await client.request('tools/call', { name, arguments: args })
+  if ('error' in resp && resp.error) {
+    throw new Error(`MCP error: ${resp.error.message}`)
+  }
+  const result = resp.result as {
+    content: Array<{ type: string; text: string }>
+    isError?: boolean
+    warnings?: string[]
+  }
+  return {
+    text: result.content[0]?.text ?? '',
+    isError: result.isError,
+  }
+}
+
+// ============================================================================
+// Test lifecycle
+// ============================================================================
+
+const PROJECT_ROOT = join(import.meta.dir, '..', '..')
+
+let client: McpClient
+
+beforeAll(async () => {
+  client = new McpClient(
+    'bun',
+    ['run', 'src/mcp/cli.ts'],
+    PROJECT_ROOT,
+  )
+  await client.start()
+}, 30000)
+
+afterAll(async () => {
+  await client?.close()
+})
+
+// ============================================================================
+// E2E Tests
+// ============================================================================
+
+describe('MCP E2E – tools/list', () => {
+  it('returns all 4 tools with correct schema', async () => {
+    const resp = await client.request('tools/list')
+    expect(resp.result).toBeDefined()
+
+    const result = resp.result as { tools: Array<{ name: string; description: string; inputSchema: unknown }> }
+    expect(result.tools).toHaveLength(4)
+
+    const names = result.tools.map(t => t.name).sort()
+    expect(names).toEqual([
+      'list_diagram_types',
+      'parse_mermaid',
+      'render_mermaid_ascii',
+      'render_mermaid_svg',
+    ])
+
+    // Each tool has a description and schema
+    for (const tool of result.tools) {
+      expect(tool.description).toBeTruthy()
+      expect(tool.inputSchema).toBeDefined()
+    }
+  })
+})
+
+describe('MCP E2E – list_diagram_types', () => {
+  it('returns 6 diagram types via MCP protocol', async () => {
+    const result = await callTool(client, 'list_diagram_types', {})
+    expect(result.isError).toBeUndefined()
+
+    const types = JSON.parse(result.text) as Array<{ name: string; description: string; example: string }>
+    expect(types).toHaveLength(6)
+    expect(types.map(t => t.name)).toEqual([
+      'flowchart', 'sequence', 'class', 'er', 'xychart', 'state',
+    ])
+  })
+})
+
+describe('MCP E2E – parse_mermaid', () => {
+  it('parses a flowchart and returns valid JSON graph', async () => {
+    const result = await callTool(client, 'parse_mermaid', {
+      mermaid_code: 'graph TD\n  A[Start] --> B{Diamond}\n  B -->|Yes| C(End)',
+    })
+    expect(result.isError).toBeUndefined()
+
+    const graph = JSON.parse(result.text)
+    expect(graph.direction).toBe('TD')
+    expect(Object.keys(graph.nodes)).toHaveLength(3)
+    expect(graph.nodes.A.label).toBe('Start')
+    expect(graph.nodes.A.shape).toBe('rectangle')
+    expect(graph.nodes.B.label).toBe('Diamond')
+    expect(graph.nodes.B.shape).toBe('diamond')
+    expect(graph.nodes.C.label).toBe('End')
+    expect(graph.nodes.C.shape).toBe('rounded')
+    expect(graph.edges).toHaveLength(2)
+    expect(graph.edges[1].label).toBe('Yes')
+    expect(graph.edges[1].style).toBe('solid')
+  })
+
+  it('parses a state diagram', async () => {
+    const result = await callTool(client, 'parse_mermaid', {
+      mermaid_code: 'stateDiagram-v2\n  [*] --> Idle\n  Idle --> Active\n  Active --> [*]',
+    })
+    const graph = JSON.parse(result.text)
+    expect(graph.direction).toBe('TD')
+    expect(Object.keys(graph.nodes).length).toBeGreaterThanOrEqual(3)
+    expect(graph.edges.length).toBeGreaterThanOrEqual(2)
+  })
+
+  it('returns error for empty input', async () => {
+    const result = await callTool(client, 'parse_mermaid', {
+      mermaid_code: '',
+    })
+    expect(result.isError).toBe(true)
+    const payload = JSON.parse(result.text)
+    expect(payload.error).toContain('Empty')
+  })
+})
+
+describe('MCP E2E – render_mermaid_svg', () => {
+  it('renders a flowchart to valid SVG', async () => {
+    const result = await callTool(client, 'render_mermaid_svg', {
+      mermaid_code: 'graph TD\n  A[Hello] --> B[World]',
+    })
+    expect(result.isError).toBeUndefined()
+
+    const svg = result.text
+    expect(svg).toContain('<svg xmlns="http://www.w3.org/2000/svg"')
+    expect(svg).toContain('</svg>')
+    expect(svg).toContain('>Hello</text>')
+    expect(svg).toContain('>World</text>')
+    expect(svg).toContain('<defs>')
+    expect(svg).toContain('<marker id="arrowhead"')
+  })
+
+  it('renders with tokyo-night theme', async () => {
+    const result = await callTool(client, 'render_mermaid_svg', {
+      mermaid_code: 'graph TD\n  A --> B',
+      theme_name: 'tokyo-night',
+    })
+    expect(result.isError).toBeUndefined()
+
+    const svg = result.text
+    expect(svg).toContain('--bg:#1a1b26')
+    expect(svg).toContain('--fg:#a9b1d6')
+    // Theme enrichment colors
+    expect(svg).toContain('--line:#3d59a1')
+    expect(svg).toContain('--accent:#7aa2f7')
+  })
+
+  it('user bg/fg override theme', async () => {
+    const result = await callTool(client, 'render_mermaid_svg', {
+      mermaid_code: 'graph TD\n  A --> B',
+      theme_name: 'tokyo-night',
+      bg: '#000000',
+      fg: '#ffffff',
+    })
+    const svg = result.text
+    expect(svg).toContain('--bg:#000000')
+    expect(svg).toContain('--fg:#ffffff')
+  })
+
+  it('renders with transparent background', async () => {
+    const result = await callTool(client, 'render_mermaid_svg', {
+      mermaid_code: 'graph TD\n  A --> B',
+      transparent: true,
+    })
+    const svg = result.text
+    expect(svg).not.toContain('background:var(--bg)')
+    expect(svg).toContain('--bg:')
+  })
+
+  it('renders all 6 diagram types successfully', async () => {
+    const diagrams: Record<string, string> = {
+      flowchart: 'graph TD\n  A --> B',
+      sequence: 'sequenceDiagram\n  A->>B: Hello',
+      class: 'classDiagram\n  Animal <|-- Duck',
+      er: 'erDiagram\n  CUSTOMER ||--o{ ORDER : places',
+      xychart: 'xychart-beta\n  line [1,2,3]',
+      state: 'stateDiagram-v2\n  [*] --> Active',
+    }
+
+    for (const [kind, code] of Object.entries(diagrams)) {
+      const result = await callTool(client, 'render_mermaid_svg', { mermaid_code: code })
+      expect(result.isError).toBeUndefined()
+      expect(result.text).toContain('<svg')
+      expect(result.text).toContain('</svg>')
+    }
+  })
+
+  it('returns error for invalid mermaid', async () => {
+    const result = await callTool(client, 'render_mermaid_svg', {
+      mermaid_code: 'not a valid diagram',
+    })
+    expect(result.isError).toBe(true)
+    const payload = JSON.parse(result.text)
+    expect(payload.error).toBeDefined()
+  })
+})
+
+describe('MCP E2E – render_mermaid_ascii', () => {
+  it('renders a flowchart to ASCII art', async () => {
+    const result = await callTool(client, 'render_mermaid_ascii', {
+      mermaid_code: 'graph LR\n  A --> B --> C',
+      use_ascii: true,
+    })
+    expect(result.isError).toBeUndefined()
+
+    const text = result.text
+    expect(text.length).toBeGreaterThan(50)
+    expect(text).toContain('+')
+    expect(text).toContain('-')
+    expect(text).toContain('>')
+  })
+
+  it('renders with Unicode box-drawing', async () => {
+    const result = await callTool(client, 'render_mermaid_ascii', {
+      mermaid_code: 'graph LR\n  A --> B --> C',
+      use_ascii: false,
+    })
+    expect(result.isError).toBeUndefined()
+    expect(result.text.length).toBeGreaterThan(0)
+  })
+
+  it('renders with color_mode=none', async () => {
+    const result = await callTool(client, 'render_mermaid_ascii', {
+      mermaid_code: 'graph LR\n  A --> B',
+      use_ascii: true,
+      color_mode: 'none',
+    })
+    expect(result.isError).toBeUndefined()
+    expect(result.text).toContain('+')
+    expect(result.text).toContain('-')
+  })
+
+  it('renders sequence diagram in ASCII', async () => {
+    const result = await callTool(client, 'render_mermaid_ascii', {
+      mermaid_code: `sequenceDiagram
+        Alice->>Bob: Hello
+        Bob->>Alice: Hi`,
+      use_ascii: true,
+    })
+    expect(result.isError).toBeUndefined()
+    expect(result.text.length).toBeGreaterThan(0)
+  })
+
+  it('renders class diagram in ASCII', async () => {
+    const result = await callTool(client, 'render_mermaid_ascii', {
+      mermaid_code: `classDiagram
+        Animal <|-- Duck
+        Duck : +String name`,
+      use_ascii: true,
+    })
+    expect(result.isError).toBeUndefined()
+    expect(result.text.length).toBeGreaterThan(0)
+  })
+
+  it('renders ER diagram in ASCII', async () => {
+    const result = await callTool(client, 'render_mermaid_ascii', {
+      mermaid_code: `erDiagram
+        CUSTOMER ||--o{ ORDER : places`,
+      use_ascii: true,
+    })
+    expect(result.isError).toBeUndefined()
+    expect(result.text.length).toBeGreaterThan(0)
+  })
+
+  it('handles CJK characters without crashing (warnings expected)', async () => {
+    const result = await callTool(client, 'render_mermaid_ascii', {
+      mermaid_code: 'graph TD\n  A[中文] --> B',
+      use_ascii: true,
+    })
+    expect(result.isError).toBeUndefined()
+    expect(result.text.length).toBeGreaterThan(0)
+  })
+
+  it('handles padding option', async () => {
+    const result = await callTool(client, 'render_mermaid_ascii', {
+      mermaid_code: 'graph LR\n  A --> B',
+      use_ascii: true,
+      padding: 10,
+    })
+    expect(result.isError).toBeUndefined()
+    expect(result.text.length).toBeGreaterThan(0)
+  })
+
+  it('returns error for invalid mermaid', async () => {
+    const result = await callTool(client, 'render_mermaid_ascii', {
+      mermaid_code: 'invalid diagram',
+    })
+    expect(result.isError).toBe(true)
+    const payload = JSON.parse(result.text)
+    expect(payload.error).toBeDefined()
+  })
+})
+
+describe('MCP E2E – error isolation', () => {
+  it('one tool error does not corrupt server state', async () => {
+    // Cause an error in parse_mermaid
+    const errResult = await callTool(client, 'parse_mermaid', {
+      mermaid_code: 'invalid',
+    })
+    expect(errResult.isError).toBe(true)
+
+    // Next request should still work
+    const okResult = await callTool(client, 'list_diagram_types', {})
+    expect(okResult.isError).toBeUndefined()
+    const types = JSON.parse(okResult.text)
+    expect(types).toHaveLength(6)
+  })
+})
+
+describe('MCP E2E – concurrency', () => {
+  it('handles sequential rapid requests', async () => {
+    const codes = [
+      'graph TD\n  A --> B',
+      'graph LR\n  X --> Y',
+      'graph TD\n  P --> Q',
+      'graph LR\n  1 --> 2',
+      'graph TD\n  Up --> Down',
+    ]
+
+    for (const code of codes) {
+      const result = await callTool(client, 'render_mermaid_svg', {
+        mermaid_code: code,
+      })
+      expect(result.isError).toBeUndefined()
+      expect(result.text).toContain('<svg xmlns="http://www.w3.org/2000/svg"')
+      expect(result.text).toContain('</svg>')
+    }
+  })
+})

--- a/src/__tests__/mcp.test.ts
+++ b/src/__tests__/mcp.test.ts
@@ -1,0 +1,1337 @@
+// ============================================================================
+// MCP tools — comprehensive test suite
+//
+// Tests all 4 MCP tool handlers across the full input space:
+// happy paths, theme resolution, error handling, best-effort rendering,
+// CJK detection, Map serialization, and edge cases.
+//
+// Follows project conventions: describe → describe → it nesting,
+// `–` separators, one concept per test case.
+// ============================================================================
+
+import { describe, it, expect } from 'bun:test'
+
+import { handleRenderSVG } from '../mcp/tools/render-svg.ts'
+import { handleRenderAscii } from '../mcp/tools/render-ascii.ts'
+import { handleParseMermaid } from '../mcp/tools/parse.ts'
+import { handleListDiagramTypes } from '../mcp/tools/list-types.ts'
+import { THEMES } from '../index.ts'
+
+// ============================================================================
+// Test data — re-used across multiple test groups
+// ============================================================================
+
+const SIMPLE_FLOWCHART = 'graph TD\n  A --> B'
+
+const ALL_DIAGRAMS: Record<string, string> = {
+  flowchart: 'graph TD\n  A --> B',
+  sequence: 'sequenceDiagram\n  A->>B: Hello',
+  class: 'classDiagram\n  Animal <|-- Duck',
+  er: 'erDiagram\n  CUSTOMER ||--o{ ORDER : places',
+  xychart: 'xychart-beta\n  line [1,2,3]',
+  state: 'stateDiagram-v2\n  [*] --> Active',
+}
+
+// ============================================================================
+// Helper: validate common response structure
+// ============================================================================
+
+function expectSuccessResponse(
+  result: { content: Array<{ type: string; text: string }>; isError?: boolean },
+): void {
+  expect(result.content).toHaveLength(1)
+  expect(result.content[0]!.type).toBe('text')
+  expect(typeof result.content[0]!.text).toBe('string')
+  expect(result.content[0]!.text.length).toBeGreaterThan(0)
+  expect(result.isError).toBeUndefined()
+}
+
+function expectErrorResponse(
+  result: { content: Array<{ type: string; text: string }>; isError?: boolean },
+): { payload: Record<string, unknown> } {
+  expect(result.content).toHaveLength(1)
+  expect(result.isError).toBe(true)
+  const payload = JSON.parse(result.content[0]!.text) as Record<string, unknown>
+  expect(payload.error).toBeDefined()
+  expect(typeof payload.error).toBe('string')
+  return { payload }
+}
+
+// ============================================================================
+// list_diagram_types
+// ============================================================================
+
+// We keep a single flat describe for list_diagram_types since it's short
+describe('list_diagram_types', () => {
+  it('returns all 6 diagram types with correct names', () => {
+    const result = handleListDiagramTypes()
+    expectSuccessResponse(result)
+
+    const types = JSON.parse(result.content[0]!.text) as Array<{ name: string }>
+    expect(types).toHaveLength(6)
+    expect(types.map(t => t.name)).toEqual([
+      'flowchart', 'sequence', 'class', 'er', 'xychart', 'state',
+    ])
+  })
+
+  it('each type has name, description, and example', () => {
+    const result = handleListDiagramTypes()
+    const types = JSON.parse(result.content[0]!.text) as Array<{
+      name: string
+      description: string
+      example: string
+    }>
+
+    for (const t of types) {
+      expect(t.name).toBeDefined()
+      expect(typeof t.name).toBe('string')
+      expect(t.name.length).toBeGreaterThan(0)
+
+      expect(t.description).toBeDefined()
+      expect(typeof t.description).toBe('string')
+      expect(t.description.length).toBeGreaterThan(0)
+
+      expect(t.example).toBeDefined()
+      expect(typeof t.example).toBe('string')
+      expect(t.example.length).toBeGreaterThan(0)
+    }
+  })
+
+  it('all type names are unique', () => {
+    const result = handleListDiagramTypes()
+    const types = JSON.parse(result.content[0]!.text) as Array<{ name: string }>
+    const names = types.map(t => t.name)
+    expect(new Set(names).size).toBe(names.length)
+  })
+
+  it('returns the same result on every call (idempotent)', () => {
+    const a = handleListDiagramTypes()
+    const b = handleListDiagramTypes()
+    expect(a.content[0]!.text).toBe(b.content[0]!.text)
+  })
+})
+
+// ============================================================================
+// parse_mermaid
+// ============================================================================
+
+describe('parse_mermaid', () => {
+  // --- Flowchart parsing ---
+
+  describe('parse_mermaid – flowchart', () => {
+    it('parses a simple graph with nodes and edges', () => {
+      const result = handleParseMermaid({ mermaid_code: SIMPLE_FLOWCHART })
+      expectSuccessResponse(result)
+
+      const graph = JSON.parse(result.content[0]!.text)
+      expect(graph.direction).toBe('TD')
+      expect(graph.nodes).toBeDefined()
+      expect(Object.keys(graph.nodes)).toHaveLength(2)
+      expect(graph.nodes.A.label).toBe('A')
+      expect(graph.nodes.B.label).toBe('B')
+      expect(graph.edges).toHaveLength(1)
+      expect(graph.edges[0].source).toBe('A')
+      expect(graph.edges[0].target).toBe('B')
+      expect(graph.edges[0].style).toBe('solid')
+      expect(graph.edges[0].hasArrowEnd).toBe(true)
+    })
+
+    it('parses LR direction', () => {
+      const result = handleParseMermaid({
+        mermaid_code: 'graph LR\n  A --> B',
+      })
+      const graph = JSON.parse(result.content[0]!.text)
+      expect(graph.direction).toBe('LR')
+    })
+
+    it('parses labeled nodes with various shapes', () => {
+      const result = handleParseMermaid({
+        mermaid_code: `graph TD
+          A[Rectangle] --> B(Rounded)
+          B --> C{Diamond}
+          C --> D([Stadium])
+          D --> E((Circle))`,
+      })
+      const graph = JSON.parse(result.content[0]!.text)
+
+      expect(graph.nodes.A.shape).toBe('rectangle')
+      expect(graph.nodes.A.label).toBe('Rectangle')
+      expect(graph.nodes.B.shape).toBe('rounded')
+      expect(graph.nodes.C.shape).toBe('diamond')
+      expect(graph.nodes.D.shape).toBe('stadium')
+      expect(graph.nodes.E.shape).toBe('circle')
+    })
+
+    it('parses batch 1 shapes (subroutine, doublecircle, hexagon)', () => {
+      const result = handleParseMermaid({
+        mermaid_code: 'graph TD\n  A[[Sub]] --> B((("Double")))\n  B --> C{{Hexagon}}',
+      })
+      const graph = JSON.parse(result.content[0]!.text)
+
+      expect(graph.nodes.A.shape).toBe('subroutine')
+      expect(graph.nodes.A.label).toBe('Sub')
+      expect(graph.nodes.B.shape).toBe('doublecircle')
+      expect(graph.nodes.B.label).toBe('Double')
+      expect(graph.nodes.C.shape).toBe('hexagon')
+      expect(graph.nodes.C.label).toBe('Hexagon')
+    })
+
+    it('parses batch 2 shapes (cylinder, asymmetric, trapezoid, trapezoid-alt)', () => {
+      const result = handleParseMermaid({
+        mermaid_code: `graph TD
+          A[(DB)] --> B>flag]
+          B --> C[/trap\\]
+          C --> D[\\alt/]`,
+      })
+      const graph = JSON.parse(result.content[0]!.text)
+
+      expect(graph.nodes.A.shape).toBe('cylinder')
+      expect(graph.nodes.B.shape).toBe('asymmetric')
+      expect(graph.nodes.C.shape).toBe('trapezoid')
+      expect(graph.nodes.D.shape).toBe('trapezoid-alt')
+    })
+
+    it('parses edges with labels', () => {
+      const result = handleParseMermaid({
+        mermaid_code: 'graph TD\n  A -->|Yes| B\n  B -.->|Maybe| C\n  C ==>|Definitely| D',
+      })
+      const graph = JSON.parse(result.content[0]!.text)
+
+      expect(graph.edges).toHaveLength(3)
+      expect(graph.edges[0].label).toBe('Yes')
+      expect(graph.edges[0].style).toBe('solid')
+      expect(graph.edges[1].label).toBe('Maybe')
+      expect(graph.edges[1].style).toBe('dotted')
+      expect(graph.edges[2].label).toBe('Definitely')
+      expect(graph.edges[2].style).toBe('thick')
+    })
+
+    it('parses chained edges and & parallel links', () => {
+      const result = handleParseMermaid({
+        mermaid_code: 'graph TD\n  A --> B --> C\n  X & Y --> Z',
+      })
+      const graph = JSON.parse(result.content[0]!.text)
+
+      // Chained: A→B, B→C = 2 edges
+      // Parallel: X→Z, Y→Z = 2 edges
+      // Total: 4 edges
+      expect(graph.edges).toHaveLength(4)
+    })
+
+    it('parses bidirectional arrows', () => {
+      const result = handleParseMermaid({
+        mermaid_code: 'graph LR\n  A <--> B',
+      })
+      const graph = JSON.parse(result.content[0]!.text)
+
+      expect(graph.edges).toHaveLength(1)
+      expect(graph.edges[0].hasArrowStart).toBe(true)
+      expect(graph.edges[0].hasArrowEnd).toBe(true)
+    })
+
+    it('parses subgraphs with nesting', () => {
+      const result = handleParseMermaid({
+        mermaid_code: `graph TD
+          subgraph Outer
+            A --> B
+            subgraph Inner
+              C --> D
+            end
+          end`,
+      })
+      const graph = JSON.parse(result.content[0]!.text)
+
+      expect(graph.subgraphs).toHaveLength(1)
+      const outer = graph.subgraphs[0]
+      expect(outer.label).toBe('Outer')
+      expect(outer.nodeIds).toContain('A')
+      expect(outer.nodeIds).toContain('B')
+      expect(outer.children).toHaveLength(1)
+      expect(outer.children[0].label).toBe('Inner')
+      expect(outer.children[0].nodeIds).toContain('C')
+      expect(outer.children[0].nodeIds).toContain('D')
+    })
+
+    it('parses classDef and class assignments', () => {
+      const result = handleParseMermaid({
+        mermaid_code: `graph TD
+          classDef highlight fill:#f9f,stroke:#333
+          class A highlight
+          A --> B`,
+      })
+      const graph = JSON.parse(result.content[0]!.text)
+
+      expect(graph.classDefs).toBeDefined()
+      expect(graph.classDefs.highlight).toBeDefined()
+      expect(graph.classDefs.highlight.fill).toBe('#f9f')
+      expect(graph.classAssignments.A).toBe('highlight')
+    })
+
+    it('parses style and linkStyle directives', () => {
+      const result = handleParseMermaid({
+        mermaid_code: `graph TD
+          style A fill:#f00,stroke:#333
+          linkStyle 0 stroke:#00f
+          A --> B`,
+      })
+      const graph = JSON.parse(result.content[0]!.text)
+
+      expect(graph.nodeStyles.A).toBeDefined()
+      expect(graph.nodeStyles.A.fill).toBe('#f00')
+      expect(graph.linkStyles['0']).toBeDefined()
+      expect(graph.linkStyles['0'].stroke).toBe('#00f')
+    })
+
+    it('parses node with ::: class shorthand', () => {
+      const result = handleParseMermaid({
+        mermaid_code: 'graph TD\n  A[NodeA]:::highlight --> B',
+      })
+      const graph = JSON.parse(result.content[0]!.text)
+
+      expect(graph.classAssignments).toBeDefined()
+      expect(graph.classAssignments.A).toBe('highlight')
+    })
+
+    it('ignores comment lines (%% comments)', () => {
+      const result = handleParseMermaid({
+        mermaid_code: `graph TD
+          %% This is a comment
+          A --> B
+          %% Another comment`,
+      })
+      const graph = JSON.parse(result.content[0]!.text)
+
+      expect(graph.nodes.A).toBeDefined()
+      expect(graph.nodes.B).toBeDefined()
+      expect(graph.edges).toHaveLength(1)
+    })
+  })
+
+  // --- State diagram parsing ---
+
+  describe('parse_mermaid – state diagram', () => {
+    it('parses stateDiagram-v2 with transitions', () => {
+      const result = handleParseMermaid({
+        mermaid_code: 'stateDiagram-v2\n  [*] --> Active\n  Active --> Inactive\n  Inactive --> [*]',
+      })
+      const graph = JSON.parse(result.content[0]!.text)
+
+      expect(graph.direction).toBe('TD')
+      const nodeIds = Object.keys(graph.nodes)
+      expect(nodeIds).toHaveLength(4) // _start, Active, Inactive, _end
+      expect(graph.edges).toHaveLength(3)
+    })
+
+    it('parses state descriptions', () => {
+      const result = handleParseMermaid({
+        mermaid_code: `stateDiagram-v2
+          s1 : Waiting for input
+          s2 : Processing`,
+      })
+      const graph = JSON.parse(result.content[0]!.text)
+
+      expect(graph.nodes.s1.label).toBe('Waiting for input')
+      expect(graph.nodes.s2.label).toBe('Processing')
+      expect(graph.nodes.s1.shape).toBe('rounded')
+      expect(graph.nodes.s2.shape).toBe('rounded')
+    })
+
+    it('parses state aliases', () => {
+      const result = handleParseMermaid({
+        mermaid_code: `stateDiagram-v2
+          state "Long Description" as s1
+          [*] --> s1`,
+      })
+      const graph = JSON.parse(result.content[0]!.text)
+
+      expect(graph.nodes.s1.label).toBe('Long Description')
+    })
+
+    it('parses composite states', () => {
+      const result = handleParseMermaid({
+        mermaid_code: `stateDiagram-v2
+          [*] --> Processing
+          state Processing {
+            [*] --> Waiting
+            Waiting --> Running
+            Running --> [*]
+          }`,
+      })
+      const graph = JSON.parse(result.content[0]!.text)
+
+      // Processing should NOT be in nodes (it's a composite state)
+      expect(graph.nodes.Processing).toBeUndefined()
+      expect(graph.subgraphs).toHaveLength(1)
+      expect(graph.subgraphs[0].label).toBe('Processing')
+      expect(graph.subgraphs[0].nodeIds).toContain('Waiting')
+      expect(graph.subgraphs[0].nodeIds).toContain('Running')
+    })
+
+    it('parses state diagram transitions with labels', () => {
+      const result = handleParseMermaid({
+        mermaid_code: 'stateDiagram-v2\n  [*] --> Idle : Start\n  Idle --> Active : Trigger',
+      })
+      const graph = JSON.parse(result.content[0]!.text)
+
+      expect(graph.edges).toHaveLength(2)
+      expect(graph.edges[0].label).toBe('Start')
+      expect(graph.edges[1].label).toBe('Trigger')
+    })
+  })
+
+  // --- Serialization correctness ---
+
+  describe('parse_mermaid – serialization', () => {
+    it('serializes Map fields to plain objects', () => {
+      const result = handleParseMermaid({
+        mermaid_code: `graph TD
+          A --> B
+          B --> C`,
+      })
+      const raw = result.content[0]!.text
+      const graph = JSON.parse(raw)
+
+      // All Map fields must be plain objects (not empty arrays)
+      expect(typeof graph.nodes).toBe('object')
+      expect(Array.isArray(graph.nodes)).toBe(false)
+      expect(Object.keys(graph.nodes).length).toBeGreaterThan(0)
+
+      expect(typeof graph.classDefs).toBe('object')
+      expect(typeof graph.classAssignments).toBe('object')
+      expect(typeof graph.nodeStyles).toBe('object')
+      expect(typeof graph.linkStyles).toBe('object')
+
+      // Edges and subgraphs are arrays
+      expect(Array.isArray(graph.edges)).toBe(true)
+      expect(Array.isArray(graph.subgraphs)).toBe(true)
+    })
+
+    it('serializes linkStyles with string keys', () => {
+      const result = handleParseMermaid({
+        mermaid_code: `graph TD
+          linkStyle 0 stroke:#f00
+          linkStyle 1 stroke:#00f
+          A --> B
+          B --> C`,
+      })
+      const graph = JSON.parse(result.content[0]!.text)
+
+      expect(graph.linkStyles['0']).toBeDefined()
+      expect(graph.linkStyles['0'].stroke).toBe('#f00')
+      expect(graph.linkStyles['1']).toBeDefined()
+      expect(graph.linkStyles['1'].stroke).toBe('#00f')
+    })
+
+    it('produces valid JSON that can be round-tripped', () => {
+      const result = handleParseMermaid({
+        mermaid_code: `graph TD
+          A[Start] --> B{Diamond}
+          B -->|Yes| C(End)`,
+      })
+      const raw1 = result.content[0]!.text
+      const parsed1 = JSON.parse(raw1)
+
+      // Re-stringify and re-parse to verify JSON stability
+      const raw2 = JSON.stringify(parsed1)
+      const parsed2 = JSON.parse(raw2)
+
+      expect(parsed2.direction).toBe('TD')
+      expect(parsed2.nodes.B.shape).toBe('diamond')
+      expect(parsed2.edges[1].label).toBe('Yes')
+    })
+  })
+
+  // --- Error handling ---
+
+  describe('parse_mermaid – errors', () => {
+    it('returns error on empty input', () => {
+      const result = handleParseMermaid({ mermaid_code: '' })
+      const { payload } = expectErrorResponse(result)
+      expect(payload.error).toContain('Empty')
+    })
+
+    it('returns error on invalid header', () => {
+      const result = handleParseMermaid({
+        mermaid_code: 'not a valid diagram',
+      })
+      const { payload } = expectErrorResponse(result)
+      expect(payload.error).toContain('Invalid')
+    })
+
+    it('returns error on sequenceDiagram header (parseMermaid only handles flowchart/state)', () => {
+      const result = handleParseMermaid({
+        mermaid_code: 'sequenceDiagram\n  A->>B: Hello',
+      })
+      const { payload } = expectErrorResponse(result)
+      expect(payload.error).toBeDefined()
+    })
+  })
+})
+
+// ============================================================================
+// render_mermaid_svg
+// ============================================================================
+
+describe('render_mermaid_svg', () => {
+  // --- Basic rendering ---
+
+  describe('render_mermaid_svg – basic', () => {
+    it('renders a valid SVG with namespace and closing tag', () => {
+      const result = handleRenderSVG({ mermaid_code: SIMPLE_FLOWCHART })
+      expectSuccessResponse(result)
+
+      const svg = result.content[0]!.text
+      expect(svg).toContain('<svg xmlns="http://www.w3.org/2000/svg"')
+      expect(svg).toContain('</svg>')
+    })
+
+    it('includes node labels in rendered SVG', () => {
+      const result = handleRenderSVG({
+        mermaid_code: 'graph TD\n  A[Start] --> B[End]',
+      })
+      const svg = result.content[0]!.text
+      expect(svg).toContain('>Start</text>')
+      expect(svg).toContain('>End</text>')
+    })
+
+    it('includes edge labels in rendered SVG', () => {
+      const result = handleRenderSVG({
+        mermaid_code: 'graph TD\n  A -->|Yes| B',
+      })
+      const svg = result.content[0]!.text
+      expect(svg).toContain('>Yes</text>')
+    })
+
+    it('includes SVG defs and arrow markers', () => {
+      const result = handleRenderSVG({ mermaid_code: SIMPLE_FLOWCHART })
+      const svg = result.content[0]!.text
+      expect(svg).toContain('<defs>')
+      expect(svg).toContain('<marker id="arrowhead"')
+      expect(svg).toContain('</defs>')
+    })
+
+    it('includes CSS style block', () => {
+      const result = handleRenderSVG({ mermaid_code: SIMPLE_FLOWCHART })
+      const svg = result.content[0]!.text
+      expect(svg).toContain('<style>')
+      expect(svg).toContain('</style>')
+    })
+
+    it('includes CSS custom properties for theming', () => {
+      const result = handleRenderSVG({ mermaid_code: SIMPLE_FLOWCHART })
+      const svg = result.content[0]!.text
+      expect(svg).toContain('var(--_node-fill)')
+      expect(svg).toContain('var(--_node-stroke)')
+      expect(svg).toContain('var(--_text)')
+    })
+  })
+
+  // --- All diagram types ---
+
+  describe('render_mermaid_svg – diagram types', () => {
+    for (const [kind, code] of Object.entries(ALL_DIAGRAMS)) {
+      it(`renders ${kind} diagram without errors`, () => {
+        const result = handleRenderSVG({ mermaid_code: code })
+        expectSuccessResponse(result)
+
+        const svg = result.content[0]!.text
+        expect(svg).toContain('<svg')
+        expect(svg).toContain('</svg>')
+      })
+    }
+
+    it('renders a complex flowchart with all node shapes', () => {
+      const result = handleRenderSVG({
+        mermaid_code: `graph TD
+          A[Rectangle] --> B(Rounded)
+          B --> C{Diamond}
+          C --> D([Stadium])
+          D --> E((Circle))
+          E --> F[[Subroutine]]
+          F --> G(((Double-Circle)))
+          G --> H{{Hexagon}}
+          H --> I[(Cylinder)]
+          I --> J>Asymmetric]
+          J --> K[/Trapezoid\\]
+          K --> L[\\Trapezoid-Alt/]`,
+      })
+      expectSuccessResponse(result)
+
+      const svg = result.content[0]!.text
+      expect(svg).toContain('<polygon')  // diamond, hexagon, etc.
+      expect(svg).toContain('<circle')   // circle
+      expect(svg).toContain('<ellipse')  // cylinder caps
+      expect(svg).toContain('<line')     // subroutine inner lines
+    })
+
+    it('renders all edge styles (solid, dotted, thick)', () => {
+      const result = handleRenderSVG({
+        mermaid_code: `graph TD
+          A -->|solid| B
+          B -.->|dotted| C
+          C ==>|thick| D`,
+      })
+      const svg = result.content[0]!.text
+      expect(svg).toContain('>solid</text>')
+      expect(svg).toContain('>dotted</text>')
+      expect(svg).toContain('>thick</text>')
+      expect(svg).toContain('stroke-dasharray="4 4"')
+    })
+
+    it('renders bidirectional arrows', () => {
+      const result = handleRenderSVG({
+        mermaid_code: `graph TD
+          A <-->|bidirectional| B`,
+      })
+      const svg = result.content[0]!.text
+      // Should have both marker-start and marker-end
+      expect(svg).toContain('>bidirectional</text>')
+    })
+
+    it('renders subgraph containers', () => {
+      const result = handleRenderSVG({
+        mermaid_code: `graph TD
+          subgraph Group
+            A --> B
+          end`,
+      })
+      const svg = result.content[0]!.text
+      expect(svg).toContain('class="subgraph"')
+      expect(svg).toContain('>Group</text>')
+    })
+
+    it('renders state diagram pseudostates', () => {
+      const result = handleRenderSVG({
+        mermaid_code: 'stateDiagram-v2\n  [*] --> Active\n  Active --> [*]',
+      })
+      expectSuccessResponse(result)
+
+      const svg = result.content[0]!.text
+      // Should have state-start and state-end pseudostates
+      // state-start is a filled circle, state-end is a bullseye
+      const circleCount = (svg.match(/<circle/g) ?? []).length
+      expect(circleCount).toBeGreaterThanOrEqual(2)
+    })
+  })
+
+  // --- Theme resolution ---
+
+  describe('render_mermaid_svg – theme resolution', () => {
+    it('uses DEFAULTS when no theme or colors provided', () => {
+      const result = handleRenderSVG({ mermaid_code: SIMPLE_FLOWCHART })
+      const svg = result.content[0]!.text
+      expect(svg).toContain('--bg:#FFFFFF')
+      expect(svg).toContain('--fg:#27272A')
+    })
+
+    it('applies tokyo-night theme colors', () => {
+      const result = handleRenderSVG({
+        mermaid_code: SIMPLE_FLOWCHART,
+        theme_name: 'tokyo-night',
+      })
+      const svg = result.content[0]!.text
+      expect(svg).toContain('--bg:#1a1b26')
+      expect(svg).toContain('--fg:#a9b1d6')
+    })
+
+    it('applies theme enrichment colors', () => {
+      // tokyo-night has line, accent, muted enrichment
+      const result = handleRenderSVG({
+        mermaid_code: SIMPLE_FLOWCHART,
+        theme_name: 'tokyo-night',
+      })
+      const svg = result.content[0]!.text
+      expect(svg).toContain('--line:#3d59a1')
+      expect(svg).toContain('--accent:#7aa2f7')
+      expect(svg).toContain('--muted:#565f89')
+    })
+
+    it('user bg overrides theme bg', () => {
+      const result = handleRenderSVG({
+        mermaid_code: SIMPLE_FLOWCHART,
+        theme_name: 'tokyo-night',
+        bg: '#000000',
+      })
+      const svg = result.content[0]!.text
+      expect(svg).toContain('--bg:#000000')
+      expect(svg).toContain('--fg:#a9b1d6') // fg from theme preserved
+    })
+
+    it('user fg overrides theme fg', () => {
+      const result = handleRenderSVG({
+        mermaid_code: SIMPLE_FLOWCHART,
+        theme_name: 'tokyo-night',
+        fg: '#ffffff',
+      })
+      const svg = result.content[0]!.text
+      expect(svg).toContain('--bg:#1a1b26') // bg from theme preserved
+      expect(svg).toContain('--fg:#ffffff')
+    })
+
+    it('both user bg and fg override theme', () => {
+      const result = handleRenderSVG({
+        mermaid_code: SIMPLE_FLOWCHART,
+        theme_name: 'tokyo-night',
+        bg: '#111111',
+        fg: '#eeeeee',
+      })
+      const svg = result.content[0]!.text
+      expect(svg).toContain('--bg:#111111')
+      expect(svg).toContain('--fg:#eeeeee')
+    })
+
+    it('unknown theme name falls back to DEFAULTS', () => {
+      const result = handleRenderSVG({
+        mermaid_code: SIMPLE_FLOWCHART,
+        theme_name: 'nonexistent-theme',
+      })
+      const svg = result.content[0]!.text
+      expect(svg).toContain('--bg:#FFFFFF')
+      expect(svg).toContain('--fg:#27272A')
+    })
+
+    it('user bg without theme overrides DEFAULTS', () => {
+      const result = handleRenderSVG({
+        mermaid_code: SIMPLE_FLOWCHART,
+        bg: '#333333',
+      })
+      const svg = result.content[0]!.text
+      expect(svg).toContain('--bg:#333333')
+      expect(svg).toContain('--fg:#27272A') // fg from DEFAULTS
+    })
+
+    it('user fg without theme overrides DEFAULTS', () => {
+      const result = handleRenderSVG({
+        mermaid_code: SIMPLE_FLOWCHART,
+        fg: '#cccccc',
+      })
+      const svg = result.content[0]!.text
+      expect(svg).toContain('--bg:#FFFFFF') // bg from DEFAULTS
+      expect(svg).toContain('--fg:#cccccc')
+    })
+
+    // Test all well-known themes
+    const THEME_NAMES = Object.keys(THEMES) as Array<keyof typeof THEMES>
+    for (const name of THEME_NAMES) {
+      it(`renders with ${name} theme without errors`, () => {
+        const result = handleRenderSVG({
+          mermaid_code: SIMPLE_FLOWCHART,
+          theme_name: name,
+        })
+        expectSuccessResponse(result)
+
+        const svg = result.content[0]!.text
+        const expectedBg = THEMES[name].bg
+        const expectedFg = THEMES[name].fg
+        expect(svg).toContain(`--bg:${expectedBg}`)
+        expect(svg).toContain(`--fg:${expectedFg}`)
+      })
+    }
+
+    it('applies dark theme (zinc-dark) colors', () => {
+      const result = handleRenderSVG({
+        mermaid_code: SIMPLE_FLOWCHART,
+        theme_name: 'zinc-dark',
+      })
+      const svg = result.content[0]!.text
+      expect(svg).toContain('--bg:#18181B')
+      expect(svg).toContain('--fg:#FAFAFA')
+    })
+
+    it('applies catppuccin-mocha theme with enrichment', () => {
+      const result = handleRenderSVG({
+        mermaid_code: SIMPLE_FLOWCHART,
+        theme_name: 'catppuccin-mocha',
+      })
+      const svg = result.content[0]!.text
+      expect(svg).toContain('--bg:#1e1e2e')
+      expect(svg).toContain('--fg:#cdd6f4')
+      expect(svg).toContain('--line:#585b70')
+      expect(svg).toContain('--accent:#cba6f7')
+    })
+  })
+
+  // --- Transparent mode ---
+
+  describe('render_mermaid_svg – transparent', () => {
+    it('renders with transparent background when enabled', () => {
+      const result = handleRenderSVG({
+        mermaid_code: SIMPLE_FLOWCHART,
+        transparent: true,
+      })
+      const svg = result.content[0]!.text
+      expect(svg).not.toContain('background:var(--bg)')
+    })
+
+    it('renders with opaque background by default', () => {
+      const result = handleRenderSVG({ mermaid_code: SIMPLE_FLOWCHART })
+      const svg = result.content[0]!.text
+      expect(svg).toContain('background:var(--bg)')
+    })
+
+    it('transparent rendering still includes --bg variable for internal use', () => {
+      const result = handleRenderSVG({
+        mermaid_code: SIMPLE_FLOWCHART,
+        transparent: true,
+      })
+      const svg = result.content[0]!.text
+      // CSS variable still present for internal derived colors
+      expect(svg).toContain('--bg:')
+    })
+  })
+
+  // --- Error handling ---
+
+  describe('render_mermaid_svg – errors', () => {
+    it('returns structured error for invalid header', () => {
+      const result = handleRenderSVG({
+        mermaid_code: 'not a valid mermaid diagram',
+      })
+      const { payload } = expectErrorResponse(result)
+      expect(payload.error).toBeDefined()
+    })
+
+    it('returns structured error for empty input', () => {
+      const result = handleRenderSVG({ mermaid_code: '' })
+      const { payload } = expectErrorResponse(result)
+      expect(payload.error).toBeDefined()
+    })
+
+    it('best-effort renders partial graph when trailing lines are broken', () => {
+      // The first line is valid, the rest is garbled
+      const result = handleRenderSVG({
+        mermaid_code: 'graph TD\n  A --> B\n  ZZZ###!!!\n  @@@invalid@@@',
+      })
+      // Should produce some output (either partial SVG or error JSON)
+      expect(result.content).toHaveLength(1)
+      expect(typeof result.content[0]!.text).toBe('string')
+      expect(result.content[0]!.text.length).toBeGreaterThan(0)
+    })
+
+    it('error response includes partial output when best-effort succeeds', () => {
+      const result = handleRenderSVG({
+        mermaid_code: `graph TD
+          A --> B
+          C --> D
+          broken line with @@@ garbage`,
+      })
+      // If partial rendering succeeds, error JSON contains "partial" field
+      if (result.isError) {
+        const payload = JSON.parse(result.content[0]!.text) as Record<string, unknown>
+        // Either error-only or error+partial
+        expect(payload.error).toBeDefined()
+      }
+    })
+  })
+
+  // --- Edge cases ---
+
+  describe('render_mermaid_svg – edge cases', () => {
+    it('renders graph with special characters in labels', () => {
+      const result = handleRenderSVG({
+        mermaid_code: 'graph TD\n  A[<script> & "quotes"] --> B',
+      })
+      const svg = result.content[0]!.text
+      expect(svg).toContain('&lt;script&gt;')
+      expect(svg).toContain('&amp;')
+      expect(svg).toContain('&quot;quotes&quot;')
+    })
+
+    it('renders graph with Unicode characters in labels', () => {
+      const result = handleRenderSVG({
+        mermaid_code: 'graph TD\n  A[Café résumé naïve] --> B',
+      })
+      const svg = result.content[0]!.text
+      expect(svg).toContain('Café résumé naïve')
+    })
+
+    it('renders graph with long label text', () => {
+      const result = handleRenderSVG({
+        mermaid_code: `graph LR
+          A[This is a very long label that should still render correctly] --> B`,
+      })
+      const svg = result.content[0]!.text
+      expect(svg).toContain('This is a very long label')
+    })
+
+    it('renders multiline labels with <br> tags', () => {
+      const result = handleRenderSVG({
+        mermaid_code: 'graph TD\n  A["Line 1<br>Line 2"] --> B',
+      })
+      const svg = result.content[0]!.text
+      expect(svg).toContain('Line 1')
+      expect(svg).toContain('Line 2')
+    })
+
+    it('renders with only bg provided (DEFAULTS fg)', () => {
+      const result = handleRenderSVG({
+        mermaid_code: SIMPLE_FLOWCHART,
+        bg: '#2e3440',
+      })
+      const svg = result.content[0]!.text
+      expect(svg).toContain('--bg:#2e3440')
+      expect(svg).toContain('--fg:#27272A') // from DEFAULTS
+    })
+
+    it('renders with only fg provided (DEFAULTS bg)', () => {
+      const result = handleRenderSVG({
+        mermaid_code: SIMPLE_FLOWCHART,
+        fg: '#88c0d0',
+      })
+      const svg = result.content[0]!.text
+      expect(svg).toContain('--bg:#FFFFFF') // from DEFAULTS
+      expect(svg).toContain('--fg:#88c0d0')
+    })
+
+    it('handles xychart-beta with basic line chart', () => {
+      const result = handleRenderSVG({
+        mermaid_code: 'xychart-beta\n  line [10, 20, 30, 40]',
+      })
+      expectSuccessResponse(result)
+      expect(result.content[0]!.text).toContain('<svg')
+    })
+
+    it('handles xychart-beta with transparent + interactive', () => {
+      const result = handleRenderSVG({
+        mermaid_code: 'xychart-beta\n  line [1,2,3]',
+        transparent: true,
+      })
+      expectSuccessResponse(result)
+    })
+
+    it('renders graph with & parallel links producing multiple polylines', () => {
+      const result = handleRenderSVG({
+        mermaid_code: 'graph TD\n  A & B & C --> D',
+      })
+      const svg = result.content[0]!.text
+      const polylines = (svg.match(/<polyline/g) ?? []).length
+      expect(polylines).toBeGreaterThanOrEqual(3)
+    })
+  })
+})
+
+// ============================================================================
+// render_mermaid_ascii
+// ============================================================================
+
+describe('render_mermaid_ascii', () => {
+  const SIMPLE_LR = 'graph LR\n  A --> B --> C'
+
+  // --- Basic rendering ---
+
+  describe('render_mermaid_ascii – basic', () => {
+    it('renders a simple graph producing non-empty output', () => {
+      const result = handleRenderAscii({ mermaid_code: SIMPLE_LR })
+      expectSuccessResponse(result)
+    })
+
+    it('default renders with Unicode box-drawing characters', () => {
+      const result = handleRenderAscii({
+        mermaid_code: SIMPLE_LR,
+        use_ascii: false,
+      })
+      const text = result.content[0]!.text
+      // Unicode box-drawing uses characters in the range ─━│┃ etc. or ANSI color codes
+      expect(text.length).toBeGreaterThan(0)
+    })
+
+    it('pure ASCII mode uses +, -, | characters', () => {
+      const result = handleRenderAscii({
+        mermaid_code: SIMPLE_LR,
+        use_ascii: true,
+      })
+      const text = result.content[0]!.text
+      expect(text).toContain('+')
+      expect(text).toContain('-')
+      expect(text).toContain('|')
+    })
+
+    it('pure ASCII mode does NOT contain Unicode box-drawing', () => {
+      const result = handleRenderAscii({
+        mermaid_code: SIMPLE_LR,
+        use_ascii: true,
+      })
+      const text = result.content[0]!.text
+      expect(text).not.toContain('┌')
+      expect(text).not.toContain('┐')
+      expect(text).not.toContain('─')
+      expect(text).not.toContain('│')
+    })
+  })
+
+  // --- All diagram types ---
+
+  describe('render_mermaid_ascii – diagram types', () => {
+    for (const [kind, code] of Object.entries(ALL_DIAGRAMS)) {
+      it(`renders ${kind} diagram in ASCII mode without errors`, () => {
+        const result = handleRenderAscii({
+          mermaid_code: code,
+          use_ascii: true,
+        })
+        expectSuccessResponse(result)
+      })
+
+      it(`renders ${kind} diagram in Unicode mode without errors`, () => {
+        const result = handleRenderAscii({
+          mermaid_code: code,
+          use_ascii: false,
+        })
+        expectSuccessResponse(result)
+      })
+    }
+
+    it('renders sequence diagram in ASCII mode with correct structure', () => {
+      const result = handleRenderAscii({
+        mermaid_code: `sequenceDiagram
+          Alice->>Bob: Hello
+          Bob->>Alice: Hi`,
+        use_ascii: true,
+      })
+      const text = result.content[0]!.text
+      expect(text.length).toBeGreaterThan(0)
+    })
+
+    it('renders class diagram in ASCII mode with correct structure', () => {
+      const result = handleRenderAscii({
+        mermaid_code: `classDiagram
+          Animal <|-- Duck
+          Duck : +String name`,
+        use_ascii: true,
+      })
+      const text = result.content[0]!.text
+      expect(text.length).toBeGreaterThan(0)
+    })
+
+    it('renders ER diagram in ASCII mode with correct structure', () => {
+      const result = handleRenderAscii({
+        mermaid_code: `erDiagram
+          CUSTOMER ||--o{ ORDER : places
+          ORDER ||--|{ LINE-ITEM : contains`,
+        use_ascii: true,
+      })
+      const text = result.content[0]!.text
+      expect(text.length).toBeGreaterThan(0)
+    })
+  })
+
+  // --- Color modes ---
+
+  describe('render_mermaid_ascii – color modes', () => {
+    const COLOR_MODES = ['none', 'auto', 'ansi16', 'ansi256', 'truecolor', 'html'] as const
+
+    for (const mode of COLOR_MODES) {
+      it(`renders with color_mode="${mode}" without errors`, () => {
+        const result = handleRenderAscii({
+          mermaid_code: SIMPLE_LR,
+          color_mode: mode,
+        })
+        expectSuccessResponse(result)
+        const text = result.content[0]!.text
+        expect(text.length).toBeGreaterThan(0)
+      })
+    }
+
+    it('defaults to auto color mode when not specified', () => {
+      const result = handleRenderAscii({ mermaid_code: SIMPLE_LR })
+      expectSuccessResponse(result)
+    })
+  })
+
+  // --- CJK detection ---
+
+  describe('render_mermaid_ascii – CJK detection', () => {
+    it('emits CJK warning for Chinese characters in labels', () => {
+      const result = handleRenderAscii({
+        mermaid_code: 'graph TD\n  A[中文] --> B',
+      })
+      expect(result.warnings).toBeDefined()
+      expect(result.warnings).toHaveLength(1)
+      expect(result.warnings![0]).toContain('CJK')
+    })
+
+    it('emits CJK warning for Chinese characters in edge labels', () => {
+      const result = handleRenderAscii({
+        mermaid_code: `graph TD
+          A -->|你好| B`,
+      })
+      expect(result.warnings).toBeDefined()
+      expect(result.warnings![0]).toContain('CJK')
+    })
+
+    it('emits CJK warning for Japanese characters (hiragana + kanji)', () => {
+      const result = handleRenderAscii({
+        mermaid_code: 'graph TD\n  A[こんにちは] --> B[日本]',
+      })
+      expect(result.warnings).toBeDefined()
+      expect(result.warnings).toHaveLength(1)
+      expect(result.warnings![0]).toContain('CJK')
+    })
+
+    it('emits CJK warning for Japanese katakana', () => {
+      const result = handleRenderAscii({
+        mermaid_code: 'graph TD\n  A[テスト] --> B',
+      })
+      expect(result.warnings).toBeDefined()
+      expect(result.warnings![0]).toContain('CJK')
+    })
+
+    it('emits CJK warning for Korean hangul', () => {
+      const result = handleRenderAscii({
+        mermaid_code: 'graph TD\n  A[한국어] --> B',
+      })
+      expect(result.warnings).toBeDefined()
+      expect(result.warnings![0]).toContain('CJK')
+    })
+
+    it('does not emit warnings for ASCII-only diagrams', () => {
+      const result = handleRenderAscii({ mermaid_code: SIMPLE_LR })
+      expect(result.warnings).toBeUndefined()
+    })
+
+    it('does not emit warnings for Latin accented characters', () => {
+      const result = handleRenderAscii({
+        mermaid_code: 'graph TD\n  A[Café résumé] --> B',
+      })
+      expect(result.warnings).toBeUndefined()
+    })
+
+    it('emits single warning even with multiple CJK blocks', () => {
+      const result = handleRenderAscii({
+        mermaid_code: 'graph TD\n  A[中文] --> B[日本語]\n  B --> C[한국어]',
+      })
+      // Should be exactly one warning message
+      expect(result.warnings).toBeDefined()
+      expect(result.warnings).toHaveLength(1)
+    })
+
+    it('still renders correctly despite CJK warning', () => {
+      const result = handleRenderAscii({
+        mermaid_code: 'graph TD\n  A[你好世界] --> B',
+      })
+      expectSuccessResponse(result)
+      expect(result.warnings).toBeDefined()
+    })
+
+    it('emits CJK warning for CJK compatibility ideographs', () => {
+      const result = handleRenderAscii({
+        mermaid_code: 'graph TD\n  A[\uFA1F] --> B',
+      })
+      expect(result.warnings).toBeDefined()
+    })
+  })
+
+  // --- Padding options ---
+
+  describe('render_mermaid_ascii – padding', () => {
+    it('renders with default padding', () => {
+      const result = handleRenderAscii({ mermaid_code: SIMPLE_LR })
+      expectSuccessResponse(result)
+    })
+
+    it('renders with custom padding', () => {
+      const result = handleRenderAscii({
+        mermaid_code: SIMPLE_LR,
+        padding: 8,
+      })
+      expectSuccessResponse(result)
+    })
+
+    it('renders with zero padding', () => {
+      const result = handleRenderAscii({
+        mermaid_code: SIMPLE_LR,
+        padding: 0,
+      })
+      expectSuccessResponse(result)
+    })
+
+    it('renders with large padding', () => {
+      const result = handleRenderAscii({
+        mermaid_code: SIMPLE_LR,
+        padding: 20,
+      })
+      expectSuccessResponse(result)
+    })
+  })
+
+  // --- Error handling ---
+
+  describe('render_mermaid_ascii – errors', () => {
+    it('returns structured error for invalid header', () => {
+      const result = handleRenderAscii({
+        mermaid_code: 'not a valid mermaid diagram',
+      })
+      const { payload } = expectErrorResponse(result)
+      expect(payload.error).toBeDefined()
+    })
+
+    it('returns structured error for empty input', () => {
+      const result = handleRenderAscii({ mermaid_code: '' })
+      const { payload } = expectErrorResponse(result)
+      expect(payload.error).toBeDefined()
+    })
+
+    it('best-effort renders partial graph when trailing lines are broken', () => {
+      const result = handleRenderAscii({
+        mermaid_code: `graph LR
+          A --> B
+          ZZZ###!!!broken`,
+      })
+      expect(result.content).toHaveLength(1)
+      expect(typeof result.content[0]!.text).toBe('string')
+      expect(result.content[0]!.text.length).toBeGreaterThan(0)
+    })
+  })
+
+  // --- Edge cases ---
+
+  describe('render_mermaid_ascii – edge cases', () => {
+    it('renders state diagram with composite states in ASCII', () => {
+      const result = handleRenderAscii({
+        mermaid_code: `stateDiagram-v2
+          [*] --> Active
+          Active --> Inactive
+          Inactive --> [*]`,
+        use_ascii: true,
+      })
+      expectSuccessResponse(result)
+    })
+
+    it('renders graph with multiline labels in ASCII', () => {
+      const result = handleRenderAscii({
+        mermaid_code: 'graph TD\n  A["Line 1<br>Line 2"] --> B',
+        use_ascii: true,
+      })
+      expectSuccessResponse(result)
+    })
+
+    it('renders with color_mode=none and use_ascii=true combined', () => {
+      const result = handleRenderAscii({
+        mermaid_code: SIMPLE_LR,
+        use_ascii: true,
+        color_mode: 'none',
+      })
+      expectSuccessResponse(result)
+      const text = result.content[0]!.text
+      // In ASCII mode with no color, output is plain text (no ANSI escapes)
+      expect(text).toContain('+')
+      expect(text).toContain('-')
+    })
+  })
+})
+
+// ============================================================================
+// Cross-tool integration
+// ============================================================================
+
+describe('MCP tools – cross-tool integration', () => {
+  it('parse then render SVG produces consistent output', () => {
+    const code = `graph LR
+      A[Parse] --> B[Render]
+      B --> C[Verify]`
+
+    const parseResult = handleParseMermaid({ mermaid_code: code })
+    expectSuccessResponse(parseResult)
+
+    const graph = JSON.parse(parseResult.content[0]!.text)
+    expect(graph.nodes.A.label).toBe('Parse')
+    expect(graph.nodes.B.label).toBe('Render')
+    expect(graph.nodes.C.label).toBe('Verify')
+
+    const svgResult = handleRenderSVG({ mermaid_code: code })
+    expectSuccessResponse(svgResult)
+    expect(svgResult.content[0]!.text).toContain('>Parse</text>')
+    expect(svgResult.content[0]!.text).toContain('>Render</text>')
+    expect(svgResult.content[0]!.text).toContain('>Verify</text>')
+  })
+
+  it('parse then render ASCII produces consistent output', () => {
+    const code = 'graph TD\n  A --> B --> C'
+
+    const parseResult = handleParseMermaid({ mermaid_code: code })
+    expectSuccessResponse(parseResult)
+
+    const asciiResult = handleRenderAscii({ mermaid_code: code, use_ascii: true })
+    expectSuccessResponse(asciiResult)
+    const text = asciiResult.content[0]!.text
+    expect(text).toContain('A')
+    expect(text).toContain('B')
+    expect(text).toContain('C')
+  })
+
+  it('all diagram types parse and render SVG consistently', () => {
+    for (const [kind, code] of Object.entries(ALL_DIAGRAMS)) {
+      const parseResult = handleParseMermaid({ mermaid_code: code })
+      const svgResult = handleRenderSVG({ mermaid_code: code })
+
+      // Sequence, class, ER, xychart will fail at parse (parseMermaid only does flowchart/state)
+      if (kind === 'flowchart' || kind === 'state') {
+        expectSuccessResponse(parseResult)
+        expectSuccessResponse(svgResult)
+      } else {
+        // For other types, parseMermaid throws but renderSVG handles them internally
+        expectSuccessResponse(svgResult)
+      }
+    }
+  })
+
+  it('theme applied via SVG does not affect ASCII rendering', () => {
+    const code = 'graph TD\n  A --> B'
+
+    const svgResult = handleRenderSVG({
+      mermaid_code: code,
+      theme_name: 'tokyo-night',
+    })
+    const asciiResult = handleRenderAscii({
+      mermaid_code: code,
+      use_ascii: true,
+    })
+
+    expectSuccessResponse(svgResult)
+    expectSuccessResponse(asciiResult)
+
+    // SVG gets themed colors, ASCII is standalone
+    expect(svgResult.content[0]!.text).toContain('tokyo-night' in THEMES ? '--bg:' : '')
+    const asciiText = asciiResult.content[0]!.text
+    // ASCII output is independent of SVG theming
+    expect(asciiText).toContain('+')
+  })
+
+  it('errors in one tool do not affect other tools', () => {
+    // parse_mermaid should fail on this
+    const parseResult = handleParseMermaid({ mermaid_code: 'invalid diagram' })
+    expect(parseResult.isError).toBe(true)
+
+    // render_mermaid_svg on valid input should still work
+    const svgResult = handleRenderSVG({ mermaid_code: SIMPLE_FLOWCHART })
+    expectSuccessResponse(svgResult)
+
+    // render_mermaid_ascii should also still work
+    const asciiResult = handleRenderAscii({ mermaid_code: SIMPLE_FLOWCHART, use_ascii: true })
+    expectSuccessResponse(asciiResult)
+  })
+
+  it('SVG output is valid XML (has proper closing)', () => {
+    const result = handleRenderSVG({
+      mermaid_code: `graph TD
+        A[Node 1] --> B[Node 2]
+        B --> C[Node 3]
+        C --> D[Node 4]
+        D --> E[Node 5]`,
+    })
+    const svg = result.content[0]!.text
+
+    // Count opening and closing tags match
+    const opens = (svg.match(/<svg/g) ?? []).length
+    const closes = (svg.match(/<\/svg>/g) ?? []).length
+    expect(opens).toBe(1)
+    expect(closes).toBe(1)
+
+    // Basic XML balance: <defs> and </defs>
+    expect(svg).toContain('<defs>')
+    expect(svg).toContain('</defs>')
+
+    // <style> and </style>
+    expect(svg).toContain('<style>')
+    expect(svg).toContain('</style>')
+  })
+})

--- a/src/__tests__/mcp.test.ts
+++ b/src/__tests__/mcp.test.ts
@@ -908,6 +908,74 @@ describe('render_mermaid_svg', () => {
       expect(polylines).toBeGreaterThanOrEqual(3)
     })
   })
+
+  // --- File output (output_path) ---
+
+  describe('render_mermaid_svg – file output', () => {
+    it('writes SVG to file when output_path is provided', () => {
+      const tmpFile = `/tmp/test-mcp-output-${Date.now()}.svg`
+      try {
+        const result = handleRenderSVG({
+          mermaid_code: SIMPLE_FLOWCHART,
+          output_path: tmpFile,
+        })
+        expectSuccessResponse(result)
+
+        const info = JSON.parse(result.content[0]!.text) as {
+          saved: string
+          size: number
+        }
+        expect(info.saved).toContain(tmpFile)
+        expect(info.size).toBeGreaterThan(100)
+
+        // Verify file exists and contains valid SVG
+        const { readFileSync } = require('node:fs')
+        const content = readFileSync(tmpFile, 'utf-8')
+        expect(content).toContain('<svg xmlns="http://www.w3.org/2000/svg"')
+        expect(content).toContain('</svg>')
+      } finally {
+        // Cleanup
+        try { require('node:fs').unlinkSync(tmpFile) } catch {}
+      }
+    })
+
+    it('still applies theme when writing to file', () => {
+      const tmpFile = `/tmp/test-mcp-themed-${Date.now()}.svg`
+      try {
+        handleRenderSVG({
+          mermaid_code: SIMPLE_FLOWCHART,
+          theme_name: 'tokyo-night',
+          output_path: tmpFile,
+        })
+        const { readFileSync } = require('node:fs')
+        const content = readFileSync(tmpFile, 'utf-8')
+        expect(content).toContain('--bg:#1a1b26')
+        expect(content).toContain('--fg:#a9b1d6')
+      } finally {
+        try { require('node:fs').unlinkSync(tmpFile) } catch {}
+      }
+    })
+
+    it('returns error for invalid output path', () => {
+      const result = handleRenderSVG({
+        mermaid_code: SIMPLE_FLOWCHART,
+        output_path: '/nonexistent/dir/should/not/exist/file.svg',
+      })
+      expect(result.isError).toBe(true)
+      const payload = JSON.parse(result.content[0]!.text)
+      expect(payload.error).toBeDefined()
+    })
+
+    it('returns error for invalid mermaid even with output_path', () => {
+      const result = handleRenderSVG({
+        mermaid_code: '',
+        output_path: '/tmp/test-output.svg',
+      })
+      expect(result.isError).toBe(true)
+      const payload = JSON.parse(result.content[0]!.text)
+      expect(payload.error).toBeDefined()
+    })
+  })
 })
 
 // ============================================================================

--- a/src/mcp/cli.ts
+++ b/src/mcp/cli.ts
@@ -1,0 +1,21 @@
+#!/usr/bin/env bun
+// ============================================================================
+// beautiful-mermaid MCP server — stdio entry point
+//
+// Starts an MCP server over stdio transport when run as the main module.
+// Safe to import (won't auto-start) — use `import.meta.main` guard.
+//
+// Usage:
+//   bun run src/mcp/cli.ts
+//   # or: beautiful-mermaid (via npm bin)
+// ============================================================================
+
+import { startServer } from './server.ts'
+
+// Auto-start only when executed as the main module (CLI), not when imported.
+if (import.meta.main) {
+  startServer().catch((error) => {
+    console.error('Fatal: Failed to start MCP server:', error)
+    process.exit(1)
+  })
+}

--- a/src/mcp/errors.ts
+++ b/src/mcp/errors.ts
@@ -1,0 +1,27 @@
+// ============================================================================
+// MCP error formatting — best-effort error handling utilities
+//
+// Provides structured error message formatting for MCP tool responses.
+// Supports optional partial output inclusion for best-effort rendering.
+// ============================================================================
+
+/**
+ * Format an error into a structured JSON string for MCP tool responses.
+ * Includes optional partial output when best-effort rendering succeeds.
+ */
+export function formatError(
+  error: unknown,
+  partial?: string
+): string {
+  const message = error instanceof Error ? error.message : String(error)
+
+  const payload: Record<string, unknown> = {
+    error: message,
+  }
+
+  if (partial) {
+    payload.partial = partial
+  }
+
+  return JSON.stringify(payload, null, 2)
+}

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -1,0 +1,148 @@
+// ============================================================================
+// MCP server factory — creates and configures McpServer with all 4 tools
+//
+// Provides createServer() for programmatic use and startServer()
+// for the CLI entry point (stdio transport).
+// ============================================================================
+
+import { McpServer, StdioServerTransport } from '@modelcontextprotocol/server'
+import { z } from 'zod'
+
+import { handleRenderSVG } from './tools/render-svg.ts'
+import { handleRenderAscii } from './tools/render-ascii.ts'
+import { handleParseMermaid } from './tools/parse.ts'
+import { handleListDiagramTypes } from './tools/list-types.ts'
+
+// ============================================================================
+// Server info
+// ============================================================================
+
+const SERVER_INFO = {
+  name: 'beautiful-mermaid',
+  version: '1.1.3',
+} as const
+
+// ============================================================================
+// Zod schemas for tool inputs
+// ============================================================================
+
+const listDiagramTypesSchema = z.object({})
+
+const parseMermaidSchema = z.object({
+  mermaid_code: z.string().describe(
+    'Mermaid diagram source code to parse into a JSON graph structure.'
+  ),
+})
+
+const renderSVGSchema = z.object({
+  mermaid_code: z.string().describe(
+    'Mermaid diagram source code to render as SVG.'
+  ),
+  theme_name: z.string().optional().describe(
+    'Well-known theme name. Supported: tokyo-night, catppuccin-mocha, nord, dracula, github-dark, github-light, zinc-light, zinc-dark, and others. Look up from the THEMES registry.'
+  ),
+  bg: z.string().optional().describe(
+    'Background color as hex (e.g. "#1a1b26"). Overrides theme background.'
+  ),
+  fg: z.string().optional().describe(
+    'Foreground/text color as hex (e.g. "#a9b1d6"). Overrides theme foreground.'
+  ),
+  transparent: z.boolean().optional().describe(
+    'Render with transparent background. Default: false.'
+  ),
+})
+
+const renderAsciiSchema = z.object({
+  mermaid_code: z.string().describe(
+    'Mermaid diagram source code to render as ASCII/Unicode art.'
+  ),
+  use_ascii: z.boolean().optional().describe(
+    'Use pure ASCII characters (+, -, |, >) instead of Unicode box-drawing (┌, ─, │, ►). Default: false.'
+  ),
+  color_mode: z.enum(['none', 'auto', 'ansi16', 'ansi256', 'truecolor', 'html']).optional().describe(
+    'Color output mode. "auto" detects terminal capabilities. "none" produces plain text. Default: "auto".'
+  ),
+  padding: z.number().int().min(0).max(20).optional().describe(
+    'Padding around nodes (applied to both X and Y). Default: 5.'
+  ),
+})
+
+// ============================================================================
+// Factory
+// ============================================================================
+
+/**
+ * Create a configured McpServer with all 4 tools registered.
+ * Does not connect to transport — caller must call server.connect().
+ */
+export function createServer(): McpServer {
+  const server = new McpServer(SERVER_INFO)
+
+  // 1. list_diagram_types — no parameters
+  server.registerTool(
+    'list_diagram_types',
+    {
+      description: 'List all supported Mermaid diagram types with descriptions and examples.',
+      inputSchema: listDiagramTypesSchema,
+    },
+    () => handleListDiagramTypes(),
+  )
+
+  // 2. parse_mermaid — parse to JSON graph
+  server.registerTool(
+    'parse_mermaid',
+    {
+      description: 'Parse Mermaid diagram source code into a JSON graph structure representing nodes, edges, subgraphs, and styling.',
+      inputSchema: parseMermaidSchema,
+    },
+    (args) => handleParseMermaid(args),
+  )
+
+  // 3. render_mermaid_svg — render to SVG with theme support
+  server.registerTool(
+    'render_mermaid_svg',
+    {
+      description: 'Render a Mermaid diagram to a beautiful, themeable SVG string. Supports flowcharts, state diagrams, sequence diagrams, class diagrams, ER diagrams, and XY charts.',
+      inputSchema: renderSVGSchema,
+    },
+    (args) => handleRenderSVG(args),
+  )
+
+  // 4. render_mermaid_ascii — render to ASCII/Unicode art
+  server.registerTool(
+    'render_mermaid_ascii',
+    {
+      description: 'Render a Mermaid diagram to ASCII or Unicode box-drawing art for terminal display. Detects CJK characters and emits warnings.',
+      inputSchema: renderAsciiSchema,
+    },
+    (args) => handleRenderAscii(args),
+  )
+
+  return server
+}
+
+// ============================================================================
+// Stdio launcher
+// ============================================================================
+
+/**
+ * Create a server and connect it to the stdio transport.
+ * This is the entry point for the `beautiful-mermaid` CLI command.
+ *
+ * Handles SIGINT/SIGTERM for graceful shutdown.
+ */
+export async function startServer(): Promise<void> {
+  const server = createServer()
+  const transport = new StdioServerTransport()
+
+  // Graceful shutdown on signals
+  const shutdown = async () => {
+    await server.close()
+    process.exit(0)
+  }
+
+  process.on('SIGINT', shutdown)
+  process.on('SIGTERM', shutdown)
+
+  await server.connect(transport)
+}

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -50,6 +50,9 @@ const renderSVGSchema = z.object({
   transparent: z.boolean().optional().describe(
     'Render with transparent background. Default: false.'
   ),
+  output_path: z.string().optional().describe(
+    'File path to save the SVG to (relative or absolute). When provided, writes the SVG to disk instead of returning it as text. Returns { saved, size } on success.'
+  ),
 })
 
 const renderAsciiSchema = z.object({
@@ -98,11 +101,11 @@ export function createServer(): McpServer {
     (args) => handleParseMermaid(args),
   )
 
-  // 3. render_mermaid_svg — render to SVG with theme support
+  // 3. render_mermaid_svg — render to SVG with theme support, optional file output
   server.registerTool(
     'render_mermaid_svg',
     {
-      description: 'Render a Mermaid diagram to a beautiful, themeable SVG string. Supports flowcharts, state diagrams, sequence diagrams, class diagrams, ER diagrams, and XY charts.',
+      description: 'Render a Mermaid diagram to a beautiful, themeable SVG string. Supports flowcharts, state diagrams, sequence diagrams, class diagrams, ER diagrams, and XY charts. Use output_path to write the SVG directly to a file instead of returning it as text.',
       inputSchema: renderSVGSchema,
     },
     (args) => handleRenderSVG(args),

--- a/src/mcp/tools/list-types.ts
+++ b/src/mcp/tools/list-types.ts
@@ -1,0 +1,52 @@
+// ============================================================================
+// list_diagram_types tool handler
+//
+// Returns a static list of supported Mermaid diagram types with
+// descriptions and examples. No parameters required.
+// ============================================================================
+
+/**
+ * Supported diagram types with descriptions and examples.
+ */
+const DIAGRAM_TYPES = [
+  {
+    name: 'flowchart',
+    description: 'Flowchart and graph diagrams (graph TD / flowchart LR)',
+    example: 'graph TD\n  A --> B --> C',
+  },
+  {
+    name: 'sequence',
+    description: 'Sequence diagrams for message-based interactions',
+    example: 'sequenceDiagram\n  A->>B: Hello\n  B->>A: Hi',
+  },
+  {
+    name: 'class',
+    description: 'UML class diagrams with inheritance, composition, and cardinality',
+    example: 'classDiagram\n  Animal <|-- Duck\n  Animal : +int age',
+  },
+  {
+    name: 'er',
+    description: 'Entity-Relationship diagrams for database modeling',
+    example: 'erDiagram\n  CUSTOMER ||--o{ ORDER : places',
+  },
+  {
+    name: 'xychart',
+    description: 'XY charts and bar charts for data visualization',
+    example: 'xychart-beta\n  line [1,2,3,4]',
+  },
+  {
+    name: 'state',
+    description: 'State diagrams for finite state machines',
+    example: 'stateDiagram-v2\n  [*] --> Active\n  Active --> Inactive',
+  },
+] as const
+
+/**
+ * MCP tool handler for `list_diagram_types`.
+ * Returns the static list of supported diagram types.
+ */
+export function handleListDiagramTypes(): { content: Array<{ type: 'text'; text: string }> } {
+  return {
+    content: [{ type: 'text', text: JSON.stringify(DIAGRAM_TYPES, null, 2) }],
+  }
+}

--- a/src/mcp/tools/parse.ts
+++ b/src/mcp/tools/parse.ts
@@ -1,0 +1,70 @@
+// ============================================================================
+// parse_mermaid tool handler
+//
+// Wraps parseMermaid() to return a JSON graph structure.
+// Handles Map serialization (nodes, classDefs, etc.) for JSON output.
+// ============================================================================
+
+import { parseMermaid } from '../../index.ts'
+import { formatError } from '../errors.ts'
+
+/**
+ * Serialize a MermaidGraph to a plain JSON-safe object.
+ * Converts Map fields (nodes, classDefs, classAssignments, nodeStyles, linkStyles)
+ * to nested objects for JSON serialization.
+ */
+function serializeGraph(graph: ReturnType<typeof parseMermaid>): Record<string, unknown> {
+  return {
+    direction: graph.direction,
+    nodes: Object.fromEntries(graph.nodes),
+    edges: graph.edges.map(e => ({
+      source: e.source,
+      target: e.target,
+      label: e.label,
+      style: e.style,
+      hasArrowStart: e.hasArrowStart,
+      hasArrowEnd: e.hasArrowEnd,
+    })),
+    subgraphs: graph.subgraphs.map(sg => ({
+      id: sg.id,
+      label: sg.label,
+      nodeIds: sg.nodeIds,
+      children: sg.children.map(child => ({
+        id: child.id,
+        label: child.label,
+        nodeIds: child.nodeIds,
+        children: child.children,
+        direction: child.direction,
+      })),
+      direction: sg.direction,
+    })),
+    classDefs: Object.fromEntries(graph.classDefs),
+    classAssignments: Object.fromEntries(graph.classAssignments),
+    nodeStyles: Object.fromEntries(graph.nodeStyles),
+    linkStyles: Object.fromEntries(
+      Array.from(graph.linkStyles.entries()).map(([k, v]) => [String(k), v])
+    ),
+  }
+}
+
+/**
+ * MCP tool handler for `parse_mermaid`.
+ * Parses Mermaid text and returns the graph structure as JSON.
+ */
+export function handleParseMermaid(args: { mermaid_code: string }): {
+  content: Array<{ type: 'text'; text: string }>
+  isError?: boolean
+} {
+  try {
+    const graph = parseMermaid(args.mermaid_code)
+    const serialized = serializeGraph(graph)
+    return {
+      content: [{ type: 'text', text: JSON.stringify(serialized, null, 2) }],
+    }
+  } catch (error) {
+    return {
+      content: [{ type: 'text', text: formatError(error) }],
+      isError: true,
+    }
+  }
+}

--- a/src/mcp/tools/render-ascii.ts
+++ b/src/mcp/tools/render-ascii.ts
@@ -1,0 +1,86 @@
+// ============================================================================
+// render_mermaid_ascii tool handler
+//
+// Wraps renderMermaidASCII() with CJK detection and warning emission.
+// Supports best-effort partial rendering on errors.
+// ============================================================================
+
+import { renderMermaidASCII } from '../../index.ts'
+import type { AsciiRenderOptions } from '../../index.ts'
+import { formatError } from '../errors.ts'
+import { checkCJK } from '../warnings.ts'
+
+// ============================================================================
+// Best-effort partial rendering
+// ============================================================================
+
+/**
+ * Attempt best-effort partial ASCII rendering by stripping lines from the end.
+ */
+function attemptPartialAscii(mermaidCode: string, options: AsciiRenderOptions): string | undefined {
+  const lines = mermaidCode.split('\n')
+  for (let i = lines.length - 1; i > 0; i--) {
+    try {
+      const partial = lines.slice(0, i).join('\n')
+      return renderMermaidASCII(partial, options)
+    } catch {
+      // Continue stripping lines
+    }
+  }
+  return undefined
+}
+
+// ============================================================================
+// Tool handler
+// ============================================================================
+
+/**
+ * MCP tool handler for `render_mermaid_ascii`.
+ * Renders Mermaid code to ASCII/Unicode art with optional CJK warnings.
+ */
+export function handleRenderAscii(args: {
+  mermaid_code: string
+  use_ascii?: boolean
+  color_mode?: string
+  padding?: number
+}): {
+  content: Array<{ type: 'text'; text: string }>
+  isError?: boolean
+  warnings?: string[]
+} {
+  // Map MCP params to AsciiRenderOptions
+  const options: AsciiRenderOptions = {
+    useAscii: args.use_ascii,
+    colorMode: (args.color_mode as AsciiRenderOptions['colorMode']) ?? 'auto',
+  }
+
+  if (args.padding !== undefined) {
+    options.paddingX = args.padding
+    options.paddingY = args.padding
+  }
+
+  try {
+    const ascii = renderMermaidASCII(args.mermaid_code, options)
+    const warnings = checkCJK(ascii)
+
+    const result: {
+      content: Array<{ type: 'text'; text: string }>
+      isError?: boolean
+      warnings?: string[]
+    } = {
+      content: [{ type: 'text', text: ascii }],
+    }
+
+    if (warnings.length > 0) {
+      result.warnings = warnings
+    }
+
+    return result
+  } catch (error) {
+    const partial = attemptPartialAscii(args.mermaid_code, options)
+    return {
+      content: [{ type: 'text', text: formatError(error, partial) }],
+      isError: true,
+    }
+  }
+}

--- a/src/mcp/tools/render-svg.ts
+++ b/src/mcp/tools/render-svg.ts
@@ -3,11 +3,16 @@
 //
 // Wraps renderMermaidSVG() with theme resolution and best-effort
 // partial rendering on parse/rendering errors.
+//
+// Supports optional output_path — when provided, writes SVG to disk
+// and returns { saved, size }; otherwise returns SVG content as text.
 // ============================================================================
 
 import { renderMermaidSVG, THEMES, DEFAULTS } from '../../index.ts'
 import { formatError } from '../errors.ts'
 import type { DiagramColors, ThemeName } from '../../index.ts'
+import { resolve } from 'node:path'
+import { writeFileSync } from 'node:fs'
 
 // ============================================================================
 // Theme resolution
@@ -79,6 +84,10 @@ function attemptPartialRendering(mermaidCode: string, colors: { bg: string; fg: 
 /**
  * MCP tool handler for `render_mermaid_svg`.
  * Renders Mermaid code to SVG with theme resolution.
+ *
+ * When `output_path` is provided, writes the SVG to disk and returns
+ * { saved: "/absolute/path/to/file.svg", size: 12345 }.
+ * Otherwise returns the SVG content as text.
  */
 export function handleRenderSVG(args: {
   mermaid_code: string
@@ -86,6 +95,7 @@ export function handleRenderSVG(args: {
   bg?: string
   fg?: string
   transparent?: boolean
+  output_path?: string
 }): {
   content: Array<{ type: 'text'; text: string }>
   isError?: boolean
@@ -93,13 +103,36 @@ export function handleRenderSVG(args: {
   const colors = resolveColors(args)
   const transparent = args.transparent ?? false
 
-  try {
-    const svg = renderMermaidSVG(args.mermaid_code, {
+  const render = (code: string): string =>
+    renderMermaidSVG(code, {
       bg: colors.bg,
       fg: colors.fg,
       ...colors.enrichment,
       transparent,
     })
+
+  try {
+    const svg = render(args.mermaid_code)
+
+    // File output path
+    if (args.output_path) {
+      try {
+        const absPath = resolve(args.output_path)
+        writeFileSync(absPath, svg, 'utf-8')
+        const result = JSON.stringify({
+          saved: absPath,
+          size: Buffer.byteLength(svg, 'utf-8'),
+        })
+        return { content: [{ type: 'text', text: result }] }
+      } catch (fsError) {
+        return {
+          content: [{ type: 'text', text: formatError(fsError) }],
+          isError: true,
+        }
+      }
+    }
+
+    // Default: return SVG content
     return {
       content: [{ type: 'text', text: svg }],
     }

--- a/src/mcp/tools/render-svg.ts
+++ b/src/mcp/tools/render-svg.ts
@@ -1,0 +1,114 @@
+// ============================================================================
+// render_mermaid_svg tool handler
+//
+// Wraps renderMermaidSVG() with theme resolution and best-effort
+// partial rendering on parse/rendering errors.
+// ============================================================================
+
+import { renderMermaidSVG, THEMES, DEFAULTS } from '../../index.ts'
+import { formatError } from '../errors.ts'
+import type { DiagramColors, ThemeName } from '../../index.ts'
+
+// ============================================================================
+// Theme resolution
+// ============================================================================
+
+/**
+ * Resolve colors from theme name + user overrides.
+ *
+ * Priority: user bg/fg > theme bg/fg > DEFAULTS
+ * Optional enrichment colors (line, accent, etc.) from theme are passed through
+ * unless overridden by user (not exposed in MCP params, so theme values pass through).
+ */
+function resolveColors(args: {
+  theme_name?: string
+  bg?: string
+  fg?: string
+}): { bg: string; fg: string; enrichment: Partial<DiagramColors> } {
+  const theme = args.theme_name && args.theme_name in THEMES
+    ? THEMES[args.theme_name as ThemeName]
+    : null
+
+  const bg = args.bg ?? theme?.bg ?? DEFAULTS.bg
+  const fg = args.fg ?? theme?.fg ?? DEFAULTS.fg
+
+  // Carry forward optional enrichment from theme
+  const enrichment: Partial<DiagramColors> = {}
+  if (theme) {
+    if (theme.line) enrichment.line = theme.line
+    if (theme.accent) enrichment.accent = theme.accent
+    if (theme.muted) enrichment.muted = theme.muted
+    if (theme.surface) enrichment.surface = theme.surface
+    if (theme.border) enrichment.border = theme.border
+  }
+
+  return { bg, fg, enrichment }
+}
+
+// ============================================================================
+// Best-effort partial rendering
+// ============================================================================
+
+/**
+ * Attempt best-effort partial rendering by stripping lines from the end.
+ * Returns a partial SVG string if successful, or undefined if no partial output.
+ */
+function attemptPartialRendering(mermaidCode: string, colors: { bg: string; fg: string; enrichment: Partial<DiagramColors> }, transparent: boolean): string | undefined {
+  const lines = mermaidCode.split('\n')
+  // Start from full length minus 1, stop at 1 (keep at least the header line)
+  for (let i = lines.length - 1; i > 0; i--) {
+    try {
+      const partial = lines.slice(0, i).join('\n')
+      return renderMermaidSVG(partial, {
+        bg: colors.bg,
+        fg: colors.fg,
+        ...colors.enrichment,
+        transparent,
+      })
+    } catch {
+      // Continue stripping lines
+    }
+  }
+  return undefined
+}
+
+// ============================================================================
+// Tool handler
+// ============================================================================
+
+/**
+ * MCP tool handler for `render_mermaid_svg`.
+ * Renders Mermaid code to SVG with theme resolution.
+ */
+export function handleRenderSVG(args: {
+  mermaid_code: string
+  theme_name?: string
+  bg?: string
+  fg?: string
+  transparent?: boolean
+}): {
+  content: Array<{ type: 'text'; text: string }>
+  isError?: boolean
+} {
+  const colors = resolveColors(args)
+  const transparent = args.transparent ?? false
+
+  try {
+    const svg = renderMermaidSVG(args.mermaid_code, {
+      bg: colors.bg,
+      fg: colors.fg,
+      ...colors.enrichment,
+      transparent,
+    })
+    return {
+      content: [{ type: 'text', text: svg }],
+    }
+  } catch (error) {
+    // Best-effort: try partial rendering
+    const partial = attemptPartialRendering(args.mermaid_code, colors, transparent)
+    return {
+      content: [{ type: 'text', text: formatError(error, partial) }],
+      isError: true,
+    }
+  }
+}

--- a/src/mcp/warnings.ts
+++ b/src/mcp/warnings.ts
@@ -1,0 +1,31 @@
+// ============================================================================
+// CJK detection for ASCII rendering warnings
+//
+// Detects CJK (Chinese/Japanese/Korean) characters in rendered output
+// and emits warnings. Does NOT attempt width correction — CJK characters
+// may misalign in fixed-width terminal output.
+//
+// Covered Unicode blocks:
+//   U+4E00–U+9FFF  CJK Unified Ideographs (Chinese/Kanji)
+//   U+3400–U+4DBF  CJK Unified Ideographs Extension A
+//   U+F900–U+FAFF  CJK Compatibility Ideographs
+//   U+3040–U+309F  Hiragana (Japanese)
+//   U+30A0–U+30FF  Katakana (Japanese)
+//   U+AC00–U+D7AF  Hangul Syllables (Korean)
+//   U+1100–U+11FF  Hangul Jamo (Korean)
+//   U+3130–U+318F  Hangul Compatibility Jamo (Korean)
+// ============================================================================
+
+/** Regex matching all CJK character ranges that are double-width in terminals */
+const CJK_REGEX = /[\u4e00-\u9fff\u3400-\u4dbf\uf900-\ufaff\u3040-\u309f\u30a0-\u30ff\uac00-\ud7af\u1100-\u11ff\u3130-\u318f]/
+
+/**
+ * Check text for CJK characters and return warnings if found.
+ * Returns empty array if no CJK characters are present.
+ */
+export function checkCJK(text: string): string[] {
+  if (CJK_REGEX.test(text)) {
+    return ['Diagram contains CJK (Chinese/Japanese/Korean) characters which may misalign in fixed-width terminal output.']
+  }
+  return []
+}

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'tsup'
 
 export default defineConfig({
-  entry: ['src/index.ts'],
+  entry: ['src/index.ts', 'src/mcp/cli.ts'],
   format: ['esm'],
   dts: true,
   splitting: false,


### PR DESCRIPTION
- Add 4 MCP tools: render_mermaid_svg, render_mermaid_ascii, parse_mermaid, list_diagram_types
- Stdio transport via @modelcontextprotocol/server + zod v4 schemas
- Theme resolution (user > theme_name > DEFAULTS) with enrichment color passthrough
- Best-effort partial rendering via iterative line-stripping on errors
- CJK detection with expanded Unicode coverage (8 blocks: ideographs + kana + hangul)
- Update README with MCP configuration and tool reference
- 139 unit/integration tests + 22 end-to-end protocol tests