### PR TITLE
Fix edge-label text overflowing its padded background on wide labels

### DIFF
--- a/src/__tests__/text-metrics.test.ts
+++ b/src/__tests__/text-metrics.test.ts
@@ -10,69 +10,63 @@ import { getCharWidth, measureTextWidth } from '../text-metrics'
 
 describe('getCharWidth', () => {
   describe('narrow characters', () => {
-    it('returns 0.4 for thin letters (i, l, t, f, j, I)', () => {
-      expect(getCharWidth('i')).toBe(0.4)
-      expect(getCharWidth('l')).toBe(0.4)
-      expect(getCharWidth('t')).toBe(0.4)
-      expect(getCharWidth('f')).toBe(0.4)
-      expect(getCharWidth('j')).toBe(0.4)
-      expect(getCharWidth('I')).toBe(0.4)
+    it('measures thin letters as narrow (i, l, t, f, j, I)', () => {
+      for (const ch of ['i', 'l', 't', 'f', 'j', 'I']) {
+        expect(getCharWidth(ch), ch).toBeLessThan(0.7)
+      }
     })
 
-    it('returns 0.4 for thin punctuation', () => {
-      expect(getCharWidth('!')).toBe(0.4)
-      expect(getCharWidth('|')).toBe(0.4)
-      expect(getCharWidth('.')).toBe(0.4)
-      expect(getCharWidth(',')).toBe(0.4)
-      expect(getCharWidth(':')).toBe(0.4)
-      expect(getCharWidth(';')).toBe(0.4)
-      expect(getCharWidth("'")).toBe(0.4)
-      expect(getCharWidth('1')).toBe(0.4)
+    it('measures thin punctuation as narrow', () => {
+      for (const ch of ['!', '|', '.', ',', ':', ';', "'", '1']) {
+        expect(getCharWidth(ch), ch).toBeLessThan(0.8)
+      }
     })
 
-    it('returns 0.8 for semi-narrow r', () => {
-      expect(getCharWidth('r')).toBe(0.8)
+    it('measures r as semi-narrow', () => {
+      expect(getCharWidth('r')).toBeGreaterThan(getCharWidth('i'))
+      expect(getCharWidth('r')).toBeLessThan(getCharWidth('a'))
     })
   })
 
   describe('normal characters', () => {
-    it('returns 1.0 for average lowercase letters', () => {
-      expect(getCharWidth('a')).toBe(1.0)
-      expect(getCharWidth('e')).toBe(1.0)
-      expect(getCharWidth('o')).toBe(1.0)
-      expect(getCharWidth('n')).toBe(1.0)
-      expect(getCharWidth('s')).toBe(1.0)
+    it('measures average lowercase letters near 1.0', () => {
+      for (const ch of ['a', 'e', 'o', 'n', 's']) {
+        expect(getCharWidth(ch), ch).toBeGreaterThan(0.9)
+        expect(getCharWidth(ch), ch).toBeLessThan(1.15)
+      }
     })
 
-    it('returns 1.0 for digits', () => {
-      expect(getCharWidth('0')).toBe(1.0)
-      expect(getCharWidth('2')).toBe(1.0)
-      expect(getCharWidth('9')).toBe(1.0)
+    it('measures digits near 1.0-1.2 (tabular width)', () => {
+      for (const ch of ['0', '2', '9']) {
+        expect(getCharWidth(ch), ch).toBeGreaterThan(1.0)
+        expect(getCharWidth(ch), ch).toBeLessThan(1.2)
+      }
     })
   })
 
   describe('wide characters', () => {
-    it('returns 1.2 for uppercase letters (except I)', () => {
-      expect(getCharWidth('A')).toBe(1.2)
-      expect(getCharWidth('B')).toBe(1.2)
-      expect(getCharWidth('N')).toBe(1.2)
-      expect(getCharWidth('Z')).toBe(1.2)
+    it('measures uppercase letters wider than lowercase (except I)', () => {
+      for (const ch of ['A', 'B', 'N', 'Z']) {
+        expect(getCharWidth(ch), ch).toBeGreaterThan(1.1)
+        expect(getCharWidth(ch), ch).toBeLessThan(1.45)
+      }
     })
 
-    it('returns 1.2 for wide lowercase (w, m)', () => {
-      expect(getCharWidth('w')).toBe(1.2)
-      expect(getCharWidth('m')).toBe(1.2)
+    it('measures wide lowercase (w, m) above 1.4', () => {
+      expect(getCharWidth('w')).toBeGreaterThan(1.4)
+      expect(getCharWidth('m')).toBeGreaterThan(1.4)
     })
 
-    it('returns 1.5 for very wide characters (W, M)', () => {
-      expect(getCharWidth('W')).toBe(1.5)
-      expect(getCharWidth('M')).toBe(1.5)
+    it('measures very wide characters (W, M) above 1.6', () => {
+      expect(getCharWidth('W')).toBeGreaterThan(1.6)
+      expect(getCharWidth('M')).toBeGreaterThan(1.6)
     })
   })
 
   describe('space', () => {
-    it('returns 0.3 for space character', () => {
-      expect(getCharWidth(' ')).toBe(0.3)
+    it('measures space at its real Inter advance (~0.52)', () => {
+      // The old bucket value of 0.3 underestimated every word gap by ~1.3px
+      expect(getCharWidth(' ')).toBeCloseTo(0.521, 3)
     })
   })
 
@@ -88,13 +82,13 @@ describe('getCharWidth', () => {
   })
 
   describe('accented characters (precomposed)', () => {
-    it('returns normal width for precomposed accented letters', () => {
-      // These are single code points, treated as normal letters
-      expect(getCharWidth('é')).toBe(1.0) // U+00E9
-      expect(getCharWidth('ñ')).toBe(1.0) // U+00F1
-      expect(getCharWidth('ü')).toBe(1.0) // U+00FC
-      expect(getCharWidth('ç')).toBe(1.0) // U+00E7
-      expect(getCharWidth('ö')).toBe(1.0) // U+00F6
+    it('returns the base letter width for precomposed accented letters', () => {
+      // Accents don't change the advance — é measures the same as e
+      expect(getCharWidth('é')).toBe(getCharWidth('e')) // U+00E9
+      expect(getCharWidth('ñ')).toBe(getCharWidth('n')) // U+00F1
+      expect(getCharWidth('ü')).toBe(getCharWidth('u')) // U+00FC
+      expect(getCharWidth('ç')).toBe(getCharWidth('c')) // U+00E7
+      expect(getCharWidth('ö')).toBe(getCharWidth('o')) // U+00F6
     })
   })
 
@@ -146,10 +140,12 @@ describe('measureTextWidth', () => {
     expect(measureTextWidth('', fontSize, fontWeight)).toBeCloseTo(minPadding, 1)
   })
 
+  // Sum of per-char ratios — verifies the formula without pinning calibration
+  const ratioSum = (text: string) => [...text].reduce((s, ch) => s + getCharWidth(ch), 0)
+
   it('handles lowercase text with narrow letters', () => {
-    // "hello" = h(1.0) + e(1.0) + l(0.4) + l(0.4) + o(1.0) = 3.8
     const width = measureTextWidth('hello', fontSize, fontWeight)
-    expect(width).toBeCloseTo(3.8 * fontSize * baseRatio + minPadding, 1)
+    expect(width).toBeCloseTo(ratioSum('hello') * fontSize * baseRatio + minPadding, 1)
   })
 
   it('narrow text is narrower than uniform estimate', () => {
@@ -167,15 +163,13 @@ describe('measureTextWidth', () => {
   })
 
   it('handles mixed Latin text', () => {
-    // "Will" = W(1.5) + i(0.4) + l(0.4) + l(0.4) = 2.7
     const width = measureTextWidth('Will', fontSize, fontWeight)
-    expect(width).toBeCloseTo(2.7 * fontSize * baseRatio + minPadding, 1)
+    expect(width).toBeCloseTo(ratioSum('Will') * fontSize * baseRatio + minPadding, 1)
   })
 
   it('handles spaces correctly', () => {
-    // "a b" = a(1.0) + space(0.3) + b(1.0) = 2.3
     const width = measureTextWidth('a b', fontSize, fontWeight)
-    expect(width).toBeCloseTo(2.3 * fontSize * baseRatio + minPadding, 1)
+    expect(width).toBeCloseTo(ratioSum('a b') * fontSize * baseRatio + minPadding, 1)
   })
 
   it('handles decomposed accents (base + combining mark)', () => {
@@ -195,9 +189,8 @@ describe('measureTextWidth', () => {
   })
 
   it('handles mixed Latin and CJK', () => {
-    // "Hello中国" = H(1.2) + e(1.0) + l(0.4) + l(0.4) + o(1.0) + 中(2.0) + 国(2.0) = 8.0
     const width = measureTextWidth('Hello中国', fontSize, fontWeight)
-    expect(width).toBeCloseTo(8.0 * fontSize * baseRatio + minPadding, 1)
+    expect(width).toBeCloseTo(ratioSum('Hello中国') * fontSize * baseRatio + minPadding, 1)
   })
 
   it('heavier weights produce wider estimates', () => {
@@ -215,6 +208,55 @@ describe('measureTextWidth', () => {
 
     expect(large).toBeGreaterThan(small)
     expect(large / small).toBeCloseTo(16 / 11, 1)
+  })
+})
+
+// ============================================================================
+// Calibration against real Inter metrics
+// ============================================================================
+//
+// Fixtures measured with canvas measureText in headless Chrome 138 with the
+// real Inter font loaded (400 weight, 11px — the edge-label spec). If the
+// estimator underestimates these, edge-label text overflows its 8px-padded
+// background rect; if it grossly overestimates, layout gets bloated.
+
+describe('calibration against real Inter widths (11px, weight 400)', () => {
+  const REAL_INTER_WIDTHS: Record<string, number> = {
+    'yes': 18.19,
+    'no': 13.09,
+    'on failure': 48.47,
+    'validates credentials': 106.56,
+    'sends confirmation email': 130.6,
+    'asynchronous message processing': 184.1,
+    'returns HTTP 401 Unauthorized response': 215.65,
+    'WRITES TO DATABASE': 119.44,
+    'user_id + session_token validation': 177.51,
+    'retry with exponential backoff (max 5)': 197.49,
+  }
+
+  it('never underestimates real width by more than 3%', () => {
+    for (const [text, real] of Object.entries(REAL_INTER_WIDTHS)) {
+      const est = measureTextWidth(text, 11, 400)
+      expect(est, `"${text}" est ${est.toFixed(1)} vs real ${real}`).toBeGreaterThanOrEqual(real * 0.97)
+    }
+  })
+
+  it('never overestimates real width by more than 12% + 3px', () => {
+    for (const [text, real] of Object.entries(REAL_INTER_WIDTHS)) {
+      const est = measureTextWidth(text, 11, 400)
+      expect(est, `"${text}" est ${est.toFixed(1)} vs real ${real}`).toBeLessThanOrEqual(real * 1.12 + 3)
+    }
+  })
+
+  it('preserves at least 6px of the nominal 8px edge-label padding per side', () => {
+    // Edge-label background rect = estimated width + 8px padding each side.
+    // The visible gap between glyphs and rect wall must stay close to 8px.
+    const EDGE_LABEL_PADDING = 8
+    for (const [text, real] of Object.entries(REAL_INTER_WIDTHS)) {
+      const est = measureTextWidth(text, 11, 400)
+      const gapPerSide = (est + EDGE_LABEL_PADDING * 2 - real) / 2
+      expect(gapPerSide, `"${text}" gap ${gapPerSide.toFixed(1)}px`).toBeGreaterThanOrEqual(6)
+    }
   })
 })
 

--- a/src/text-metrics.ts
+++ b/src/text-metrics.ts
@@ -10,6 +10,39 @@
 // ============================================================================
 
 /**
+ * Exact advance widths for printable ASCII, measured from the real Inter font
+ * (canvas measureText, headless Chrome, weight 400) and normalized so that
+ * ratio × fontSize × baseRatio reproduces the measured pixel advance.
+ *
+ * The coarse character-class buckets below remain as fallback for characters
+ * not in this table. The buckets systematically underestimated Inter widths
+ * (spaces, m/w, digits, punctuation), and the error grew with text length —
+ * wide edge labels overflowed their 8px-padded background rects.
+ */
+const INTER_ADVANCES: Record<string, number> = {
+  ' ': 0.521, '!': 0.533, '"': 0.863, '%': 1.818, "'": 0.555,
+  '(': 0.675, ')': 0.675, '+': 1.225, ',': 0.534, '-': 0.852,
+  '.': 0.534, '/': 0.667,
+  '0': 1.168, '1': 0.753, '2': 1.129, '3': 1.144, '4': 1.196,
+  '5': 1.099, '6': 1.148, '7': 1.048, '8': 1.146, '9': 1.148,
+  ':': 0.534, ';': 0.559, '@': 1.789,
+  'A': 1.278, 'B': 1.212, 'C': 1.353, 'D': 1.336, 'E': 1.113,
+  'F': 1.093, 'G': 1.382, 'H': 1.376, 'I': 0.497, 'J': 1.057,
+  'K': 1.244, 'L': 1.047, 'M': 1.673, 'N': 1.395, 'O': 1.416,
+  'P': 1.183, 'Q': 1.416, 'R': 1.192, 'S': 1.188, 'T': 1.195,
+  'U': 1.378, 'V': 1.278, 'W': 1.825, 'X': 1.263, 'Y': 1.257,
+  'Z': 1.165,
+  '[': 0.675, '\\': 0.667, ']': 0.675, '_': 0.845,
+  'a': 1.04, 'b': 1.134, 'c': 1.058, 'd': 1.134, 'e': 1.08,
+  'f': 0.685, 'g': 1.136, 'h': 1.095, 'i': 0.448, 'j': 0.448,
+  'k': 1.016, 'l': 0.448, 'm': 1.622, 'n': 1.094, 'o': 1.11,
+  'p': 1.134, 'q': 1.134, 'r': 0.697, 's': 0.977, 't': 0.606,
+  'u': 1.095, 'v': 1.041, 'w': 1.515, 'x': 1.011, 'y': 1.041,
+  'z': 1.023,
+  '{': 0.789, '|': 0.616, '}': 0.789,
+}
+
+/**
  * Narrow characters - visually thin glyphs.
  * Note: '1' is included because in proportional fonts (like Inter), it's
  * significantly narrower than other digits which use tabular/uniform width.
@@ -127,11 +160,22 @@ export function getCharWidth(char: string): number {
   const code = char.codePointAt(0)
   if (code === undefined) return 0
 
+  // Exact measured advance for printable ASCII (Inter)
+  const measured = INTER_ADVANCES[char]
+  if (measured !== undefined) return measured
+
   // Zero-width: combining diacritical marks
   if (isCombiningMark(code)) return 0
 
   // Fullwidth: CJK, emoji
   if (isFullwidth(code) || isEmoji(char)) return 2.0
+
+  // Accented Latin: use the base letter's measured advance (é → e, Ü → U)
+  const base = char.normalize('NFD')[0]
+  if (base !== undefined && base !== char) {
+    const baseMeasured = INTER_ADVANCES[base]
+    if (baseMeasured !== undefined) return baseMeasured
+  }
 
   // Space
   if (char === ' ') return 0.3


### PR DESCRIPTION
## Problem

Wide edge labels lose their padding: the label text touches or overflows the walls of its background rect. Short labels look fine, which hides the bug until a label gets long.

**Root cause:** `measureTextWidth` in `src/text-metrics.ts` estimates widths via coarse character-class buckets. Comparing those estimates against the real Inter font (canvas `measureText` in headless Chrome, 11px / weight 400 — the edge-label spec) shows the buckets systematically underestimate: spaces (est 1.78px vs real 3.09px), `m`/`w` (~2px each), digits, `1`, `f`, hyphens, quotes, braces, `%`, `@`, and round uppercase (O, Q, C, G). Nearly every bucket errs low, so the error accumulates linearly with text length instead of canceling. Once the underestimate exceeds the 16px total padding budget, glyphs overflow the rect:

| Label | Real width | Old estimate | Gap per side (nominal 8px) |
|---|---|---|---|
| `yes` | 18.2px | 19.5px | 8.6px ✓ |
| `sends confirmation email` | 130.6px | 115.7px | 0.5px |
| `returns HTTP 401 Unauthorized response` | 215.7px | 197.7px | **−1.0px (touching)** |
| `retry with exponential backoff (max 5)` | 197.5px | 172.1px | **−4.7px (overflow)** |

## Fix

- Add `INTER_ADVANCES`: exact per-character advances for printable ASCII, measured from the real Inter font and normalized to the existing `ratio × fontSize × baseRatio` scale. `getCharWidth` consults it first; the class buckets remain as fallback for anything not covered (CJK, emoji already handled).
- Accented Latin letters resolve to their base letter's advance via NFD normalization (`é` → `e`, `Ü` → `U`) — accents don't change a glyph's advance.
- The overall `baseRatio` (0.54 at weight 400) was already correct (measured 0.536), so only per-character ratios changed.

Node sizing and ELK layout share this measurement path, so their accuracy improves equally.

## Before / After

Before — label text touching the box walls:

![before](https://raw.githubusercontent.com/OmShiv/beautiful-mermaid/pr-assets-edge-label/before.png)

After — padding restored:

![after](https://raw.githubusercontent.com/OmShiv/beautiful-mermaid/pr-assets-edge-label/after.png)

## Verification

- New calibration tests pin `measureTextWidth` to real Chrome-measured Inter widths: never underestimate by >3%, never overestimate by >12%+3px, and preserve ≥6px of the 8px edge-label padding per side. They fail on the old buckets and pass with the table, so future tuning can't silently reintroduce the underestimate.
- Full suite: 714 tests pass. Pre-existing tests that hand-pinned the old bucket values were updated to formula-based checks (`getCharWidth` sums) so they don't re-pin calibration.
- End-to-end: rendered a flowchart with the worst-case labels and measured glyph-to-rect gaps in Chrome with Inter loaded — all labels now show a symmetric ~9px gap per side.

**Known limit:** the table is calibrated for Inter (the default render font). Metrically different fonts (e.g. monospace) are still approximated; supporting exact measurement for arbitrary fonts would need a caller-supplied measurer hook, which I'm happy to follow up on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
