### PR TITLE
fix: Correct parsing of `}o` cardinality

### DIFF
--- a/src/er/parser.ts
+++ b/src/er/parser.ts
@@ -15,10 +15,10 @@ import { normalizeBrTags } from '../multiline-utils.ts'
 //   }
 //
 // Cardinality notation:
-//   ||  exactly one
-//   o|  zero or one (also |o)
-//   }|  one or more (also |{)
-//   o{  zero or more (also {o)
+//   ||  ||  exactly one
+//   |o  o|  zero or one
+//   }|  |{  one or more
+//   }o  o{  zero or more
 //
 // Line style:
 //   --  identifying (solid line)
@@ -128,9 +128,9 @@ function parseAttribute(line: string): ErAttribute | null {
  * Parse a relationship line.
  *
  * Cardinality symbols on each side of the line style:
- *   Left side (entity1):  ||  |o  o|  }|  |{  o{  {o
+ *   Left side (entity1):  ||  |o  }|  }o
  *   Line:                 --  (identifying) or  ..  (non-identifying)
- *   Right side (entity2): ||  o|  |o  |{  }|  {o  o{
+ *   Right side (entity2): ||  o|  |{  o{
  *
  * Full pattern example: CUSTOMER ||--o{ ORDER : places
  */
@@ -174,8 +174,8 @@ function parseCardinality(str: string): Cardinality | null {
   if (sorted === 'o|') return 'zero-one'
   // One or more: }| or |{ → sorted "|}" or "{|"
   if (sorted === '|}' || sorted === '{|') return 'many'
-  // Zero or more: o{ or {o → sorted "{o" or "o{"
-  if (sorted === '{o' || sorted === 'o{') return 'zero-many'
+  // Zero or more: }o or o{ → sorted "o}" or "o{"
+  if (sorted === 'o}' || sorted === 'o{') return 'zero-many'
 
   return null
 }


### PR DESCRIPTION
Consider this example:

    foo }o--|| bar : "should work but doesn't"
    foo }|--|| baz : "works fine"

This commit fixes the parser, so the example above now works.

Additionally:

    fuz {o--|| bar : "should not work"
    fuz {|--|| baz : "should not work"

These are invalid and should NOT work. Yet, beautiful-mermaid accepts these (and other invalid symbols). We should probably be more strict about it and reject such incorrect symbols, but that should be done in another commit.

Fixes #124

---

Notes:

1. I could not run the unit tests locally, as 104 of them failed for no good reason. That's also why I have not included any unit test in this commit. Please, someone else should add the tests.
2. We should reject invalid cardinality symbols. This should be done in another commit, and hopefully with unit tests to validate the code. (For doing that, we can just simplify the `parseCardinality()` function to remove that sorting logic.)
3. Commit 100% written by a human, no LLM involved.