### PR TITLE
Add "sideEffects": false so bundlers can drop elkjs from ASCII-only builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "license": "MIT",
   "description": "Render Mermaid diagrams as beautiful SVGs or ASCII art. Ultra-fast, fully themeable, zero DOM dependencies.",
   "type": "module",
+  "sideEffects": false,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {


### PR DESCRIPTION
The package entry exports both the SVG renderers and `renderMermaidASCII`. The SVG path statically imports `elkjs/lib/elk.bundled.js` through `src/elk-instance.ts`; the ASCII path never reaches it — `src/ascii/` mentions ELK in two comments and imports it nowhere.

Because `package.json` declares no `sideEffects` field, a bundler has to assume every module in the graph can do work at import time, so `elkjs` is retained even when the only import is `renderMermaidASCII`. That is 3.0 MB of a 3.2 MB bundle for an ASCII-only consumer.

## Reproduction

```ts
// entry.ts
import { renderMermaidASCII } from "beautiful-mermaid"
console.log(renderMermaidASCII("flowchart TD\n  A[a] --> B[b]"))
```

```
bun add beautiful-mermaid@1.1.3
bun build --target=bun entry.ts --outfile out.js
```

| | bundle | `elk` references |
|---|---|---|
| 1.1.3 as published | 3242 KB | 29 |
| with `"sideEffects": false` | **189 KB** | 0 |

Rendered output is unchanged (same diagram on stdout).

## Why this is safe

`sideEffects: false` only permits dropping modules that nothing imports; anything on a reachable path is kept as before.

`src/elk-instance.ts` is the module in question, and it has no import-time work to lose: it declares `let elk = null` / `let rawWorker = null` at module scope and builds the singleton lazily inside `ensureElk()`.

Checked by rendering flowchart, sequence, class, ER and state diagrams through the published package and the flagged one side by side — byte-identical output in all five.

## Notes

- `bun test src/__tests__/` gives 472 pass / 9 fail both with and without this change; those 9 are pre-existing on `main` (2ac8bbb).
- The flag affects consumers' bundlers only; it does not change the tsup build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)