### PR TITLE
Strict cardinality parser

### DIFF
--- a/src/ascii/er-diagram.ts
+++ b/src/ascii/er-diagram.ts
@@ -63,7 +63,7 @@ function getCrowsFootChars(card: Cardinality, useAscii: boolean, isRight = false
   if (useAscii) {
     switch (card) {
       case 'one':       return '|'
-      case 'zero-one':  return 'o|'
+      case 'zero-one':  return isRight ? 'o|' : '|o'
       case 'many':      return isRight ? '<' : '>'
       case 'zero-many': return isRight ? 'o<' : '>o'
     }
@@ -71,7 +71,7 @@ function getCrowsFootChars(card: Cardinality, useAscii: boolean, isRight = false
     // Use cleaner Unicode characters
     switch (card) {
       case 'one':       return '│'
-      case 'zero-one':  return '○│'
+      case 'zero-one':  return isRight ? '○│' : '│○'
       case 'many':      return isRight ? '╟' : '╢'
       case 'zero-many': return isRight ? '○╟' : '╢○'
     }

--- a/src/er/parser.ts
+++ b/src/er/parser.ts
@@ -15,10 +15,10 @@ import { normalizeBrTags } from '../multiline-utils.ts'
 //   }
 //
 // Cardinality notation:
-//   ||  exactly one
-//   o|  zero or one (also |o)
-//   }|  one or more (also |{)
-//   o{  zero or more (also {o)
+//   ||  ||  exactly one
+//   |o  o|  zero or one
+//   }|  |{  one or more
+//   }o  o{  zero or more
 //
 // Line style:
 //   --  identifying (solid line)
@@ -128,9 +128,9 @@ function parseAttribute(line: string): ErAttribute | null {
  * Parse a relationship line.
  *
  * Cardinality symbols on each side of the line style:
- *   Left side (entity1):  ||  |o  o|  }|  |{  o{  {o
+ *   Left side (entity1):  ||  |o  }|  }o
  *   Line:                 --  (identifying) or  ..  (non-identifying)
- *   Right side (entity2): ||  o|  |o  |{  }|  {o  o{
+ *   Right side (entity2): ||  o|  |{  o{
  *
  * Full pattern example: CUSTOMER ||--o{ ORDER : places
  */
@@ -174,8 +174,8 @@ function parseCardinality(str: string): Cardinality | null {
   if (sorted === 'o|') return 'zero-one'
   // One or more: }| or |{ → sorted "|}" or "{|"
   if (sorted === '|}' || sorted === '{|') return 'many'
-  // Zero or more: o{ or {o → sorted "{o" or "o{"
-  if (sorted === '{o' || sorted === 'o{') return 'zero-many'
+  // Zero or more: }o or o{ → sorted "o}" or "o{"
+  if (sorted === 'o}' || sorted === 'o{') return 'zero-many'
 
   return null
 }

--- a/src/er/parser.ts
+++ b/src/er/parser.ts
@@ -154,8 +154,8 @@ function parseRelationshipLine(line: string): ErRelationship | null {
   const lineStyle = lineMatch[2]!
   const rightStr = lineMatch[3]!
 
-  const cardinality1 = parseCardinality(leftStr)
-  const cardinality2 = parseCardinality(rightStr)
+  const cardinality1 = parseLeftCardinality(leftStr)
+  const cardinality2 = parseRightCardinality(rightStr)
   const identifying = lineStyle === '--'
 
   if (!cardinality1 || !cardinality2) return null
@@ -164,18 +164,19 @@ function parseRelationshipLine(line: string): ErRelationship | null {
 }
 
 /** Parse a cardinality notation string into a Cardinality type */
-function parseCardinality(str: string): Cardinality | null {
-  // Normalize: sort the characters to handle both orders (e.g., |o and o|)
-  const sorted = str.split('').sort().join('')
+function parseLeftCardinality(str: string): Cardinality | null {
+  if (str === '||') return 'one'
+  if (str === '|o') return 'zero-one'
+  if (str === '}|') return 'many'
+  if (str === '}o') return 'zero-many'
+  return null
+}
 
-  // Exact one: || → sorted "||"
-  if (sorted === '||') return 'one'
-  // Zero or one: o| or |o → sorted "o|" (o=111 < |=124 in char codes)
-  if (sorted === 'o|') return 'zero-one'
-  // One or more: }| or |{ → sorted "|}" or "{|"
-  if (sorted === '|}' || sorted === '{|') return 'many'
-  // Zero or more: }o or o{ → sorted "o}" or "o{"
-  if (sorted === 'o}' || sorted === 'o{') return 'zero-many'
-
+/** Parse a cardinality notation string into a Cardinality type */
+function parseRightCardinality(str: string): Cardinality | null {
+  if (str === '||') return 'one'
+  if (str === 'o|') return 'zero-one'
+  if (str === '|{') return 'many'
+  if (str === 'o{') return 'zero-many'
   return null
 }

--- a/src/er/types.ts
+++ b/src/er/types.ts
@@ -34,10 +34,10 @@ export interface ErAttribute {
 
 /**
  * Cardinality notation (crow's foot):
- *   'one'       ||  exactly one
- *   'zero-one'  |o  zero or one
- *   'many'      }|  one or more
- *   'zero-many' o{  zero or more
+ *   'one'       ||  ||  exactly one
+ *   'zero-one'  |o  o|  zero or one
+ *   'many'      }|  |{  one or more
+ *   'zero-many' }o  o{  zero or more
  */
 export type Cardinality = 'one' | 'zero-one' | 'many' | 'zero-many'
 


### PR DESCRIPTION
fix: Stricter cardinality symbols for ER diagrams
Previously, invalid cardinality symbols were supported by beautiful-mermaid:

    foo {o--|| bar : "should not work"
    foo o{--|| bar : "should not work"
    foo o}--|| bar : "should not work"
    foo {|--|| bar : "should not work"
    foo |{--|| bar : "should not work"
    foo |}--|| bar : "should not work"
    foo o|--|| bar : "should not work"

    foo ||--{o bar : "should not work"
    foo ||--}o bar : "should not work"
    foo ||--o} bar : "should not work"
    foo ||--{| bar : "should not work"
    foo ||--}| bar : "should not work"
    foo ||--|} bar : "should not work"
    foo ||--|o bar : "should not work"

This commit stops supporting those invalid symbols.

This commit also fixes the ASCII rendering of such symbols.

No unit tests are touched in this commit. Unit tests should be added, so we are sure everything is being correctly parsed. However, I'm having trouble running tests on my machine, so I'm expecting someone else to help with them.

This is a follow-up to #126.

Commit made by a human, no LLMs involved.