### PR TITLE
fix(parser): support CJK subgraph ids and quoted bracket titles (closes #89)

### DIFF
--- a/src/__tests__/parser.test.ts
+++ b/src/__tests__/parser.test.ts
@@ -543,6 +543,41 @@ describe('parseMermaid – subgraphs', () => {
     expect(g.subgraphs[0]!.label).toBe('My Group')
   })
 
+  it('strips wrapping quotes from a quoted bracket title: subgraph id ["Title"]', () => {
+    const g = parseMermaid(`graph TD
+      subgraph be ["Backend Services"]
+        A --> B
+      end`)
+    expect(g.subgraphs[0]!.id).toBe('be')
+    expect(g.subgraphs[0]!.label).toBe('Backend Services')
+  })
+
+  it('parses a bracket title on a non-ASCII (CJK) subgraph id', () => {
+    const g = parseMermaid(`flowchart TB
+      subgraph 柜体 ["PLC 控制柜正面布局"]
+        A --> B
+      end`)
+    expect(g.subgraphs[0]!.id).toBe('柜体')
+    expect(g.subgraphs[0]!.label).toBe('PLC 控制柜正面布局')
+  })
+
+  it('keeps a non-empty id for a CJK-only subgraph label (regression: #89)', () => {
+    const g = parseMermaid(`flowchart TB
+      subgraph 关系三元组
+        A --> B
+      end`)
+    expect(g.subgraphs[0]!.id).toBe('关系三元组')
+    expect(g.subgraphs[0]!.label).toBe('关系三元组')
+  })
+
+  it('strips wrapping quotes from a quoted label without a separate id', () => {
+    const g = parseMermaid(`graph TD
+      subgraph "My Quoted Group"
+        A --> B
+      end`)
+    expect(g.subgraphs[0]!.label).toBe('My Quoted Group')
+  })
+
   it('parses nested subgraphs', () => {
     const g = parseMermaid(`graph TD
       subgraph Outer

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1,6 +1,18 @@
 import type { MermaidGraph, MermaidNode, MermaidEdge, MermaidSubgraph, Direction, NodeShape, EdgeStyle } from './types.ts'
 import { normalizeBrTags } from './multiline-utils.ts'
 
+/** Remove a single layer of matching wrapping quotes (`"…"` or `'…'`). */
+function stripWrappingQuotes(s: string): string {
+  const t = s.trim()
+  if (
+    t.length >= 2 &&
+    ((t[0] === '"' && t[t.length - 1] === '"') || (t[0] === "'" && t[t.length - 1] === "'"))
+  ) {
+    return t.slice(1, -1)
+  }
+  return t
+}
+
 // ============================================================================
 // Mermaid parser — flowcharts and state diagrams
 //
@@ -126,18 +138,22 @@ function parseFlowchart(lines: string[]): MermaidGraph {
     const subgraphMatch = line.match(/^subgraph\s+(.+)$/)
     if (subgraphMatch) {
       const rest = subgraphMatch[1]!.trim()
-      // Check for "subgraph id [Label]" form
-      // ID can contain hyphens (e.g. "us-east"), so use [\w-]+ not \w+
-      const bracketMatch = rest.match(/^([\w-]+)\s*\[(.+)\]$/)
+      // Check for `subgraph id [Label]` / `subgraph id ["Label"]` form. The id
+      // may contain non-ASCII chars (e.g. CJK), so match any run of non-space,
+      // non-`[` chars rather than ASCII [\w-]; strip optional quotes wrapping
+      // the title.
+      const bracketMatch = rest.match(/^([^\s[]+)\s*\[(.+)\]$/)
       let id: string
       let label: string
       if (bracketMatch) {
         id = bracketMatch[1]!
-        label = normalizeBrTags(bracketMatch[2]!)
+        label = normalizeBrTags(stripWrappingQuotes(bracketMatch[2]!))
       } else {
-        // Use the label text as id (slugified)
-        label = normalizeBrTags(rest)
-        id = rest.replace(/\s+/g, '_').replace(/[^\w]/g, '')
+        // `subgraph Label` (optionally quoted): the label doubles as the id,
+        // slugified — but preserve unicode letters/numbers so a CJK-only title
+        // doesn't collapse to an empty id (which broke nested layout).
+        label = normalizeBrTags(stripWrappingQuotes(rest))
+        id = label.replace(/\s+/g, '_').replace(/[^\p{L}\p{N}_-]/gu, '')
       }
       const sg: MermaidSubgraph = { id, label, nodeIds: [], children: [] }
       subgraphStack.push(sg)


### PR DESCRIPTION
## Problem

The flowchart `subgraph` header parser assumes ASCII, which breaks two common cases:

1. **`subgraph <id> ["Title"]` with a non-ASCII id.** The id was matched with `[\w-]+`, which doesn't match CJK characters, so the bracket form fell through and the **entire line became the literal title** — e.g. `subgraph 柜体 ["PLC 控制柜正面布局"]` rendered the title as `柜体 ["PLC 控制柜正面布局"]` (id + brackets + quotes shown verbatim).
2. **CJK-only `subgraph <Label>`** (the repro in #89). The fallback id was slugged with `replace(/[^\w]/g, '')`, which strips every CJK char → an **empty id**, which breaks nested-subgraph layout ("labels float to top").

Quoted titles also weren't unwrapped, so even an ASCII `subgraph id ["Title"]` rendered with literal quotes.

## Fix (`src/parser.ts`)

- Match the subgraph id as any run of non-space, non-`[` characters instead of ASCII `[\w-]+`, so non-ASCII ids parse.
- Strip a single layer of wrapping quotes (`"…"` / `'…'`) from the title.
- Slug the fallback id while **preserving** unicode letters/numbers (`\p{L}\p{N}`), so a CJK-only label keeps a stable, non-empty id.

## Tests

Added `parseMermaid – subgraphs` cases: quoted bracket title `subgraph id ["Title"]`, a bracket title on a CJK id, the CJK-only regression for #89, and a quoted label without a separate id. Existing subgraph tests (basic, `id [Label]`, hyphenated id, slugified label, nested) are unchanged.

> Note: I don't have `bun` locally to run `bun test`, so I verified the parser against all the above cases via Node's TypeScript type-stripping (all pass, including the existing cases). CI will run the full suite.

Closes #89.