### PR TITLE
fix: tolerate trailing semicolon on flowchart class assignments

### DIFF
--- a/src/__tests__/parser.test.ts
+++ b/src/__tests__/parser.test.ts
@@ -637,6 +637,26 @@ describe('parseMermaid – classDef and class', () => {
     expect(g.classAssignments.get('A')).toBe('highlight')
     expect(g.classAssignments.get('B')).toBe('highlight')
   })
+
+  it('tolerates a trailing semicolon on class assignments', () => {
+    const g = parseMermaid(`graph TD
+      A --> B
+      class B highlight;`)
+    // The assignment is recorded...
+    expect(g.classAssignments.get('B')).toBe('highlight')
+    // ...and no stray node labelled "class" leaks from the unmatched statement.
+    expect(g.nodes.has('class')).toBe(false)
+    expect(g.nodes.size).toBe(2)
+  })
+
+  it('tolerates a trailing semicolon on multi-node class assignments', () => {
+    const g = parseMermaid(`graph TD
+      A --> B --> C
+      class A,B highlight;`)
+    expect(g.classAssignments.get('A')).toBe('highlight')
+    expect(g.classAssignments.get('B')).toBe('highlight')
+    expect(g.nodes.has('class')).toBe(false)
+  })
 })
 
 // ============================================================================

--- a/src/__tests__/parser.test.ts
+++ b/src/__tests__/parser.test.ts
@@ -657,6 +657,33 @@ describe('parseMermaid – classDef and class', () => {
     expect(g.classAssignments.get('B')).toBe('highlight')
     expect(g.nodes.has('class')).toBe(false)
   })
+
+  it('tolerates space before trailing semicolon', () => {
+    const g = parseMermaid(`graph TD
+      A --> B
+      class B highlight ;`)
+    expect(g.classAssignments.get('B')).toBe('highlight')
+    expect(g.nodes.has('class')).toBe(false)
+    expect(g.nodes.size).toBe(2)
+  })
+
+  it('tolerates space after trailing semicolon', () => {
+    const g = parseMermaid(`graph TD
+      A --> B
+      class B highlight; `)
+    expect(g.classAssignments.get('B')).toBe('highlight')
+    expect(g.nodes.has('class')).toBe(false)
+    expect(g.nodes.size).toBe(2)
+  })
+
+  it('tolerates multiple spaces around trailing semicolon', () => {
+    const g = parseMermaid(`graph TD
+      A --> B
+      class B highlight  ;  `)
+    expect(g.classAssignments.get('B')).toBe('highlight')
+    expect(g.nodes.has('class')).toBe(false)
+    expect(g.nodes.size).toBe(2)
+  })
 })
 
 // ============================================================================

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -76,7 +76,11 @@ function parseFlowchart(lines: string[]): MermaidGraph {
     }
 
     // --- class assignment: `class A,B className` ---
-    const classAssignMatch = line.match(/^class\s+([\w,-]+)\s+(\w+)$/)
+    // Allow an optional trailing semicolon (`class A,B foo;`) — Mermaid treats
+    // it as valid/optional, and `classDef`/`style` already tolerate it via their
+    // `(.+)$` capture. Without this, the semicolon form fails to match here and
+    // falls through to node parsing, rendering a stray node labelled "class".
+    const classAssignMatch = line.match(/^class\s+([\w,-]+)\s+(\w+)\s*;?\s*$/)
     if (classAssignMatch) {
       const nodeIds = classAssignMatch[1]!.split(',').map(s => s.trim())
       const className = classAssignMatch[2]!


### PR DESCRIPTION
## Summary:

This fix allows Mermaid diagrams to use trailing semicolons on class statements, which Mermaid treats as valid optional syntax. Previously, class B highlight; would fail to match the class assignment regex and incorrectly render a stray node labeled "class".

## What changed:

Updated the regex pattern for class assignment parsing from /^class\s+([\w,-]+)\s+(\w+)$/ to /^class\s+([\w,-]+)\s+(\w+)\s*;?\s*$/
This allows optional whitespace followed by an optional semicolon at the end
Aligns the class statement handling with how classDef and style statements already tolerate trailing semicolons

## Why it matters:

Users writing Mermaid diagrams often use trailing semicolons for consistency across all statements
Without this fix, diagrams with class B highlight; would render incorrectly with an extra "class" node
The fix improves compatibility with standard Mermaid syntax conventions

## Test coverage:

* Added tests for single-node class assignments with trailing semicolon
* Added tests for multi-node class assignments with trailing semicolon

## Screenshots



### Before

<img width="664" height="576" alt="image" src="https://github.com/user-attachments/assets/eedcd19d-cc81-4cd2-bfff-730680dc0796" />

### After

<img width="671" height="635" alt="image" src="https://github.com/user-attachments/assets/f057be9d-a9de-4de2-9ad3-a1ae69141914" />

### Live

```mermaid
graph TD
  A[Node A]
  B[Node B]
  C[Node C]
  A --> B --> C

  classDef highlight fill:#ffeeee
  class B highlight;
```